### PR TITLE
Tutor Settings: On toggle switch show hide dependent settings elements

### DIFF
--- a/assets/react/admin-dashboard/segments/options.js
+++ b/assets/react/admin-dashboard/segments/options.js
@@ -496,12 +496,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
 		fields = fields.map(s => s.trim());
 		isChecked
-			? fields.forEach((f) => $('#field_' + f).removeClass('tutor-hide-settings'))
-			: fields.forEach((f) => $('#field_' + f).addClass('tutor-hide-settings'))
+			? fields.forEach((f) => $('#field_' + f).removeClass('tutor-hide-option'))
+			: fields.forEach((f) => $('#field_' + f).addClass('tutor-hide-option'))
 
 		let toggleWrapper = el.parent().parent().parent()
 		let sectionWrapper = el.parent().parent().parent().parent()
-		let visibleElements = sectionWrapper.find('.tutor-option-field-row').not('div.tutor-hide-settings').length
+		let visibleElements = sectionWrapper.find('.tutor-option-field-row').not('div.tutor-hide-option').length
 
 		visibleElements === 1
 			? toggleWrapper.addClass('tutor-option-no-bottom-border')

--- a/assets/react/admin-dashboard/segments/options.js
+++ b/assets/react/admin-dashboard/segments/options.js
@@ -484,4 +484,28 @@ document.addEventListener('DOMContentLoaded', function () {
 			showHideOption(field_fee_amount_type_wrapper, value)
 		});
 	}
+
+	/**
+	 * On toggle switch change - show, hide setting's elements
+	 * @since 2.1.9
+	 */
+	function showHideToggleChildren(el) {
+		let isChecked = el.is(':checked')
+		let fields = el.data('toggle-fields').split(',')
+		if (Array.isArray(fields) === false || fields.length === 0) return
+		fields = fields.map(s => s.trim());
+		isChecked
+			? fields.forEach((f) => $('#field_' + f).show())
+			: fields.forEach((f) => $('#field_' + f).hide())
+	}
+	
+	const btnToggles = $('input[type="checkbox"][data-toggle-fields]')
+	btnToggles.each(function () {
+		showHideToggleChildren($(this))
+	})
+
+	btnToggles.change(function () {
+		showHideToggleChildren($(this))
+	})
+
 });

--- a/assets/react/admin-dashboard/segments/options.js
+++ b/assets/react/admin-dashboard/segments/options.js
@@ -493,12 +493,22 @@ document.addEventListener('DOMContentLoaded', function () {
 		let isChecked = el.is(':checked')
 		let fields = el.data('toggle-fields').split(',')
 		if (Array.isArray(fields) === false || fields.length === 0) return
+
 		fields = fields.map(s => s.trim());
 		isChecked
-			? fields.forEach((f) => $('#field_' + f).show())
-			: fields.forEach((f) => $('#field_' + f).hide())
+			? fields.forEach((f) => $('#field_' + f).removeClass('tutor-hide-settings'))
+			: fields.forEach((f) => $('#field_' + f).addClass('tutor-hide-settings'))
+
+		let toggleWrapper = el.parent().parent().parent()
+		let sectionWrapper = el.parent().parent().parent().parent()
+		let visibleElements = sectionWrapper.find('.tutor-option-field-row').not('div.tutor-hide-settings').length
+
+		visibleElements === 1
+			? toggleWrapper.addClass('tutor-option-no-bottom-border')
+			: toggleWrapper.removeClass('tutor-option-no-bottom-border')
+
 	}
-	
+
 	const btnToggles = $('input[type="checkbox"][data-toggle-fields]')
 	btnToggles.each(function () {
 		showHideToggleChildren($(this))

--- a/assets/scss/admin-dashboard/_tutor-admin.scss
+++ b/assets/scss/admin-dashboard/_tutor-admin.scss
@@ -206,7 +206,7 @@ body.tutor-backend-tutor_settings #wpbody-content {
 * Option Field
 */
 
-.tutor-hide-settings{
+.tutor-hide-option{
 	display: none!important;
 }
 

--- a/assets/scss/admin-dashboard/_tutor-admin.scss
+++ b/assets/scss/admin-dashboard/_tutor-admin.scss
@@ -215,6 +215,10 @@ body.tutor-backend-tutor_settings #wpbody-content {
 	padding-bottom: 0!important;
 }
 
+.tutor-option-checkbox-horizontal{
+	display: block;
+}
+
 .tutor-option-field-row {
 	border-bottom: 1px solid #e4e4e4;
 	padding: 20px 0;

--- a/assets/scss/admin-dashboard/_tutor-admin.scss
+++ b/assets/scss/admin-dashboard/_tutor-admin.scss
@@ -206,6 +206,15 @@ body.tutor-backend-tutor_settings #wpbody-content {
 * Option Field
 */
 
+.tutor-hide-settings{
+	display: none!important;
+}
+
+.tutor-option-no-bottom-border{
+	border-bottom: 0!important;
+	padding-bottom: 0!important;
+}
+
 .tutor-option-field-row {
 	border-bottom: 1px solid #e4e4e4;
 	padding: 20px 0;

--- a/views/options/field-types/checkbox_horizontal.php
+++ b/views/options/field-types/checkbox_horizontal.php
@@ -15,7 +15,7 @@ if ( ! empty( $field['options'] ) ) {
 	$saved_data                             = $this->get( esc_attr( $field_key ), array() );
 	! is_array( $saved_data ) ? $saved_data = array() : 0;
 	?>
-	<div class="tutor-option-field-row tutor-d-block" id="<?php echo esc_attr( $field_id ); ?>">
+	<div class="tutor-option-field-row tutor-option-checkbox-horizontal" id="<?php echo esc_attr( $field_id ); ?>">
 		<?php include tutor()->path . 'views/options/template/common/field_heading.php'; ?>
 		<div class="tutor-option-field-input tutor-d-flex">
 			<div class="type-check tutor-d-flex">

--- a/views/options/field-types/toggle_switch.php
+++ b/views/options/field-types/toggle_switch.php
@@ -17,6 +17,7 @@ $label_title       = ( isset( $field_label_title ) && null !== esc_attr( $field_
 $default           = isset( $field_default ) ? esc_attr( $field_default ) : esc_attr( 'off' );
 $option_value = $this->get( esc_attr( $field_key ), $default );
 $option_value = ( isset( $option_value ) && 1 == $option_value || 'on' == $option_value ) ? 'on' : 'off';
+$toggle_fields = isset( $field['toggle_fields'] ) ? $field['toggle_fields'] : null;
 ?>
 <div class="tutor-option-field-row" id="<?php echo esc_attr( $field_id ); ?>">
 	<?php require tutor()->path . 'views/options/template/common/field_heading.php'; ?>
@@ -24,7 +25,12 @@ $option_value = ( isset( $option_value ) && 1 == $option_value || 'on' == $optio
 		<label class="tutor-form-toggle">
 			<?php printf( "<span class='label-before'>%s</span>", esc_attr( $field_label_title ) ); ?>
 			<input type="hidden" name="tutor_option[<?php echo esc_attr( $field_key ); ?>]" value="<?php echo esc_attr( $option_value ); ?>">
-			<input type="checkbox" <?php checked( esc_attr( $option_value ), 'on' ); ?> class="tutor-form-toggle-input">
+			<input type="checkbox" 
+				<?php if ( $toggle_fields ) : ?>
+					data-toggle-fields="<?php echo esc_attr( $toggle_fields ); ?>" 
+				<?php endif; ?>
+				<?php checked( esc_attr( $option_value ), 'on' ); ?> 
+				class="tutor-form-toggle-input">
 			<span class="tutor-form-toggle-control"></span>
 		</label>
 	</div>


### PR DESCRIPTION
In the PHP side settings definition just add this for `toggle_switch` type setting.
```php
'toggle_fields' => 'settings_key_1,settings_key_2'
```