### PR TITLE
method added: get_human_readable_time

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -1638,6 +1638,38 @@ class Utils {
 	}
 
 	/**
+     * Get human readable time
+     *
+     * @param string $from                  date time string value. Example: 2022-06-24 22:00:00
+     * @param string $to                    (optional) date time string value. Default value is current.
+     * @param string $format                format you want to print. Help: https://www.php.net/manual/en/dateinterval.format.php
+     * @param bool   $show_postfix_text     show postfix text like 'ago', 'left'
+     * @return string
+     * 
+     * @since 2.0.7
+     */
+    public function get_human_readable_time( $from, $to = null, $format = '%ad %hh %im %ss', $show_postfix_text = true ) {
+        $postfix_text   = '';
+		$wp_tz 			= new \DateTimeZone( wp_timezone_string() );
+        $fromDateTime   = new \DateTime( $from, $wp_tz );
+        $toDateTime     = $to === null ? new \DateTime( 'now', $wp_tz ) : new \DateTime( $to, $wp_tz );
+        
+        if ( $toDateTime > $fromDateTime ) 
+        {
+            $postfix_text = __( ' ago', 'tutor' );
+        }
+        else
+        {
+            $postfix_text = __( ' left', 'tutor' );
+        }
+
+        $timeSpan       = $toDateTime->diff( $fromDateTime );
+        $postfix_text   = $show_postfix_text === true ? $postfix_text : '';
+
+        return $timeSpan->format( $format ) . $postfix_text;
+    }
+
+	/**
 	 * @param int $lesson_id
 	 *
 	 * @return bool|object

--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -1642,17 +1642,18 @@ class Utils {
      *
      * @param string $from                  date time string value. Example: 2022-06-24 22:00:00
      * @param string $to                    (optional) date time string value. Default value is current.
-     * @param string $format                format you want to print. Help: https://www.php.net/manual/en/dateinterval.format.php
+     * @param string $format                format you want to print. Default: '%ad %hh %im %ss' Help: https://www.php.net/manual/en/dateinterval.format.php
      * @param bool   $show_postfix_text     show postfix text like 'ago', 'left'
      * @return string
      * 
      * @since 2.0.7
      */
-    public function get_human_readable_time( $from, $to = null, $format = '%ad %hh %im %ss', $show_postfix_text = true ) {
+    public function get_human_readable_time( $from, $to = null, $format = null, $show_postfix_text = true ) {
         $postfix_text   = '';
 		$wp_tz 			= new \DateTimeZone( wp_timezone_string() );
         $fromDateTime   = new \DateTime( $from, $wp_tz );
         $toDateTime     = $to === null ? new \DateTime( 'now', $wp_tz ) : new \DateTime( $to, $wp_tz );
+		$format			= $format === null ? '%ad %hh %im %ss' : $format;
         
         if ( $toDateTime > $fromDateTime ) 
         {


### PR DESCRIPTION
Example:
```php
$fromDate  = '2022-06-29 14:00:00';
$oldDate   = '2022-06-22 14:00:00';
get_human_readable_time( $fromDate ); //  4d 20h 27m 22s left
get_human_readable_time( $fromDate, null, false ); // 4d 20h 27m 22s 
get_human_readable_time( $oldDate, '%ad:%hh:%im' ); // 2d:22hr:27m ago
get_human_readable_time( $fromDate, '%ad' ); // 4d left
get_human_readable_time( $fromDate, '%ad', false ); // 4d
```