### PR TITLE
Fix get_course_first_lesson() to get the correct url of the last uncompleted lesson

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -1228,7 +1228,7 @@ class Utils {
 		$user_id   = get_current_user_id();
 
 		$lessons = $wpdb->get_results( $wpdb->prepare(
-			"SELECT items.ID
+			"SELECT items.ID, items.post_type
 			FROM 	{$wpdb->posts} topic
 					INNER JOIN {$wpdb->posts} items
 							ON topic.ID = items.post_parent
@@ -1250,7 +1250,7 @@ class Utils {
 
 			foreach ( $lessons as $lesson ) {
 				$is_complete = get_user_meta( $user_id, "_tutor_completed_lesson_id_{$lesson->ID}", true );
-				if ( ! $is_complete ) {
+				if ( ! $is_complete && $lesson->post_type === 'lesson' ) {
 					$first_lesson = $lesson;
 					break;
 				}


### PR DESCRIPTION
Hey there!
On the 'Continue to lesson' button I always got the URL of the first Quiz instead of the first (uncompleted) lesson, even though the Quiz is also complete and there're completed lessons after this first Quiz.
To solve this issue, see the suggested fixes on lines 1231 and 1253 in classes/Utils.php.

Kind regards,
Dmitry