### PR TITLE
adding support for PMPro

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -2543,18 +2543,18 @@ class Utils {
 	public function get_subscription_by_subscription_id( $subscription_id ) {
 		global $wpdb;
 
-		// Getting return all children of subscription
+		// Returns subscription information
 		$subscription = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT subscriptions.*
 				 FROM {$wpdb->prefix}woocommerce_order_items items
 				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta meta
-						ON items.order_item_id = meta.order_item_id
-					   AND meta.meta_key = '_product_id'
+					ON items.order_item_id = meta.order_item_id
+				       AND meta.meta_key = '_product_id'
 				 LEFT JOIN $wpdb->posts subscriptions
-						ON meta.meta_value = subscriptions.ID
-					 WHERE `order_id` = %s
-					   AND `order_item_type` = 'line_item'
+					ON meta.meta_value = subscriptions.ID
+				 WHERE `order_id` = %s
+				   AND `order_item_type` = 'line_item'
 				",
 				$subscription_id
 			)

--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -5829,12 +5829,17 @@ class Utils {
 		$post_type = '';
 		$user_meta = '';
 
-		if ( $monetize_by === 'wc' ) {
+		if ( $monetize_by === 'wc' || $monetize_by === 'pmpro' ) {
 			$post_type = 'shop_order';
 			$user_meta = '_customer_user';
 		} elseif ( $monetize_by === 'edd' ) {
 			$post_type = 'edd_payment';
 			$user_meta = '_edd_payment_user_id';
+		}
+		
+		$add_join = '';
+		if ($monetize_by !== 'pmpro') {
+			$add_join = "INNER JOIN {$wpdb->postmeta} tutor_order ON id = tutor_order.post_id AND tutor_order.meta_key = '_is_tutor_order_for_course'";
 		}
 
 		$period_query = '';
@@ -5865,9 +5870,7 @@ class Utils {
 					INNER JOIN {$wpdb->postmeta} customer
 							ON id = customer.post_id
 						   AND customer.meta_key = '{$user_meta}'
-					INNER JOIN {$wpdb->postmeta} tutor_order
-							ON id = tutor_order.post_id
-						   AND tutor_order.meta_key = '_is_tutor_order_for_course'
+					{$add_join}
 			WHERE	post_type = %s
 					AND customer.meta_value = %d
 					{$period_query}

--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -2517,6 +2517,53 @@ class Utils {
 	}
 
 	/**
+	 * @param $order_id
+	 *
+	 * @return array
+	 *
+	 */
+	public function get_subscriptions_by_order_id( $order_id ) {
+		global $wpdb;
+
+		// Return all children of subscription
+		$args = array(
+			'post_parent' 	=> $order_id,
+			'post_type' 	=> 'shop_subscription'
+		);
+		
+		return get_children($args);
+	}
+	
+	/**
+	 * @param $subscription_id
+	 *
+	 * @return object
+	 *
+	 */
+	public function get_subscription_by_subscription_id( $subscription_id ) {
+		global $wpdb;
+
+		// Getting return all children of subscription
+		$subscription = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT subscriptions.*
+				 FROM {$wpdb->prefix}woocommerce_order_items items
+				 LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta meta
+						ON items.order_item_id = meta.order_item_id
+					   AND meta.meta_key = '_product_id'
+				 LEFT JOIN $wpdb->posts subscriptions
+						ON meta.meta_value = subscriptions.ID
+					 WHERE `order_id` = %s
+					   AND `order_item_type` = 'line_item'
+				",
+				$subscription_id
+			)
+		);
+		
+		return $subscription;
+	}
+	
+	/**
 	 * Get wc product in efficient query
 	 *
 	 * @since v.1.0.0

--- a/templates/dashboard/purchase_history.php
+++ b/templates/dashboard/purchase_history.php
@@ -105,7 +105,7 @@ $monetize_by  = tutor_utils()->get_option( 'monetize_by' );
 				<tbody>
 					<?php foreach ( $orders as $order ) : ?>
 						<?php
-						if ( 'wc' === $monetize_by ) {
+						if ( 'wc' === $monetize_by || 'pmpro' === $monetize_by ) {
 							$wc_order          = wc_get_order( $order->ID );
 							$price             = tutor_utils()->tutor_price( $wc_order->get_total() );
 							$raw_price         = $wc_order->get_total();
@@ -159,6 +159,16 @@ $monetize_by  = tutor_utils()->get_option( 'monetize_by' );
 								if ( tutor_utils()->count( $courses ) ) {
 									foreach ( $courses as $course ) {
 										echo '<div>' . esc_html( get_the_title( $course['course_id'] ) ) . '</div>';
+									}
+								}
+								
+								if ( $monetize_by === 'pmpro') {
+									$subscriptions = tutor_utils()->get_subscriptions_by_order_id( $order->ID );
+									if ( tutor_utils()->count( $subscriptions ) ) {
+										foreach ( $subscriptions as $subscription ) {
+											echo '<div>Subscription - ' . esc_html( tutor_utils()->get_subscription_by_subscription_id( $subscription->ID )->post_title ) . '</div>';
+										}
+	
 									}
 								}
 								?>


### PR DESCRIPTION
While Tutor supports PMPro as a monetization engine, the current `get_orders_by_user_id` implementation returns an empty `orders` array.

I've updated (and tested) the function to return orders captured in PMPro.

Changes:
1. Added condition for PMPro and WooCommerce (both return `shop_order` for the post type).
2. Made the second inner join optional (for PMPro orders, the meta key `_is_tutor_order_for_course` isn't saved).