### PR TITLE
Fix: Vimeo not fetching video duration on live platform

### DIFF
--- a/assets/react/course-builder/lesson.js
+++ b/assets/react/course-builder/lesson.js
@@ -353,12 +353,14 @@ window.jQuery(document).ready(function($) {
 				var regExp = /^.*(vimeo\.com\/)((channels\/[A-z]+\/)|(groups\/[A-z]+\/videos\/))?([0-9]+)/;
 				var match = video_url.match(regExp);
 				var video_id = match ? match[5] : null;
+				var is_ssl = _tutorobject.is_ssl ? 's' : '';
+;				var vimeo_api_url = `http${is_ssl}://vimeo.com/api/v2/video/${video_id}/json`;
 
 				if (video_id) {
 					toggle_loading(true);
 
 					$.getJSON(
-						'http://vimeo.com/api/v2/video/' + video_id + '/json',
+						vimeo_api_url,
 						function(data) {
 							if (
 								Array.isArray(data) &&

--- a/classes/Assets.php
+++ b/classes/Assets.php
@@ -99,7 +99,7 @@ class Assets {
 		$post_type = get_post_type( $post_id );
 
 		$current_page = tutor_utils()->get_current_page_slug();
-		
+
 		return array(
 			'ajaxurl'                      => admin_url( 'admin-ajax.php' ),
 			'home_url'                     => get_home_url(),
@@ -123,6 +123,7 @@ class Assets {
 			'assignment_max_file_allowed'  => 'tutor_assignments' === $post_type ? (int) tutor_utils()->get_assignment_option( $post_id, 'upload_files_limit' ) : 0,
 			'current_page'                 => $current_page,
 			'quiz_answer_display_time'     => 1000 * (int) tutor_utils()->get_option( 'quiz_answer_display_time' ),
+			'is_ssl'                       => is_ssl(),
 		);
 	}
 


### PR DESCRIPTION
API url was static none ssl http, that was causing the issue

Now API URL will be http or https based on SSL