### PR TITLE
Date formate showing wrong after translation

### DIFF
--- a/templates/single/course/enrolled/announcements.php
+++ b/templates/single/course/enrolled/announcements.php
@@ -36,7 +36,7 @@ $announcements = tutor_utils()->get_announcements( get_the_ID() );
 					</div>
 
 					<div>
-						<?php echo esc_html( human_time_diff( time(), strtotime( $announcement->post_date_gmt ) ) . __(' ago', 'tutor' ) ); ?>
+						<?php echo esc_html( sprintf( __( '%s ago', 'tutor' ), human_time_diff( strtotime(  $announcement->post_date_gmt ) ) ) ); ?>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
The announcement publish date format is showing wrong if someone translating the tutor. I have modified the code now the translation will work in a proper format.