### PR TITLE
Fix: Frontend assignment deprication warning message

### DIFF
--- a/templates/single/lesson/content.php
+++ b/templates/single/lesson/content.php
@@ -88,7 +88,7 @@ tutor_load_template(
 
 	<?php
 	$referer_url        = wp_get_referer();
-	$referer_comment_id = explode( '#', filter_input( INPUT_SERVER, 'REQUEST_URI' ) );
+	$referer_comment_id = explode( '#', filter_input( INPUT_SERVER, 'REQUEST_URI' ) ?? '' );
 	$url_components     = parse_url( $referer_url );
 	$page_tab           = \TUTOR\Input::get( 'page_tab', 'overview' );
 


### PR DESCRIPTION
Assignment page deprication warning message issue fixed

<img width="1157" alt="image" src="https://github.com/themeum/tutor/assets/42798816/aeec1e4c-a2df-4c4e-9d7b-b11a86bc9542">
