### PR TITLE
Fixed Content Drip "Course content available sequentially" not working on the mobile device

### DIFF
--- a/includes/tutor-template-functions.php
+++ b/includes/tutor-template-functions.php
@@ -8,6 +8,8 @@
  * @since 1.0.0
  */
 
+use TUTOR_CONTENT_DRIP\ContentDrip;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -1071,6 +1073,13 @@ if ( ! function_exists( 'tutor_lesson_content' ) ) {
 
 if ( ! function_exists( 'tutor_lesson_mark_complete_html' ) ) {
 	function tutor_lesson_mark_complete_html( $echo = true ) {
+		
+		if( function_exists( 'tutor_pro' ) ) {
+			$drip = new ContentDrip();
+			if ( $drip->is_lock_lesson( get_the_ID() ) ) {
+				return;
+			}
+		}
 		ob_start();
 		tutor_load_template( 'single.lesson.complete_form' );
 		$output = apply_filters( 'tutor_lesson/single/complete_form', ob_get_clean() );

--- a/includes/tutor-template-functions.php
+++ b/includes/tutor-template-functions.php
@@ -8,8 +8,6 @@
  * @since 1.0.0
  */
 
-use TUTOR_CONTENT_DRIP\ContentDrip;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -1073,13 +1071,6 @@ if ( ! function_exists( 'tutor_lesson_content' ) ) {
 
 if ( ! function_exists( 'tutor_lesson_mark_complete_html' ) ) {
 	function tutor_lesson_mark_complete_html( $echo = true ) {
-		
-		if( function_exists( 'tutor_pro' ) ) {
-			$drip = new ContentDrip();
-			if ( $drip->is_lock_lesson( get_the_ID() ) ) {
-				return;
-			}
-		}
 		ob_start();
 		tutor_load_template( 'single.lesson.complete_form' );
 		$output = apply_filters( 'tutor_lesson/single/complete_form', ob_get_clean() );

--- a/templates/single-content-loader.php
+++ b/templates/single-content-loader.php
@@ -8,8 +8,6 @@
  * @since 1.0.0
  */
 
-use TUTOR_CONTENT_DRIP\ContentDrip;
-
 global $post;
 //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 $currentPost = $post;

--- a/templates/single-content-loader.php
+++ b/templates/single-content-loader.php
@@ -54,11 +54,10 @@ do_action( 'tutor/course/single/content/before/all', $course_id, $content_id );
 
 get_tutor_header();
 
-$post_type                                   = get_post_type( get_the_ID() );
-$accepted_array_for_showing_mark_as_complete = array( 'lesson' );
-$show_mark_as_complete                       = false;
+$post_type             = get_post_type( get_the_ID() );
+$show_mark_as_complete = false;
 
-if ( in_array( $post_type, $accepted_array_for_showing_mark_as_complete ) ) {
+if ( tutor()->lesson_post_type === $post_type ) {
 	$show_mark_as_complete = true;
 
 	if ( function_exists( 'tutor_pro' ) ) {

--- a/templates/single-content-loader.php
+++ b/templates/single-content-loader.php
@@ -58,14 +58,7 @@ $post_type             = get_post_type( get_the_ID() );
 $show_mark_as_complete = false;
 
 if ( tutor()->lesson_post_type === $post_type ) {
-	$show_mark_as_complete = true;
-
-	if ( function_exists( 'tutor_pro' ) ) {
-		$drip = new ContentDrip();
-		if ( $drip->is_lock_lesson( get_the_ID() ) ) {
-			$show_mark_as_complete = false;
-		}
-	}
+	$show_mark_as_complete = apply_filters( 'tutor_lesson_show_mark_as_complete', true );
 }
 
 ?>

--- a/templates/single-content-loader.php
+++ b/templates/single-content-loader.php
@@ -52,10 +52,9 @@ do_action( 'tutor/course/single/content/before/all', $course_id, $content_id );
 
 get_tutor_header();
 
-$post_type             = get_post_type( get_the_ID() );
 $show_mark_as_complete = false;
 
-if ( tutor()->lesson_post_type === $post_type ) {
+if ( tutor()->lesson_post_type === $post->post_type ) {
 	$show_mark_as_complete = apply_filters( 'tutor_lesson_show_mark_as_complete', true );
 }
 

--- a/templates/single-content-loader.php
+++ b/templates/single-content-loader.php
@@ -8,6 +8,8 @@
  * @since 1.0.0
  */
 
+use TUTOR_CONTENT_DRIP\ContentDrip;
+
 global $post;
 //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 $currentPost = $post;
@@ -51,6 +53,21 @@ function tutor_course_single_sidebar( $echo = true, $context = 'desktop' ) {
 do_action( 'tutor/course/single/content/before/all', $course_id, $content_id );
 
 get_tutor_header();
+
+$post_type                                   = get_post_type( get_the_ID() );
+$accepted_array_for_showing_mark_as_complete = array( 'lesson' );
+$show_mark_as_complete                       = false;
+
+if ( in_array( $post_type, $accepted_array_for_showing_mark_as_complete ) ) {
+	$show_mark_as_complete = true;
+
+	if ( function_exists( 'tutor_pro' ) ) {
+		$drip = new ContentDrip();
+		if ( $drip->is_lock_lesson( get_the_ID() ) ) {
+			$show_mark_as_complete = false;
+		}
+	}
+}
 
 ?>
 
@@ -96,7 +113,11 @@ get_tutor_header();
 
 			<?php if ( ! $is_completed_lesson ) : ?>
 				<div class="tutor-spotlight-mobile-progress-right tutor-col-sm-4 tutor-col-6">
-					<?php tutor_lesson_mark_complete_html(); ?>
+					<?php
+					if ( $show_mark_as_complete ) {
+						tutor_lesson_mark_complete_html();
+					}
+					?>
 				</div>
 			<?php endif; ?>
 


### PR DESCRIPTION
- Fixed the issue when Content Drip "Course content available sequentially" is enabled and the lesson is locked but it shows the button
- Hide 'Mark as Complete' button for Assignment & Quiz page on mobile view

Task link
https://ollyo.atlassian.net/browse/TUTOR-1699

Related PR on Tutor-Pro
https://github.com/themeum/tutor-pro/pull/126