### PR TITLE
[Fix] In assignment page (the last one) continue lesson button need to be removed 🦜

### DIFF
--- a/templates/single/assignment/content.php
+++ b/templates/single/assignment/content.php
@@ -587,7 +587,7 @@ $upload_basedir = trailingslashit( $upload_dir['basedir'] ?? '' );
 						<?php endif; ?>
 					</div>
 
-					<?php if ( isset( $next_prev_content_id->next_id ) && '' !== $next_prev_content_id->next_id ) : ?>
+					<?php if ( $next_prev_content_id->next_id ) : ?>
 						<div class="tutor-assignment-footer tutor-pt-32 tutor-pt-sm-44">
 							<a class="tutor-btn tutor-btn-primary tutor-static-loader"
 								href="<?php echo esc_url( get_the_permalink( $next_prev_content_id->next_id ) ); ?>">


### PR DESCRIPTION
Removed the `continue lesson` button from the very last phase of the assignment.

[Jira task link](https://ollyo.atlassian.net/browse/TUTOR-1692)

<img width="462" alt="image" src="https://user-images.githubusercontent.com/11697368/220050716-8cbe29c8-07b2-4b59-8b19-fbe3a7485179.png">
