### PR TITLE
Fix and improve support for PMPro (Paid Memberships Pro)

### DIFF
--- a/templates/dashboard/purchase_history.php
+++ b/templates/dashboard/purchase_history.php
@@ -105,7 +105,7 @@ $monetize_by  = tutor_utils()->get_option( 'monetize_by' );
 				<tbody>
 					<?php foreach ( $orders as $order ) : ?>
 						<?php
-						if ( 'wc' === $monetize_by ) {
+						if ( 'wc' === $monetize_by || 'pmpro' === $monetize_by ) {
 							$wc_order          = wc_get_order( $order->ID );
 							$price             = tutor_utils()->tutor_price( $wc_order->get_total() );
 							$raw_price         = $wc_order->get_total();
@@ -159,6 +159,14 @@ $monetize_by  = tutor_utils()->get_option( 'monetize_by' );
 								if ( tutor_utils()->count( $courses ) ) {
 									foreach ( $courses as $course ) {
 										echo '<div>' . esc_html( get_the_title( $course['course_id'] ) ) . '</div>';
+									}
+								}
+								if ( $monetize_by === 'pmpro') {
+									$subscriptions = tutor_utils()->get_subscriptions_by_order_id( $order->ID );
+									if ( tutor_utils()->count( $subscriptions ) ) {
+										foreach ( $subscriptions as $subscription ) {
+											echo '<div>Subscription - ' . esc_html( tutor_utils()->get_subscription_by_subscription_id( $subscription->ID )->post_title ) . '</div>';
+										}
 									}
 								}
 								?>


### PR DESCRIPTION
@shewa12 
While Tutor supports PMPro as a monetization engine, the current implementation of get_orders_by_user_id() returns an empty orders array.

Fix this function to return orders captured in PMPro, implemented and tested by Joshua Davis (@a11smiles)

- Add condition for PMPro and WooCommerce (both return shop_order for the post type).
- Add support for querying PMPro subscriptions
- Make the second inner join optional (for PMPro orders, the meta key _is_tutor_order_for_course isn't saved).

Was originally opened by Joshua Davis <me@jdav.is> @a11smiles as #419,
- commits and log messages squashed,
- rebased to current dev
- and spaces at end of lines fixed by me.

Originally-From: Joshua Davis <me@jdav.is>