### PR TITLE
[DRAFT] SCSS files cached in gulp watch with gulp-cache

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var gulp = require('gulp'),
 	wpPot = require('gulp-wp-pot'),
 	clean = require('gulp-clean'),
 	zip = require('gulp-zip'),
+	cache = require('gulp-cached'),
 	fs = require('fs'),
 	path = require('path'),
 	versionNumber = '';
@@ -84,6 +85,7 @@ for (let task in scss_blueprints) {
 	gulp.task(task, function() {
 		return gulp
 			.src(blueprint.src)
+			.pipe(cache('sass'))
 			.pipe(plumber({ errorHandler: onError }))
 			.pipe(sourcemaps.init({ loadMaps: true, largeFile: true }))
 			.pipe(sass({ outputStyle: 'compressed', sass: require('sass') }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -13753,6 +13753,15 @@
 				}
 			}
 		},
+		"gulp-cached": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/gulp-cached/-/gulp-cached-1.1.1.tgz",
+			"integrity": "sha512-OEGsICR6Vmx0VK3nhpy5MGPzAjeDYC3+NKxNtJAu4DW8L15oy8tCe2WuD6HDEj9BsbSopnOBiXPK95YHvO0DpA==",
+			"requires": {
+				"lodash.defaults": "^4.2.0",
+				"through2": "^2.0.1"
+			}
+		},
 		"gulp-clean": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/gulp-clean/-/gulp-clean-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"docz": "^2.3.1",
 		"emotion": "^11.0.0",
 		"fs-extra": "^10.0.0",
+		"gulp-cached": "^1.1.1",
 		"immutability-helper": "^3.1.1",
 		"lodash": "^4.17.21",
 		"mini-css-extract-plugin": "^2.2.2",


### PR DESCRIPTION
Gulp watch takes too long (around 10 to 12 seconds) to compile SCSS files every time any file changes. The `gulp-cached` plugin provides a simple file-based caching mechanism for Gulp. It allows Gulp to remember files that have passed through a task and efficiently process only the files that have changed since the last run. This can significantly speed up the build process, especially when dealing with a large number of files.