### PR TITLE
Pay Option for The Failed Order

### DIFF
--- a/ecommerce/CheckoutController.php
+++ b/ecommerce/CheckoutController.php
@@ -838,7 +838,11 @@ class CheckoutController {
 	 * @return void
 	 */
 	public function pay_incomplete_order() {
-		$order_id = Input::get( 'order_id', 0, Input::TYPE_INT );
+		$order_id = Input::post( 'order_id', 0, Input::TYPE_INT );
+		if ( ! tutor_utils()->is_nonce_verified() ) {
+			tutor_utils()->redirect_to( tutor_utils()->tutor_dashboard_url( 'purchase_history' ), tutor_utils()->error_message( 'nonce' ), 'error' );
+			exit;
+		}
 		if ( $order_id ) {
 			$order_data = ( new OrderModel() )->get_order_by_id( $order_id );
 			if ( $order_data ) {

--- a/ecommerce/CheckoutController.php
+++ b/ecommerce/CheckoutController.php
@@ -94,6 +94,7 @@ class CheckoutController {
 
 		if ( $register_hooks ) {
 			add_action( 'tutor_action_tutor_pay_now', array( $this, 'pay_now' ) );
+			add_action( 'tutor_action_tutor_pay_incomplete_order', array( $this, 'pay_incomplete_order' ) );
 			add_action( 'template_redirect', array( $this, 'restrict_checkout_page' ) );
 			add_action( 'wp_ajax_tutor_get_checkout_html', array( $this, 'ajax_get_checkout_html' ) );
 		}
@@ -439,7 +440,7 @@ class CheckoutController {
 		}
 
 		// if ( ! Ecommerce::is_payment_gateway_configured( $payment_method ) ) {
-		// 	array_push( $errors, Ecommerce::get_incomplete_payment_setup_error_message( $payment_method ) );
+		// array_push( $errors, Ecommerce::get_incomplete_payment_setup_error_message( $payment_method ) );
 		// }
 
 		$billing_info = $billing_model->get_info( $current_user_id );
@@ -485,26 +486,12 @@ class CheckoutController {
 						$this->proceed_to_payment( $payment_data, $payment_method, $order_type );
 					} catch ( \Throwable $th ) {
 						error_log( 'File: ' . $th->getFile() . ' line: ' . $th->getLine() . ' message: ' . $th->getMessage() );
-						$order_id  = $order_data['id'];
-						$error_msg = $th->getMessage();
-
-						wp_safe_redirect( home_url( "?tutor_order_placement=failed&order_id=$order_id&error_message=$error_msg" ) );
-						exit();
+						tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, $order_data['id'], $th->getMessage() );
 					}
 				} else {
 					// Set alert message session.
 					$this->set_pay_now_alert_msg( $order_data );
-
-					wp_safe_redirect(
-						add_query_arg(
-							array(
-								'tutor_order_placement' => 'success',
-								'order_id'              => $order_data['id'],
-							),
-							home_url()
-						)
-					);
-					exit();
+					tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_SUCCESS, $order_data['id'] );
 				}
 			} else {
 				array_push( $errors, __( 'Failed to place order!', 'tutor' ) );
@@ -836,6 +823,43 @@ class CheckoutController {
 		}
 	}
 
+	/**
+	 * Pay for the incomplete order
+	 *
+	 * Redirect to the payment gateway to complete the order
+	 * After completing the process it will redirect user to
+	 * order placement page
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return void
+	 */
+	public function pay_incomplete_order() {
+		$order_id = Input::get( 'order_id', 0 );
+		if ( $order_id ) {
+			$order_data = ( new OrderModel() )->get_order_by_id( $order_id );
+			if ( $order_data ) {
+				try {
+					foreach ( $order_data->items as $key => $item ) {
+						$order_data->items[ $key ]->item_id = $item->id;
+					}
+
+					$payment_data = $this->prepare_payment_data( (array) $order_data, $order_data->payment_method, $order_data->order_type );
+					$this->proceed_to_payment( $payment_data, $order_data->payment_method, $order_data->order_type );
+				} catch ( \Throwable $th ) {
+					error_log( 'File: ' . $th->getFile() . ' line: ' . $th->getLine() . ' message: ' . $th->getMessage() );
+
+					tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, $$order_data['id'], $th->getMessage() );
+				}
+			} else {
+				$error_msg = __( 'Order not found!', 'tutor' );
+				tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, $$order_data['id'], $error_msg );
+			}
+		} else {
+			$error_msg = __( 'Invalid order ID!', 'tutor' );
+			tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, $$order_data['id'], $error_msg );
+		}
+	}
 
 	/**
 	 * Validate pay now request

--- a/ecommerce/CheckoutController.php
+++ b/ecommerce/CheckoutController.php
@@ -485,7 +485,7 @@ class CheckoutController {
 						$payment_data = self::prepare_payment_data( $order_data );
 						$this->proceed_to_payment( $payment_data, $payment_method, $order_type );
 					} catch ( \Throwable $th ) {
-						error_log( 'File: ' . $th->getFile() . ' line: ' . $th->getLine() . ' message: ' . $th->getMessage() );
+						tutor_log( $th );
 						tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, $order_data['id'], $th->getMessage() );
 					}
 				} else {
@@ -838,7 +838,7 @@ class CheckoutController {
 	 * @return void
 	 */
 	public function pay_incomplete_order() {
-		$order_id = Input::get( 'order_id', 0 );
+		$order_id = Input::get( 'order_id', 0, Input::TYPE_INT );
 		if ( $order_id ) {
 			$order_data = ( new OrderModel() )->get_order_by_id( $order_id );
 			if ( $order_data ) {
@@ -846,17 +846,16 @@ class CheckoutController {
 					$payment_data = $this->prepare_payment_data( (array) $order_data, $order_data->payment_method, $order_data->order_type );
 					$this->proceed_to_payment( $payment_data, $order_data->payment_method, $order_data->order_type );
 				} catch ( \Throwable $th ) {
-					error_log( 'File: ' . $th->getFile() . ' line: ' . $th->getLine() . ' message: ' . $th->getMessage() );
-
+					tutor_log( $th );
 					tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, $order_data->id, $th->getMessage() );
 				}
 			} else {
 				$error_msg = __( 'Order not found!', 'tutor' );
-				tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, 0, $error_msg );
+				tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, $order_id, $error_msg );
 			}
 		} else {
 			$error_msg = __( 'Invalid order ID!', 'tutor' );
-			tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, 0, $error_msg );
+			tutor_redirect_after_payment( OrderModel::ORDER_PLACEMENT_FAILED, $order_id, $error_msg );
 		}
 	}
 

--- a/includes/tutor-general-functions.php
+++ b/includes/tutor-general-functions.php
@@ -1662,3 +1662,34 @@ if ( ! function_exists( 'tutor_is_dev_mode' ) ) {
 		return defined( 'TUTOR_DEV_MODE' ) && TUTOR_DEV_MODE;
 	}
 }
+
+if ( ! function_exists( 'tutor_redirect_after_payment' ) ) {
+	/**
+	 * Redirect after payment with status and message
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $status Success or error status of payment.
+	 * @param int    $order_id Order ID.
+	 * @param string $message Success/error message to display.
+	 *
+	 * @return void
+	 */
+	function tutor_redirect_after_payment( $status, $order_id, $message = '' ) {
+		$query_params = array(
+			'tutor_order_placement' => $status,
+			'order_id'              => $order_id,
+		);
+
+		if ( $message ) {
+			if ( 'success' === $status ) {
+				$query_params['success_message'] = $message;
+			} else {
+				$query_params['error_message'] = $message;
+			}
+		}
+
+		wp_safe_redirect( add_query_arg( $query_params, home_url() ) );
+		exit();
+	}
+}

--- a/models/OrderModel.php
+++ b/models/OrderModel.php
@@ -77,6 +77,20 @@ class OrderModel {
 	const TRANSIENT_ORDER_BADGE_COUNT = 'tutor_order_badge_count';
 
 	/**
+	 * Order placement success
+	 *
+	 * @since 3.0.0
+	 */
+	const ORDER_PLACEMENT_SUCCESS = 'success';
+
+	/**
+	 * Order placement failed
+	 *
+	 * @since 3.0.0
+	 */
+	const ORDER_PLACEMENT_FAILED = 'failed';
+
+	/**
 	 * Order table name
 	 *
 	 * @since 3.0.0

--- a/templates/dashboard/purchase_history.php
+++ b/templates/dashboard/purchase_history.php
@@ -99,7 +99,7 @@ if ( Ecommerce::MONETIZE_BY === $monetize_by ) {
 		<div class="tutor-table-responsive">
 			<table class="tutor-table">
 				<thead>
-					<th width="10%">
+					<th width="8%">
 						<?php esc_html_e( 'Order ID', 'tutor' ); ?>
 					</th>
 					<th width="30%">
@@ -111,15 +111,17 @@ if ( Ecommerce::MONETIZE_BY === $monetize_by ) {
 					<th>
 						<?php esc_html_e( 'Price', 'tutor' ); ?>
 					</th>
-					<?php if ( Ecommerce::MONETIZE_BY === $monetize_by ) : ?>
-					<th>
-						<?php esc_html_e( 'Method', 'tutor' ); ?>
-					</th>
-					<?php endif; ?>
 					<th>
 						<?php esc_html_e( 'Status', 'tutor' ); ?>
 					</th>
+					<?php if ( Ecommerce::MONETIZE_BY === $monetize_by ) : ?>
+					<th>
+						<?php esc_html_e( 'Payment Method', 'tutor' ); ?>
+					</th>
 					<th></th>
+					<?php endif; ?>
+					<th></th>
+					
 				</thead>
 				<?php if ( Ecommerce::MONETIZE_BY === $monetize_by ) : ?>
 					<tbody>
@@ -163,25 +165,25 @@ if ( Ecommerce::MONETIZE_BY === $monetize_by ) {
 										<?php echo esc_html( tutor_get_formatted_price( $order->total_price ) ); ?>
 									</div>
 								</td>
-								<?php if ( Ecommerce::MONETIZE_BY === $monetize_by ) : ?>
+								<td>
+								<?php
+									echo wp_kses_post( tutor_utils()->translate_dynamic_text( $order->order_status, true ) );
+								?>
+								</td>
 								<td>
 									<div class="tutor-fs-7">
 										<?php echo esc_html( ucwords( $order->payment_method ?? '' ) ); ?>
 									</div>
 								</td>
-								<?php endif; ?>
 								<td>
 								<form method="get">
-									<?php
-									echo wp_kses_post( tutor_utils()->translate_dynamic_text( $order->order_status, true ) );
-									?>
 									<input type="hidden" name="tutor_action" value="tutor_pay_incomplete_order">
 									<input type="hidden" name="order_id" value="<?php echo esc_attr( $order->id ); ?>">
 									<?php
 									if ( $order->payment_method && 'manual' !== $order->payment_method && OrderModel::ORDER_INCOMPLETE === $order->order_status ) :
 										?>
-									<button type="submit" class="tutor-btn tutor-btn-outline-primary">
-										<?php esc_html_e( 'Pay now', 'tutor' ); ?>
+									<button type="submit" class="tutor-btn tutor-btn-sm tutor-btn-outline-primary">
+										<?php esc_html_e( 'Pay', 'tutor' ); ?>
 									</button>
 									<?php endif; ?>
 								</form>

--- a/templates/dashboard/purchase_history.php
+++ b/templates/dashboard/purchase_history.php
@@ -171,7 +171,20 @@ if ( Ecommerce::MONETIZE_BY === $monetize_by ) {
 								</td>
 								<?php endif; ?>
 								<td>
-								<?php echo wp_kses_post( tutor_utils()->translate_dynamic_text( $order->order_status, true ) ); ?>
+								<form method="get">
+									<?php
+									echo wp_kses_post( tutor_utils()->translate_dynamic_text( $order->order_status, true ) );
+									?>
+									<input type="hidden" name="tutor_action" value="tutor_pay_incomplete_order">
+									<input type="hidden" name="order_id" value="<?php echo esc_attr( $order->id ); ?>">
+									<?php
+									if ( $order->payment_method && 'manual' !== $order->payment_method && OrderModel::ORDER_INCOMPLETE === $order->order_status ) :
+										?>
+									<button type="submit" class="tutor-btn tutor-btn-outline-primary">
+										<?php esc_html_e( 'Pay now', 'tutor' ); ?>
+									</button>
+									<?php endif; ?>
+								</form>
 								</td>
 								<td>
 								</td>
@@ -282,21 +295,21 @@ if ( Ecommerce::MONETIZE_BY === $monetize_by ) {
 			</table>
 		</div>
 
-		<?php
-			$pagination_data = array(
-				'total_items' => $total_orders,
-				'per_page'    => $per_page,
-				'paged'       => $paged,
-			);
+					<?php
+					$pagination_data = array(
+						'total_items' => $total_orders,
+						'per_page'    => $per_page,
+						'paged'       => $paged,
+					);
 
-			$total_page = ceil( $pagination_data['total_items'] / $pagination_data['per_page'] );
+					$total_page = ceil( $pagination_data['total_items'] / $pagination_data['per_page'] );
 
-			if ( $total_page > 1 ) {
-				$pagination_template = tutor()->path . 'templates/dashboard/elements/pagination.php';
-				tutor_load_template_from_custom_path( $pagination_template, $pagination_data );
-			}
-			?>
-	<?php else : ?>
-		<?php tutor_utils()->tutor_empty_state( tutor_utils()->not_found_text() ); ?>
+					if ( $total_page > 1 ) {
+						$pagination_template = tutor()->path . 'templates/dashboard/elements/pagination.php';
+						tutor_load_template_from_custom_path( $pagination_template, $pagination_data );
+					}
+					?>
+					<?php else : ?>
+						<?php tutor_utils()->tutor_empty_state( tutor_utils()->not_found_text() ); ?>
 	<?php endif; ?>
 </div>

--- a/templates/dashboard/purchase_history.php
+++ b/templates/dashboard/purchase_history.php
@@ -176,7 +176,8 @@ if ( Ecommerce::MONETIZE_BY === $monetize_by ) {
 									</div>
 								</td>
 								<td>
-								<form method="get">
+								<form method="post">
+									<?php tutor_nonce_field(); ?>
 									<input type="hidden" name="tutor_action" value="tutor_pay_incomplete_order">
 									<input type="hidden" name="order_id" value="<?php echo esc_attr( $order->id ); ?>">
 									<?php

--- a/templates/ecommerce/order-placement-failed.php
+++ b/templates/ecommerce/order-placement-failed.php
@@ -16,7 +16,8 @@ tutor_utils()->tutor_custom_header();
 $order_status;
 $order_id;
 $error_msg = Input::get( 'error_message' );
-?>
+$back_url  = wp_get_referer() ? wp_get_referer() : CheckoutController::get_page_url();?>
+
 <div class="tutor-container tutor-order-status-wrapper">
 	<div class="tutor-d-flex tutor-flex-column tutor-align-center tutor-gap-2 tutor-px-20 tutor-py-80 tutor-text-center">
 		<div class="tutor-order-status-icon">
@@ -33,7 +34,7 @@ $error_msg = Input::get( 'error_message' );
 		</div>
 
 		<div class="tutor-order-status-actions">
-			<a href="<?php echo esc_url( CheckoutController::get_page_url() ); ?>" class="tutor-btn tutor-btn-primary">
+			<a href="<?php echo esc_url( $back_url ); ?>" class="tutor-btn tutor-btn-primary">
 				<?php esc_html_e( 'Back to Checkout', 'tutor' ); ?>
 			</a>
 		</div>


### PR DESCRIPTION
The pay button will appear only if a user tries to make a payment and fails. Not applicable for the Manual Enrollment.

1. Now students will be able to make the payment for failed order
2. `tutor_redirect_after_payment` new function added
3. The purchase history table updated
4. **Back to checkout**  URL set using `wp_get_referer ` 