### PR TITLE
WP Editor Lesson video issue fix

### DIFF
--- a/assets/scss/course-builder/index.scss
+++ b/assets/scss/course-builder/index.scss
@@ -97,3 +97,32 @@ body.tutor-screen-course-builder {
         }
     }
 }
+
+#tutor-lesson-videos {
+    // Course segments only for Lessons on Wp Editor
+    @import './segments/video.scss';
+
+    .tutor-dropdown-icon-pack {
+        position: absolute;
+        top: 5px;
+        left: 10px;
+
+        &+select {
+            padding-left: 35px !important;
+        }
+
+        [data-for] {
+            display: none;
+        }
+
+        &[data-video_source=html5] [data-for=html5], 
+        &[data-video_source=youtube] [data-for=youtube], 
+        &[data-video_source=vimeo] [data-for=vimeo],
+        &[data-video_source=external_url] [data-for=external_url],
+        &[data-video_source=embedded] [data-for=embedded],
+        &[data-video_source=shortcode] [data-for=shortcode]
+        {
+            display: block;
+        }
+    }
+}

--- a/classes/Lesson.php
+++ b/classes/Lesson.php
@@ -83,6 +83,19 @@ class Lesson extends Tutor_Base {
 		add_action( 'wp_ajax_tutor_single_course_lesson_load_more', array( $this, 'tutor_single_course_lesson_load_more' ) );
 		add_action( 'wp_ajax_tutor_create_lesson_comment', array( $this, 'tutor_single_course_lesson_load_more' ) );
 		add_action( 'wp_ajax_tutor_reply_lesson_comment', array( $this, 'reply_lesson_comment' ) );
+		add_filter( 'tutor_load_course_builder_scripts', array( $this, 'tutor_admin_check_lesson_editor' ) );
+	}
+
+	public function tutor_admin_check_lesson_editor($param)
+	{
+		$post_ID = get_the_ID();
+		$type = get_post_type($post_ID);
+
+		if ( is_admin() && tutor()->lesson_post_type === $type ) {
+			return true;
+		}
+		
+		return $param;
 	}
 
 	/**

--- a/classes/Lesson.php
+++ b/classes/Lesson.php
@@ -86,15 +86,21 @@ class Lesson extends Tutor_Base {
 		add_filter( 'tutor_load_course_builder_scripts', array( $this, 'tutor_admin_check_lesson_editor' ) );
 	}
 
-	public function tutor_admin_check_lesson_editor($param)
-	{
+	/**
+	 * Function to check Lesson WP Editor
+	 *
+	 * @param mixed $param Param.
+	 *
+	 * @return mixed
+	 */
+	public function tutor_admin_check_lesson_editor( $param ) {
 		$post_ID = get_the_ID();
-		$type = get_post_type($post_ID);
+		$type    = get_post_type( $post_ID );
 
 		if ( is_admin() && tutor()->lesson_post_type === $type ) {
 			return true;
 		}
-		
+
 		return $param;
 	}
 
@@ -270,7 +276,7 @@ class Lesson extends Tutor_Base {
 		tutor_utils()->checking_nonce();
 
 		global $wpdb;
-		
+
 		/**
 		 * Allow iframe inside lesson content to support
 		 * embed video & other stuff


### PR DESCRIPTION
Fix: While editing a Lesson with WP Editor, the "Browse File" button does not work in case of HTML5 Lesson Video Source

Task URL
https://ollyo.atlassian.net/browse/TUTOR-1564

Linked PR
https://github.com/themeum/tutor-pro/pull/171