### PR TITLE
Option to Enforce registration (Create new account) on WooCommerce guest checkout

### DIFF
--- a/classes/Options_V2.php
+++ b/classes/Options_V2.php
@@ -683,6 +683,14 @@ class Options_V2
 								'desc'        => __('Allow customers to place orders without an account.', 'tutor'),
 							),
 							array(
+								'key'         => 'enforce_login_course_cart',
+								'type'        => 'toggle_switch',
+								'label'       => __( 'Enforce login or registration for courses on checkout', 'tutor' ),
+								'label_title' => __( '', 'tutor' ),
+								'default'     => 'off',
+								'desc'        => __( 'Enforces users to login or create a new account if cart contains a course. Disables guest checkout only if cart contains a course.', 'tutor' ),
+							),
+							array(
 								'key'         => 'sharing_percentage',
 								'type'        => 'double_input',
 								'label'       => __('Sharing Percentage', 'tutor'),

--- a/classes/Tutor_Setup.php
+++ b/classes/Tutor_Setup.php
@@ -506,6 +506,12 @@ class Tutor_Setup {
 						'lable' => __( 'Guest Checkout', 'tutor' ),
 						'desc'  => __( 'Allow users to buy and consume content without logging in.', 'tutor' ),
 					),
+					array(
+						'key'         => 'enforce_login_course_cart',
+						'type'        => 'switch',
+						'label'       => __( 'Enforce login / registration', 'tutor' ),
+						'desc'        => __( 'Enforces users to login or create a new account if cart contains a course.Disables guest checkout only if cart contains a course.', 'tutor' ),
+				),
 					'commission_split'              => array(
 						'type'    => 'range',
 						'lable'   => __( 'Commission Rate', 'tutor' ),
@@ -728,7 +734,7 @@ class Tutor_Setup {
 					</div>
 					<div class="wizard-type-body">
 						<div class="wizard-type-item">
-							<input id="enable_course_marketplace-0" type="radio" name="enable_course_marketplace" value="off" 
+							<input id="enable_course_marketplace-0" type="radio" name="enable_course_marketplace" value="off"
 							<?php
 							if ( ! $course_marketplace ) {
 								echo 'checked'; }
@@ -748,7 +754,7 @@ class Tutor_Setup {
 						</div>
 
 						<div class="wizard-type-item">
-							<input id="enable_course_marketplace-1" type="radio" name="enable_course_marketplace" value="on" 
+							<input id="enable_course_marketplace-1" type="radio" name="enable_course_marketplace" value="on"
 							<?php
 							if ( $course_marketplace ) {
 								echo 'checked'; }
@@ -832,7 +838,7 @@ class Tutor_Setup {
 		$visited = get_option( 'tutor_welcome_page_visited' );
 		return $visited ? true : false;
 	}
-	
+
 	/**
 	 * Mark as welcome page visited
 	 *


### PR DESCRIPTION
This implements the feature as described in https://wordpress.org/support/topic/enforce-registration-create-new-account-on-woocommerce-guest-checkout/

The problem like many others have pointed out in the [forum](https://wordpress.org/support/plugin/tutor/) before is that a guest needs to manually check the “Create a customer” account checkbox on checkout. This is often forgotten (by default it is also off).

It would be better if when a shopping cart includes a course, then the creation of a new account would be enforced on checkout (unless the user is already logged in).

### Technical details

The WooCommerce Subscriptions and WooCommerce Memberships plugins do it also this way using the same WooCommerce hooks. The PR uses the same approach:
 
* `woocommerce_checkout_registration_required` filter (which checks if cart contains a Tutor course, then yes) 
* and then also sets `$_POST['createaccount'] = 1;` using the `woocommerce_before_checkout_process` action in the network post request

### Some more word on why is this needed

For many, many shops like us, there is no point having a **guest** buying a course because how would a guest be able to access the course some days later if she/he has no acount and no login. Same reasoning exists for WooCommerce Subscriptions (for subscription products) and WooCommerce Memberships (also needs a user account). So guest checkout really makes no sense. Hence the option to enforce a registration/login during checking as done in the patch.  

Actually, in WooCommerce Subscriptions and WooCommerce Memberships this behavior is no option but enabled by default (because as said before there really is no point in a guest checkout (no account) for products like courses).