### PR TITLE
chore: Update usePortalPopover and modal component zIndex handling

### DIFF
--- a/assets/react/v3/entries/course-builder/components/curriculum/Topic.tsx
+++ b/assets/react/v3/entries/course-builder/components/curriculum/Topic.tsx
@@ -532,7 +532,7 @@ const Topic = ({ topic, onDelete, onCopy, onSort, onCollapse, onEdit, isOverlay 
                         topicId: topic.id,
                         title: __('Lesson', 'tutor'),
                         icon: <SVGIcon name="lesson" width={24} height={24} />,
-                        subtitle: `${__('Topic:', 'tutor')}  ${topic.title}`,
+                        subtitle: sprintf(__('Topic: %s', 'tutor'), topic.title),
                       },
                     });
                   }}
@@ -553,7 +553,7 @@ const Topic = ({ topic, onDelete, onCopy, onSort, onCollapse, onEdit, isOverlay 
                         contentDripType: courseDetailsForm.watch('contentDripType'),
                         title: __('Quiz', 'tutor'),
                         icon: <SVGIcon name="quiz" width={24} height={24} />,
-                        subtitle: `${__('Topic:', 'tutor')}  ${topic.title}`,
+                        subtitle: sprintf(__('Topic: %s', 'tutor'), topic.title),
                       },
                     });
                   }}
@@ -574,7 +574,7 @@ const Topic = ({ topic, onDelete, onCopy, onSort, onCollapse, onEdit, isOverlay 
                         contentDripType: courseDetailsForm.watch('contentDripType'),
                         title: __('Assignment', 'tutor'),
                         icon: <SVGIcon name="assignment" width={24} height={24} />,
-                        subtitle: `${__('Topic:', 'tutor')}  ${topic.title}`,
+                        subtitle: sprintf(__('Topic: %s', 'tutor'), topic.title),
                       },
                     });
                   }}
@@ -899,6 +899,7 @@ const styles = {
     isDragging: boolean;
   }) => css`
     ${styleUtils.resetButton};
+    ${styleUtils.flexCenter()};
     cursor: ${isDragging ? 'grabbing' : 'grab'};
   `,
 };

--- a/assets/react/v3/entries/course-builder/components/modals/AssignmentModal.tsx
+++ b/assets/react/v3/entries/course-builder/components/modals/AssignmentModal.tsx
@@ -380,6 +380,14 @@ const AssignmentModal = ({
             <Controller
               name="pass_mark"
               control={form.control}
+              rules={{
+                validate: (value) => {
+                  if (value > form.getValues('total_mark')) {
+                    return __('Pass mark cannot be greater than total mark', 'tutor');
+                  }
+                  return true;
+                },
+              }}
               render={(controllerProps) => (
                 <FormInput
                   {...controllerProps}

--- a/assets/react/v3/shared/components/fields/FormWPEditor.tsx
+++ b/assets/react/v3/shared/components/fields/FormWPEditor.tsx
@@ -88,6 +88,7 @@ const FormWPEditor = ({
                           icon: <SVGIcon name={customEditorIcons[editor.name]} height={24} width={24} />,
                           title: __(`${editor.name} Editor`, 'tutor'),
                         },
+                        zIndex: zIndex.highest,
                       })
                     }
                   >
@@ -173,8 +174,8 @@ const FormWPEditor = ({
                             title: __(`${editorUsed.name} Editor`, 'tutor'),
                             editorUsed: editorUsed,
                             icon: <SVGIcon name={customEditorIcons[editorUsed.name]} height={24} width={24} />,
-                            zIndex: zIndex.highest,
                           },
+                          zIndex: zIndex.highest,
                         })
                       }
                     >

--- a/assets/react/v3/shared/components/fields/FormWPEditor.tsx
+++ b/assets/react/v3/shared/components/fields/FormWPEditor.tsx
@@ -88,7 +88,7 @@ const FormWPEditor = ({
                           icon: <SVGIcon name={customEditorIcons[editor.name]} height={24} width={24} />,
                           title: __(`${editor.name} Editor`, 'tutor'),
                         },
-                        zIndex: zIndex.highest,
+                        depthIndex: zIndex.highest,
                       })
                     }
                   >
@@ -175,7 +175,7 @@ const FormWPEditor = ({
                             editorUsed: editorUsed,
                             icon: <SVGIcon name={customEditorIcons[editorUsed.name]} height={24} width={24} />,
                           },
-                          zIndex: zIndex.highest,
+                          depthIndex: zIndex.highest,
                         })
                       }
                     >

--- a/assets/react/v3/shared/components/modals/Modal.tsx
+++ b/assets/react/v3/shared/components/modals/Modal.tsx
@@ -1,4 +1,4 @@
-import { colorTokens, zIndex as configZIndex } from '@Config/styles';
+import { colorTokens, zIndex } from '@Config/styles';
 import { AnimatedDiv, AnimationType, useAnimation } from '@Hooks/useAnimation';
 import { nanoid, noop } from '@Utils/util';
 import { css } from '@emotion/react';
@@ -10,7 +10,7 @@ const styles = {
     background-color: ${colorTokens.background.modal};
     opacity: 0.7;
     inset: 0;
-    z-index: ${configZIndex.negative};
+    z-index: ${zIndex.negative};
 
     ${
       magicAi &&
@@ -22,7 +22,7 @@ const styles = {
     }
   `,
   container: css`
-    z-index: ${configZIndex.modal};
+    z-index: ${zIndex.modal};
     position: fixed;
     display: flex;
     justify-content: center;
@@ -50,7 +50,7 @@ type ModalContextType = {
     props?: Omit<P, 'closeModal'>;
     closeOnOutsideClick?: boolean;
     isMagicAi?: boolean;
-    zIndex?: number;
+    depthIndex?: number;
   }): Promise<NonNullable<Parameters<P['closeModal']>[0]> | PromiseResolvePayload<'CLOSE'>>;
   closeModal(data?: PromiseResolvePayload): void;
   hasModalOnStack?: boolean;
@@ -75,14 +75,14 @@ export const ModalProvider: React.FunctionComponent<{ children: ReactNode }> = (
       resolve: (data: PromiseResolvePayload<any>) => void;
       closeOnOutsideClick: boolean;
       isMagicAi?: boolean;
-      zIndex?: number;
+      depthIndex?: number;
     }[];
   }>({
     modals: [],
   });
 
   const showModal = useCallback<ModalContextType['showModal']>(
-    ({ component, props, closeOnOutsideClick = false, isMagicAi = false, zIndex = configZIndex.modal }) => {
+    ({ component, props, closeOnOutsideClick = false, isMagicAi = false, depthIndex = zIndex.modal }) => {
       return new Promise((resolve) => {
         setState((previousState) => ({
           ...previousState,
@@ -94,7 +94,7 @@ export const ModalProvider: React.FunctionComponent<{ children: ReactNode }> = (
               resolve,
               closeOnOutsideClick,
               id: nanoid(),
-              zIndex,
+              depthIndex,
               isMagicAi,
             },
           ],
@@ -134,7 +134,7 @@ export const ModalProvider: React.FunctionComponent<{ children: ReactNode }> = (
             css={[
               styles.container,
               {
-                zIndex: modal.zIndex,
+                zIndex: modal.depthIndex,
               },
             ]}
           >

--- a/assets/react/v3/shared/components/modals/Modal.tsx
+++ b/assets/react/v3/shared/components/modals/Modal.tsx
@@ -1,4 +1,4 @@
-import { colorTokens, zIndex } from '@Config/styles';
+import { colorTokens, zIndex as configZIndex } from '@Config/styles';
 import { AnimatedDiv, AnimationType, useAnimation } from '@Hooks/useAnimation';
 import { nanoid, noop } from '@Utils/util';
 import { css } from '@emotion/react';
@@ -10,7 +10,7 @@ const styles = {
     background-color: ${colorTokens.background.modal};
     opacity: 0.7;
     inset: 0;
-    z-index: ${zIndex.negative};
+    z-index: ${configZIndex.negative};
 
     ${
       magicAi &&
@@ -22,7 +22,7 @@ const styles = {
     }
   `,
   container: css`
-    z-index: ${zIndex.modal};
+    z-index: ${configZIndex.modal};
     position: fixed;
     display: flex;
     justify-content: center;
@@ -42,7 +42,6 @@ export type ModalProps = {
   headerChildren?: React.ReactNode;
   entireHeader?: React.ReactNode;
   actions?: React.ReactNode;
-  zIndex?: number;
 };
 
 type ModalContextType = {
@@ -51,6 +50,7 @@ type ModalContextType = {
     props?: Omit<P, 'closeModal'>;
     closeOnOutsideClick?: boolean;
     isMagicAi?: boolean;
+    zIndex?: number;
   }): Promise<NonNullable<Parameters<P['closeModal']>[0]> | PromiseResolvePayload<'CLOSE'>>;
   closeModal(data?: PromiseResolvePayload): void;
   hasModalOnStack?: boolean;
@@ -82,13 +82,21 @@ export const ModalProvider: React.FunctionComponent<{ children: ReactNode }> = (
   });
 
   const showModal = useCallback<ModalContextType['showModal']>(
-    ({ component, props, closeOnOutsideClick = false, isMagicAi = false }) => {
+    ({ component, props, closeOnOutsideClick = false, isMagicAi = false, zIndex = configZIndex.modal }) => {
       return new Promise((resolve) => {
         setState((previousState) => ({
           ...previousState,
           modals: [
             ...previousState.modals,
-            { component, props, resolve, closeOnOutsideClick, id: nanoid(), isMagicAi },
+            {
+              component,
+              props,
+              resolve,
+              closeOnOutsideClick,
+              id: nanoid(),
+              zIndex,
+              isMagicAi,
+            },
           ],
         }));
       });
@@ -131,7 +139,7 @@ export const ModalProvider: React.FunctionComponent<{ children: ReactNode }> = (
             ]}
           >
             <AnimatedDiv style={style} hideOnOverflow={false}>
-              {React.createElement(modal.component, { ...modal.props, closeModal, zIndex: modal.zIndex })}
+              {React.createElement(modal.component, { ...modal.props, closeModal })}
             </AnimatedDiv>
             <div
               css={styles.backdrop({ magicAi: modal.isMagicAi })}

--- a/assets/react/v3/shared/hooks/usePortalPopover.tsx
+++ b/assets/react/v3/shared/hooks/usePortalPopover.tsx
@@ -8,6 +8,8 @@ import { noop } from '@Utils/util';
 import { AnimatedDiv, AnimationType, useAnimation } from './useAnimation';
 import { usePrevious } from './usePrevious';
 
+const ANIMATION_DURATION_WITH_THRESHHOLD = 200;
+
 enum ArrowPosition {
   left = 'left',
   right = 'right',
@@ -178,7 +180,7 @@ export const Portal = ({ isOpen, children, onClickOutside, animationType = Anima
         if (!hasPopoverOnStack) {
           document.body.style.overflow = 'initial';
         }
-      }, 200); // this is the total of -> duration of the animation + threshold + 30ms
+      }, ANIMATION_DURATION_WITH_THRESHHOLD);
     };
   }, [isOpen]);
 

--- a/assets/react/v3/shared/hooks/usePortalPopover.tsx
+++ b/assets/react/v3/shared/hooks/usePortalPopover.tsx
@@ -1,4 +1,3 @@
-import { useModal } from '@Components/modals/Modal';
 import { zIndex } from '@Config/styles';
 import { styleUtils } from '@Utils/style-utils';
 import { css } from '@emotion/react';
@@ -70,13 +69,8 @@ export const usePortalPopover = <T extends HTMLElement, D extends HTMLElement>({
 
     const triggerRect = triggerRef.current.getBoundingClientRect();
     const popoverRect = popoverRef.current.getBoundingClientRect();
-    const { height: previousPopoverHeight, top: previousPopoverTop } = previousPopoverRect || {};
     const popoverWidth = popoverRect.width || triggerRect.width;
     const popoverHeight = popoverRect.height;
-
-    if (previousPopoverHeight === popoverHeight && previousPopoverTop === popoverRect.top) {
-      return;
-    }
 
     let calculatedPosition: { top: number; left: number } = { top: 0, left: 0 };
     let arrowPlacement: PopoverPosition['arrowPlacement'] = ArrowPosition.bottom;
@@ -160,7 +154,7 @@ export const usePortalPopover = <T extends HTMLElement, D extends HTMLElement>({
     }
 
     setPosition({ ...calculatedPosition, arrowPlacement });
-  }, [triggerRef, popoverRef, previousPopoverRect, triggerWidth, isOpen, gap, arrow, isDropdown]);
+  }, [triggerRef, popoverRef, triggerWidth, isOpen, gap, arrow, isDropdown]);
 
   return { position, triggerWidth, triggerRef, popoverRef };
 };
@@ -173,21 +167,20 @@ interface PortalProps {
 }
 
 export const Portal = ({ isOpen, children, onClickOutside, animationType = AnimationType.slideDown }: PortalProps) => {
-  // We can determine if there any modal opens by using this `hasModalOnStack`
-  // If there any modal opens then we will not set the overflow value to initial.
-  const { hasModalOnStack } = useModal();
-
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
     }
 
     return () => {
-      if (!hasModalOnStack) {
-        document.body.style.overflow = 'initial';
-      }
+      setTimeout(() => {
+        const hasPopoverOnStack = document.querySelectorAll('.tutor-portal-popover').length > 0;
+        if (!hasPopoverOnStack) {
+          document.body.style.overflow = 'initial';
+        }
+      }, 200); // this is the total of -> duration of the animation + threshold + 30ms
     };
-  }, [isOpen, hasModalOnStack]);
+  }, [isOpen]);
 
   const { transitions } = useAnimation({
     data: isOpen,
@@ -198,7 +191,7 @@ export const Portal = ({ isOpen, children, onClickOutside, animationType = Anima
     if (openState) {
       return createPortal(
         <AnimatedDiv css={styles.wrapper} style={style}>
-          <div role="presentation">
+          <div className="tutor-portal-popover" role="presentation">
             <div
               css={styles.backdrop}
               onKeyUp={noop}


### PR DESCRIPTION
This commit updates `usePortalPopover` to fix scrolling and position and `Modal` component to handle the `zIndex` property. It replaces the usage of the `zIndex` constant from the `@Config/styles` module with the `configZIndex` constant. This change ensures consistent handling of the `zIndex` value throughout the component.