### PR TITLE
Add shortcode processing to external video allows fvplayer embed

### DIFF
--- a/templates/single/video/embedded.php
+++ b/templates/single/video/embedded.php
@@ -20,7 +20,7 @@ do_action('tutor_lesson/single/before/video/embedded');
 ?>
     <div class="tutor-single-lesson-segment tutor-lesson-video-wrap">
         <div class="tutor-video-embeded-wrap">
-            <?php echo tutor_utils()->array_get('source_embedded', $video_info); ?>
+            <?php echo do_shortcode(tutor_utils()->array_get('source_embedded', $video_info)); ?>
         </div>
     </div>
 <?php


### PR DESCRIPTION
I wanted to use another plugin to play my video so added shortcode processing to the embed link. This works with fvplayer pro so that I can stream (e.g. HLS) signed URLs