### PR TITLE
Added $sub_url to tutor_dashboard_url filter

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -5299,7 +5299,7 @@ class Utils {
 	public function tutor_dashboard_url( $sub_url = '' ) {
 		$page_id = (int) $this->get_option( 'tutor_dashboard_page_id' );
 		$page_id = apply_filters( 'tutor_dashboard_page_id', $page_id );
-		return apply_filters( 'tutor_dashboard_url', trailingslashit( get_the_permalink( $page_id ) ) . $sub_url );
+		return apply_filters( 'tutor_dashboard_url', trailingslashit( get_the_permalink( $page_id ) ) . $sub_url, $sub_url );
 	}
 
 	/**


### PR DESCRIPTION
Reopen of #522 for @w3guy:

> Add `$sub_url` to `tutor_dashboard_url` filter

@w3guy said about this submission at https://github.com/themeum/tutor/pull/496#issuecomment-1661586546:
> _"This PR is important to us though"_:
>
> I am unable to create a PR against the dev branch. I don't have such permission.
> Here's my fork https://github.com/w3guy/tutor/commit/40bc7cc3b5c4ccbe0762e5cbf4c101881c595f59