### PR TITLE
Wrong text on settings(frontend) page

### DIFF
--- a/v2-library/_src/js/passwordStrengthChecker.js
+++ b/v2-library/_src/js/passwordStrengthChecker.js
@@ -53,7 +53,7 @@
 						weak.classList.add('active');
 						if (noticeText) {
 							noticeText.style.display = 'block';
-							noticeText.textContent = 'week';
+							noticeText.textContent = 'weak';
 							// noticeText.classList.add('weak');
 						}
 					}


### PR DESCRIPTION
As a user > settings
Password Field
- Changed the password strength text from `Week` to `Weak`

<img width="664" alt="Screenshot 2023-03-01 at 3 33 41 PM" src="https://user-images.githubusercontent.com/42798816/222102427-b304a8a2-d685-4327-81b9-ea5262440042.png">

Task link
https://ollyo.atlassian.net/browse/TUTOR-1694