### PR TITLE
🎉 Unit Test - local .env file support added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ vendor/
 !v2-library/_src/scss/structure/vendor
 .phpunit.result.cache
 yarn.lock
+.env

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -229,6 +229,7 @@ gulp.task('copy', function() {
 			'!yarn-error.log',
 			'!bin/**',
 			'!tests/**',
+			'!.env',
 			'!vendor/bin/**',
 			'!vendor/doctrine/**',
 			'!vendor/myclabs/**',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,22 @@
  * @package Tutor
  */
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
+! session_id() ? session_start() : 0;
+
+$test_env_key = 'WP_TESTS_DIR';
+$_tests_dir   = getenv( $test_env_key );
+
+/**
+ * Local .env file support
+ * Put a .env file in root of project.
+ */
+$local_env = __DIR__ . '/../.env';
+if ( file_exists( $local_env ) ) {
+	$env = parse_ini_file( $local_env );
+	if ( is_array( $env ) && array_key_exists( $test_env_key, $env ) ) {
+		$_tests_dir = trim( $env[ $test_env_key ] );
+	}
+}
 
 if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';


### PR DESCRIPTION
Add a `.env` file in root of project then add this entry.
```
WP_TESTS_DIR=absolute-path-of/wordpress-tests-lib
```
