### PR TITLE
Performance - is_public_course variable moved outside of the loop

### DIFF
--- a/templates/single/lesson/lesson_sidebar.php
+++ b/templates/single/lesson/lesson_sidebar.php
@@ -33,6 +33,7 @@ $enable_q_and_a_on_course     = tutor_utils()->get_option( 'enable_q_and_a_on_co
 $is_enrolled                  = tutor_utils()->is_enrolled( $course_id );
 $is_instructor_of_this_course = tutor_utils()->has_user_course_content_access( $user_id, $course_id );
 $is_user_admin                = current_user_can( 'administrator' );
+$is_public_course             = \TUTOR\Course_List::is_public( $course_id );
 ?>
 
 <?php do_action( 'tutor_lesson/single/before/lesson_sidebar' ); ?>
@@ -103,7 +104,6 @@ if ( $topics->have_posts() ) {
 				// Loop through lesson, quiz, assignment, zoom lesson.
 				while ( $lessons->have_posts() ) {
 					$lessons->the_post();
-					$is_public_course = \TUTOR\Course_List::is_public( $course_id );
 
 					$show_permalink = ! $_is_preview || $is_enrolled || get_post_meta( $post->ID, '_is_preview', true ) || $is_public_course || $is_instructor_of_this_course;
 					$show_permalink = apply_filters( 'tutor_course/single/content/show_permalink', $show_permalink, get_the_ID() );
@@ -124,8 +124,8 @@ if ( $topics->have_posts() ) {
 								</div>
 								<div class="tutor-d-flex tutor-ml-auto tutor-flex-shrink-0">
 									<?php
-									$time_limit    = (int) tutor_utils()->get_quiz_option( $quiz->ID, 'time_limit.time_value' );
-									$last_attempt  = ( new QuizModel() )->get_first_or_last_attempt( $quiz->ID );
+									$time_limit   = (int) tutor_utils()->get_quiz_option( $quiz->ID, 'time_limit.time_value' );
+									$last_attempt = ( new QuizModel() )->get_first_or_last_attempt( $quiz->ID );
 
 									$attempt_ended = is_object( $last_attempt ) && ( 'attempt_ended' === ( $last_attempt->attempt_status ) || $last_attempt->is_manually_reviewed ) ? true : false;
 


### PR DESCRIPTION
`Course_List::is_public` method unnecessarily called ( `lesson * n` times ) inside the lesson loop  