### PR TITLE
Optional input validation checking added

### DIFF
--- a/helpers/ValidationHelper.php
+++ b/helpers/ValidationHelper.php
@@ -44,49 +44,58 @@ class ValidationHelper {
 			foreach ( $rules as $rule ) {
 				$nested_rules = explode( ':', $rule );
 
+				/**
+				 * Optional input validation.
+				 */
+				if ( isset( $nested_rules[0] ) && 'if_input' === $nested_rules[0] ) {
+					if ( ! self::has_key( $key, $data ) ) {
+						break;
+					}
+				}
+
 				foreach ( $nested_rules as $nested_rule ) {
 					switch ( $nested_rule ) {
 						case 'required':
 							if ( ! self::has_key( $key, $data ) || self::is_empty( $data[ $key ] ) ) {
-								$validation_pass     = false;
+								$validation_pass           = false;
 								$validation_errors[ $key ] = $key . __( ' is required', 'tutor' );
 							}
 							break;
 						case 'numeric':
 							if ( ! self::is_numeric( $data[ $key ] ) ) {
-								$validation_pass     = false;
+								$validation_pass           = false;
 								$validation_errors[ $key ] = $key . __( ' is not numeric', 'tutor' );
 							}
 							break;
 						case 'min_length':
 							if ( strlen( $data[ $key ] ) < $nested_rules[1] ) {
-								$validation_pass     = false;
+								$validation_pass           = false;
 								$validation_errors[ $key ] = $key . __( ' minimum length is ', 'tutor' ) . $nested_rules[1];
 							}
 							break;
 						case 'mimes':
 							$extensions = explode( ',', $nested_rules[1] );
 							if ( ! self::in_array( $data[ $key ], $extensions ) ) {
-								$validation_pass     = false;
+								$validation_pass           = false;
 								$validation_errors[ $key ] = $key . __( ' extension is not valid', 'tutor' );
 							}
 							break;
 						case 'match_string':
 							$strings = explode( ',', $nested_rules[1] );
 							if ( ! self::in_array( $data[ $key ], $strings ) ) {
-								$validation_pass     = false;
+								$validation_pass           = false;
 								$validation_errors[ $key ] = $key . __( ' string is not valid', 'tutor' );
 							}
 							break;
 						case 'boolean':
 							if ( ! self::is_boolean( $data[ $key ] ) ) {
-								$validation_pass     = false;
+								$validation_pass           = false;
 								$validation_errors[ $key ] = $key . __( ' is not boolean', 'tutor' );
 							}
 							break;
 						case 'is_array':
 							if ( ! self::is_array( $data[ $key ] ) ) {
-								$validation_pass     = false;
+								$validation_pass           = false;
 								$validation_errors[ $key ] = $key . __( ' is not an array', 'tutor' );
 							}
 							break;


### PR DESCRIPTION
```php
use Tutor\Helpers\ValidationHelper;

$rules = [
  'name' => 'min_length:5',
  'age'  => 'if_input|numeric',
];

$inputs = [
 'name' => 'John doe',
];

// Success.
ValidationHelper::validate( $rules, $inputs );

$inputs = [
 'name' => 'John doe',
 'age'  => 'dummy'
];

// Fail. reason, If the age input exists, it must be numeric
ValidationHelper::validate( $rules, $inputs );
```