### PR TITLE
✨feat: add readonly prop FromAnswerExplantion and apply styles

### DIFF
--- a/assets/react/v3/entries/course-builder/components/course-basic/CourseSettings.tsx
+++ b/assets/react/v3/entries/course-builder/components/course-basic/CourseSettings.tsx
@@ -64,7 +64,7 @@ const CourseSettings = () => {
 
   return (
     <div>
-      <label css={typography.caption()}>{__('Course Settings', 'tutor')}</label>
+      <label css={typography.caption()}>{__('Options', 'tutor')}</label>
 
       <div css={styles.courseSettings}>
         <Tabs tabList={tabList} activeTab={activeTab} onChange={setActiveTab} orientation="vertical" />

--- a/assets/react/v3/entries/course-builder/components/curriculum/Topic.tsx
+++ b/assets/react/v3/entries/course-builder/components/curriculum/Topic.tsx
@@ -714,32 +714,36 @@ const Topic = ({ topic, onDelete, onCopy, onSort, onCollapse, onEdit, isOverlay 
                     arrowPosition="auto"
                     hideArrow
                   >
-                    <ThreeDots.Option
-                      text={
-                        <span ref={triggerGoogleMeetRef} css={styles.threeDotButton}>
-                          {__('Meet live lesson', 'tutor')}
-                          <Show when={!isTutorPro}>
-                            <ProBadge size="small" content={__('Pro', 'tutor')} />
-                          </Show>
-                        </span>
-                      }
-                      disabled={!isTutorPro}
-                      icon={<SVGIcon width={24} height={24} name="googleMeetColorize" isColorIcon />}
-                      onClick={() => setMeetingType('tutor-google-meet')}
-                    />
-                    <ThreeDots.Option
-                      text={
-                        <span ref={triggerZoomRef} css={styles.threeDotButton}>
-                          {__('Zoom live lesson', 'tutor')}
-                          <Show when={!isTutorPro}>
-                            <ProBadge size="small" content={__('Pro', 'tutor')} />
-                          </Show>
-                        </span>
-                      }
-                      disabled={!isTutorPro}
-                      icon={<SVGIcon width={24} height={24} name="zoomColorize" isColorIcon />}
-                      onClick={() => setMeetingType('tutor_zoom_meeting')}
-                    />
+                    <Show when={isAddonEnabled(Addons.TUTOR_GOOGLE_MEET_INTEGRATION)}>
+                      <ThreeDots.Option
+                        text={
+                          <span ref={triggerGoogleMeetRef} css={styles.threeDotButton}>
+                            {__('Meet live lesson', 'tutor')}
+                            <Show when={!isTutorPro}>
+                              <ProBadge size="small" content={__('Pro', 'tutor')} />
+                            </Show>
+                          </span>
+                        }
+                        disabled={!isTutorPro}
+                        icon={<SVGIcon width={24} height={24} name="googleMeetColorize" isColorIcon />}
+                        onClick={() => setMeetingType('tutor-google-meet')}
+                      />
+                    </Show>
+                    <Show when={isAddonEnabled(Addons.TUTOR_ZOOM_INTEGRATION)}>
+                      <ThreeDots.Option
+                        text={
+                          <span ref={triggerZoomRef} css={styles.threeDotButton}>
+                            {__('Zoom live lesson', 'tutor')}
+                            <Show when={!isTutorPro}>
+                              <ProBadge size="small" content={__('Pro', 'tutor')} />
+                            </Show>
+                          </span>
+                        }
+                        disabled={!isTutorPro}
+                        icon={<SVGIcon width={24} height={24} name="zoomColorize" isColorIcon />}
+                        onClick={() => setMeetingType('tutor_zoom_meeting')}
+                      />
+                    </Show>
                     <Show when={!isTutorPro || isAddonEnabled(Addons.QUIZ_EXPORT_IMPORT)}>
                       <ThreeDots.Option
                         text={

--- a/assets/react/v3/entries/course-builder/components/layouts/Header.tsx
+++ b/assets/react/v3/entries/course-builder/components/layouts/Header.tsx
@@ -235,13 +235,7 @@ const Header = () => {
 
   return (
     <div css={styles.wrapper}>
-      <button
-        type="button"
-        css={[styleUtils.resetButton, styles.logo]}
-        onClick={() => {
-          window.open(tutorConfig.tutor_frontend_dashboard_url, '_blank', 'noopener');
-        }}
-      >
+      <button type="button" css={[styleUtils.resetButton, styles.logo]}>
         <Show
           when={isTutorPro && tutorConfig.settings?.course_builder_logo_url}
           fallback={<Logo width={108} height={24} />}
@@ -251,24 +245,23 @@ const Header = () => {
       </button>
 
       <div css={styles.container}>
-        <div css={styles.titleAndTacker}>
-          <h6 css={styles.title}>{__('Course Builder', 'tutor')}</h6>
-          <span css={styles.divider} />
-          <Tracker />
-
+        <div css={styles.titleAndTackerWrapper}>
+          <div css={styles.titleAndTacker}>
+            <h6 css={styles.title}>{__('Course Builder', 'tutor')}</h6>
+            <span css={styles.divider} />
+            <Tracker />
+          </div>
           <Show when={currentIndex === 0 && isOpenAiEnabled}>
             <span css={styles.divider} />
-            <div>
+            <div css={styleUtils.flexCenter()}>
               <MagicButton
                 variant="plain"
                 css={css`
                   display: inline-flex;
                   align-items: center;
                   gap: ${spacing[4]};
-                  
-
-                    padding-inline: 0px;
-                  
+                  padding-inline: 0px;
+                  margin-left: ${spacing[12]};
                 `}
                 onClick={() => {
                   if (!isTutorPro) {
@@ -431,6 +424,7 @@ const styles = {
   `,
   logo: css`
     padding-left: ${spacing[32]};
+    cursor: default;
 
     img {
       max-height: 24px;
@@ -439,10 +433,15 @@ const styles = {
       object-position: center;
     }
   `,
+  titleAndTackerWrapper: css`
+    ${styleUtils.display.flex()};
+    align-items: center;
+  `,
   titleAndTacker: css`
     ${styleUtils.display.flex()};
     gap: ${spacing[20]};
     align-items: center;
+    margin-right: ${spacing[20]};
   `,
   divider: css`
     width: 2px;

--- a/assets/react/v3/entries/course-builder/components/layouts/Header.tsx
+++ b/assets/react/v3/entries/course-builder/components/layouts/Header.tsx
@@ -261,7 +261,7 @@ const Header = () => {
                   align-items: center;
                   gap: ${spacing[4]};
                   padding-inline: 0px;
-                  margin-left: ${spacing[12]};
+                  margin-left: ${spacing[4]};
                 `}
                 onClick={() => {
                   if (!isTutorPro) {
@@ -439,9 +439,9 @@ const styles = {
   `,
   titleAndTacker: css`
     ${styleUtils.display.flex()};
-    gap: ${spacing[20]};
+    gap: ${spacing[12]};
     align-items: center;
-    margin-right: ${spacing[20]};
+    margin-right: ${spacing[16]};
   `,
   divider: css`
     width: 2px;
@@ -450,7 +450,7 @@ const styles = {
     border-radius: ${borderRadius[20]};
   `,
   title: css`
-    ${typography.heading6('medium')};
+    ${typography.body('medium')};
     color: ${colorTokens.text.subdued};
   `,
   headerRight: css`

--- a/assets/react/v3/entries/course-builder/components/layouts/Tracker.tsx
+++ b/assets/react/v3/entries/course-builder/components/layouts/Tracker.tsx
@@ -61,11 +61,15 @@ const styles = {
     gap: ${spacing[8]};
     align-items: center;
 
+    &:is(:first-child) {
+      padding-left: 0;
+    }
+
     ${
       isActive &&
       css`
-      color: ${colorTokens.text.primary};
-    `
+        color: ${colorTokens.text.primary};
+      `
     }
 
     ${

--- a/assets/react/v3/entries/course-builder/components/modals/AssignmentModal.tsx
+++ b/assets/react/v3/entries/course-builder/components/modals/AssignmentModal.tsx
@@ -215,7 +215,7 @@ const AssignmentModal = ({
                 render={(controllerProps) => (
                   <FormInput
                     {...controllerProps}
-                    label={__('Assignment Title', 'tutor')}
+                    label={__('Title', 'tutor')}
                     placeholder={__('Enter Assignment Title', 'tutor')}
                     isClearable
                     selectOnFocus

--- a/assets/react/v3/entries/course-builder/components/modals/LessonModal.tsx
+++ b/assets/react/v3/entries/course-builder/components/modals/LessonModal.tsx
@@ -197,14 +197,14 @@ const LessonModal = ({
                 name="title"
                 control={form.control}
                 rules={{
-                  required: __('Lesson Name is required', 'tutor'),
+                  required: __('Lesson title is required.', 'tutor'),
                   ...maxLimitRule(255),
                 }}
                 render={(controllerProps) => (
                   <FormInput
                     {...controllerProps}
-                    label={__('Lesson Name', 'tutor')}
-                    placeholder={__('Enter Lesson Name', 'tutor')}
+                    label={__('Title', 'tutor')}
+                    placeholder={__('Enter Lesson Title', 'tutor')}
                     helpText={__('Lesson titles are displayed publicly wherever required.', 'tutor')}
                     selectOnFocus
                     isClearable

--- a/assets/react/v3/entries/course-builder/pages/CourseBasic.tsx
+++ b/assets/react/v3/entries/course-builder/pages/CourseBasic.tsx
@@ -262,7 +262,7 @@ const CourseBasic = () => {
               render={(controllerProps) => (
                 <FormInput
                   {...controllerProps}
-                  label={__('Course Title', 'tutor')}
+                  label={__('Title', 'tutor')}
                   placeholder={__('ex. Learn Photoshop CS6 from scratch', 'tutor')}
                   isClearable
                   selectOnFocus

--- a/assets/react/v3/entries/course-builder/pages/CourseBasic.tsx
+++ b/assets/react/v3/entries/course-builder/pages/CourseBasic.tsx
@@ -378,7 +378,7 @@ const CourseBasic = () => {
             <FormImageInput
               {...controllerProps}
               label={__('Featured Image', 'tutor')}
-              buttonText={__('Upload Course Thumbnail', 'tutor')}
+              buttonText={__('Upload Thumbnail', 'tutor')}
               infoText={__('Supported file formats: .jpg, .jpeg, .png, .gif, .webp', 'tutor')}
               generateWithAi={!isTutorPro || isOpenAiEnabled}
               loading={!!isCourseDetailsFetching && !controllerProps.field.value}

--- a/assets/react/v3/shared/atoms/ImageInput.tsx
+++ b/assets/react/v3/shared/atoms/ImageInput.tsx
@@ -83,6 +83,7 @@ const ImageInput = ({
                 <Button
                   variant="secondary"
                   size={size}
+                  buttonCss={css`margin-top: ${spacing[16]};`}
                   onClick={(event) => {
                     event.stopPropagation();
                     uploadHandler();

--- a/assets/react/v3/shared/atoms/WPEditor.tsx
+++ b/assets/react/v3/shared/atoms/WPEditor.tsx
@@ -281,6 +281,7 @@ const WPEditor = ({
       css={styles.wrapper({
         isMinimal,
         isFocused,
+        isReadOnly: readonly,
       })}
     >
       <textarea ref={editorRef} id={editorId} defaultValue={value} />
@@ -294,9 +295,11 @@ const styles = {
   wrapper: ({
     isMinimal,
     isFocused,
+    isReadOnly,
   }: {
     isMinimal?: boolean;
     isFocused: boolean;
+    isReadOnly?: boolean;
   }) => css`
     flex: 1;
 
@@ -360,7 +363,7 @@ const styles = {
       isMinimal &&
       css`
         .mce-tinymce.mce-container {
-          border: 1px solid ${colorTokens.stroke.default};
+          border: ${!isReadOnly ? `1px solid ${colorTokens.stroke.default}` : 'none'};
           border-radius: ${borderRadius[6]};
 
           ${

--- a/assets/react/v3/shared/components/fields/FormAnswerExplanation.tsx
+++ b/assets/react/v3/shared/components/fields/FormAnswerExplanation.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 
 import Button from '@Atoms/Button';
@@ -47,86 +46,77 @@ const FormAnswerExplanation = ({
   const [previousValue, setPreviousValue] = useState<string>(inputValue);
 
   return (
-    <div css={styles.container({ isEdit: isEdit || !!inputValue })}>
-      <Show
-        when={isEdit}
-        fallback={
+    <div
+      css={styles.wrapper({
+        hasValue: !!inputValue && !isEdit,
+      })}
+    >
+      <Show when={isEdit || inputValue}>
+        <label css={styles.answerLabel}>{label}</label>
+      </Show>
+      <div css={styles.editorWrapper({ isEdit })}>
+        <div css={styles.container({ isEdit: isEdit || !!inputValue })}>
           <Show
-            when={inputValue}
+            when={!inputValue && !isEdit}
             fallback={
-              <div
-                css={styles.placeholder}
-                role="button"
-                onClick={() => setIsEdit(true)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    setIsEdit(true);
-                  }
-                }}
-              >
-                {placeholder}
-              </div>
+              <FormWPEditor
+                field={field}
+                fieldState={fieldState}
+                disabled={disabled}
+                helpText={helpText}
+                loading={loading}
+                readOnly={!isEdit}
+                onChange={onChange}
+                placeholder={placeholder}
+                autoFocus
+                isMinimal
+              />
             }
           >
+            <div css={styles.placeholder}>{placeholder}</div>
+          </Show>
+          <Show when={isEdit}>
+            <div data-action-buttons css={styles.actionButtonWrapper({ isEdit })}>
+              <Button
+                variant="text"
+                size="small"
+                onClick={() => {
+                  field.onChange(previousValue);
+                  setIsEdit(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="secondary"
+                size="small"
+                onClick={() => {
+                  setPreviousValue(field.value ?? '');
+                  setIsEdit(false);
+                }}
+                disabled={field.value === previousValue}
+              >
+                Ok
+              </Button>
+            </div>
+          </Show>
+          <Show when={!isEdit}>
             <div
-              css={styles.answer}
-              role="button"
-              onClick={() => setIsEdit(true)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
+              onClick={(e) => {
+                if (!isEdit && !disabled) {
                   setIsEdit(true);
                 }
               }}
-            >
-              <div css={styles.answerLabel}>{__('Answer explanation', 'tutor')}</div>
-              <p
-                css={styles.answerParagraph}
-                dangerouslySetInnerHTML={{
-                  __html: inputValue,
-                }}
-              />
-            </div>
+              onKeyDown={(event) => {
+                if ((event.key === 'Enter' || event.key === ' ') && !isEdit) {
+                  setIsEdit(true);
+                }
+              }}
+              data-overlay
+            />
           </Show>
-        }
-      >
-        <FormWPEditor
-          field={field}
-          fieldState={fieldState}
-          disabled={disabled}
-          helpText={helpText}
-          key={field.name}
-          label={label}
-          loading={loading}
-          onChange={onChange}
-          placeholder={placeholder}
-          readOnly={readOnly}
-          autoFocus
-          isMinimal
-        />
-        <div data-action-buttons css={styles.actionButtonWrapper({ isEdit })}>
-          <Button
-            variant="text"
-            size="small"
-            onClick={() => {
-              field.onChange(previousValue);
-              setIsEdit(false);
-            }}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="secondary"
-            size="small"
-            onClick={() => {
-              setPreviousValue(field.value ?? '');
-              setIsEdit(false);
-            }}
-            disabled={field.value === previousValue}
-          >
-            Ok
-          </Button>
         </div>
-      </Show>
+      </div>
     </div>
   );
 };
@@ -134,6 +124,41 @@ const FormAnswerExplanation = ({
 export default FormAnswerExplanation;
 
 const styles = {
+  wrapper: ({
+    hasValue,
+  }: {
+    hasValue: boolean;
+  }) => css`
+    ${styleUtils.display.flex('column')}
+    gap: ${spacing[10]};
+    border-radius: ${borderRadius.card};
+
+    ${
+      hasValue &&
+      css`
+        background-color: ${colorTokens.color.success[30]};
+        padding: ${spacing[12]} ${spacing[24]};
+
+        &:hover {
+          background-color: ${colorTokens.color.success[40]};
+        }
+      `
+    }
+  `,
+  editorWrapper: ({ isEdit }: { isEdit: boolean }) => css`
+    position: relative;
+    max-height: 400px;
+    overflow-y: scroll;
+
+    ${
+      isEdit &&
+      css`
+        padding-inline: 0;
+        max-height: unset;
+        overflow: unset;
+      `
+    }
+  `,
   container: ({
     isEdit,
   }: {
@@ -146,8 +171,15 @@ const styles = {
     min-height: 48px;
     height: 100%;
     width: 100%;
+    inset: 0;
     border-radius: ${borderRadius[6]};
     transition: background 0.15s ease-in-out;
+
+    [data-overlay] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+    }
 
     & label {
       ${typography.caption()}

--- a/assets/react/v3/shared/components/fields/FormQuestionDescription.tsx
+++ b/assets/react/v3/shared/components/fields/FormQuestionDescription.tsx
@@ -24,7 +24,7 @@ const FormQuestionDescription = ({
   label,
   field,
   fieldState,
-  disabled,
+  disabled = false,
   loading,
   placeholder,
   helpText,
@@ -37,7 +37,7 @@ const FormQuestionDescription = ({
 
   return (
     <div css={styles.editorWrapper({ isEdit })}>
-      <div css={styles.container({ isEdit })}>
+      <div css={styles.container({ isEdit, isDisabled: disabled })}>
         <Show
           when={!inputValue && !isEdit}
           fallback={
@@ -109,7 +109,7 @@ const styles = {
   editorWrapper: ({ isEdit }: { isEdit: boolean }) => css`
     position: relative;
     max-height: 400px;
-    overflow-y: scroll;
+    overflow-y: auto;
 
     ${
       isEdit &&


### PR DESCRIPTION
Here is the pull request description:

This pull request adds a new `readonly` prop to the `FromAnswerExplantion` component and applies the necessary styles. The new prop allows the component to be displayed in a read-only mode, which is useful for scenarios where the user should not be able to edit the content.

The changes include:

- Added the `readonly` prop to the `FromAnswerExplantion` component
- Applied styles to the component to visually indicate the read-only state

These changes will improve the overall functionality and user experience of the `WPEditor` feature.