### PR TITLE
Workaround for gutenberg do_blocks() render issue affecting tutor courses and dashboard pages

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -8712,6 +8712,10 @@ class Utils {
 	public function tutor_custom_header() {
 		global $wp_version;
 		if ( version_compare( $wp_version, '5.9', '>=' ) && function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+			$theme      = wp_get_theme();
+			$theme_slug = $theme->get( 'TextDomain' );
+			$header_theme_block = do_blocks( '<!-- wp:template-part {"slug":"header","theme":"' . $theme_slug . '","tagName":"header","className":"site-header","layout":{"inherit":true}} /-->' );
+
 			?>
 			<!doctype html>
 				<html <?php language_attributes(); ?>>
@@ -8723,9 +8727,7 @@ class Utils {
 				<?php wp_body_open(); ?>
 					<div class="wp-site-blocks">
 					<?php
-						$theme      = wp_get_theme();
-						$theme_slug = $theme->get( 'TextDomain' );
-						echo do_blocks( '<!-- wp:template-part {"slug":"header","theme":"' . $theme_slug . '","tagName":"header","className":"site-header","layout":{"inherit":true}} /-->' );
+						echo $header_theme_block;
 		} else {
 			get_header();
 		}


### PR DESCRIPTION
The do_blocks() function has a [known bug](https://github.com/WordPress/gutenberg/issues/40018#issue-1191504744) of missing block css. 

In my website, the home page, blog page, etc look like this: ![image](https://user-images.githubusercontent.com/23329551/222786303-c2443d46-9a99-4ac6-8d62-1749a4f9dc41.png)

But when I move to the tutor dashboard or courses page, the navigation block alignment gets broken like below:
![image](https://user-images.githubusercontent.com/23329551/222787163-9eb29b66-a0f3-4f72-915d-53bcfcde9bd4.png)
 
On reading the tutor code, it was clear that this has to do with the do_blocks rendering issue, for which the [known workaround](https://github.com/WordPress/gutenberg/issues/40018#issuecomment-1109370224) is to assign the return value of do_blocks() to a variable before calling the wp_head(). 

This code change fixes my issue. Please modify as needed.

**Steps to reproduce:**
1. Set the theme to the default wordpress theme that supports full site editing.
2. Check /courses and /dashboard pages - They will have the alignment broken.