### PR TITLE
 fix a bug that after finished paid but order status still pending

### DIFF
--- a/classes/WooCommerce.php
+++ b/classes/WooCommerce.php
@@ -99,8 +99,8 @@ class WooCommerce extends Tutor_Base {
 	function auto_complete_woocommerce_virtual_orders( $payment_complete_status, $order_id, $order ) {
 
 		$auto_complete_woocommerce_virtual_orders = tutor_utils()->get_option( 'auto_complete_woocommerce_virtual_orders' );
-		if ( 'on' !== $auto_complete_woocommerce_virtual_orders ) {
-			return;
+		if ( !$auto_complete_woocommerce_virtual_orders ) {
+			return $payment_complete_status;
 		}
 
 


### PR DESCRIPTION
 tutor_utils()->get_option( 'auto_complete_woocommerce_virtual_orders' ) return true/false not 'on'/'off' and
 if not enabling auto_complete_woocommerce_virtual_orders, we still need to keep the woocommerce assigned order status, so return $payment_complete_status