### PR TITLE
classes/Options_V2: Update the permalink when changing the course slug

### DIFF
--- a/classes/Options_V2.php
+++ b/classes/Options_V2.php
@@ -636,6 +636,15 @@ class Options_V2 {
 						'block_type' => 'uniform',
 						'fields'     => array(
 							array(
+								'key'         => 'course_permalink_base',
+								'type'        => 'text',
+								'label'       => __( 'Course Slug', 'tutor' ),
+								'placeholder' => __( 'Course Slug', 'tutor' ),
+								'label_title' => '',
+								'default'     => tutor()->course_post_type,
+								'desc'        => __( 'Update the permalink when changing the course slug', 'tutor' ),
+							),
+							array(
 								'key'         => 'student_must_login_to_view_course',
 								'type'        => 'toggle_switch',
 								'label'       => __( 'Course Visibility', 'tutor' ),

--- a/classes/Post_types.php
+++ b/classes/Post_types.php
@@ -84,8 +84,6 @@ class Post_types {
 	 * @return void
 	 */
 	public function register_course_post_types() {
-		$course_post_type = $this->course_post_type;
-
 		$labels = array(
 			'name'               => _x( 'Courses', 'post type general name', 'tutor' ),
 			'singular_name'      => _x( 'Course', 'post type singular name', 'tutor' ),
@@ -112,7 +110,7 @@ class Post_types {
 			// 'show_in_menu'              => 'tutor',
 			'query_var'          => true,
 			'rewrite'            => array(
-				'slug'       => tutor_utils()->get_option( 'course_permalink_base', $course_post_type ),
+				'slug'       => tutor_utils()->get_option( 'course_permalink_base', $this->course_post_type ),
 				'with_front' => true,
 			),
 			'menu_icon'          => 'dashicons-book-alt',


### PR DESCRIPTION
> This feature is already released
But it was initially not working for existing courses, See bug #576.

This code is originally from @shewa12's PR about it.

Renaming the course base slug of existing courses is missing. They stay with their old slug!!!

These changes (of this Pull Request) which @shewa12 made, may do that, right?
> These changes have not been merged yet!!!
```php
	array(
		'key'         => 'course_permalink_base',
		'type'        => 'text',
		'label'       => __( 'Course Slug', 'tutor' ),
		'placeholder' => __( 'Course Slug', 'tutor' ),
		'label_title' => '',
		'default'     => tutor()->course_post_type,
		'desc'        => __( 'Update the permalink when changing the course slug', 'tutor' ),
	),
```							
The same renaming would also have to be done when the lesson base slug changes, which is also not done.