### PR TITLE
TUTOR2-893

### DIFF
--- a/classes/Tools_V2.php
+++ b/classes/Tools_V2.php
@@ -236,14 +236,6 @@ class Tools_V2 {
 
 								),
 								array(
-									'key'     => 'wordpress_debug_mode',
-									'type'    => 'info_col',
-									'label'   => __( 'WordPress debug mode', 'tutor' ),
-									'status'  => 'default',
-									'default' => $this->status( 'wordpress_debug_mode' ),
-
-								),
-								array(
 									'key'     => 'language',
 									'type'    => 'info_col',
 									'label'   => __( 'Language', 'tutor' ),


### PR DESCRIPTION
Fix: WordPress debug mode showing twice in the tools section