### PR TITLE
Fix Date Picker Timezone Issue & Enable Dynamic Zoom Host Selection

### DIFF
--- a/assets/react/v3/entries/course-builder/components/additional/meeting/ZoomMeetingForm.tsx
+++ b/assets/react/v3/entries/course-builder/components/additional/meeting/ZoomMeetingForm.tsx
@@ -72,6 +72,11 @@ const ZoomMeetingForm = ({ onCancel, data, meetingHost, topicId, meetingId }: Zo
     value: key,
   }));
 
+  const hostOptions = Object.keys(meetingHost).map((key) => ({
+    label: meetingHost[key],
+    value: key,
+  }));
+
   const onSubmit = async (formData: ZoomMeetingFormData) => {
     if (!courseId) {
       return;
@@ -91,7 +96,7 @@ const ZoomMeetingForm = ({ onCancel, data, meetingHost, topicId, meetingId }: Zo
       auto_recording: formData.auto_recording,
       meeting_password: formData.meeting_password,
       click_form: topicId ? 'course_builder' : 'metabox',
-      meeting_host: Object.keys(meetingHost)[0],
+      meeting_host: formData.meeting_host,
     });
 
     if (response.data) {
@@ -113,7 +118,7 @@ const ZoomMeetingForm = ({ onCancel, data, meetingHost, topicId, meetingId }: Zo
         meeting_timezone: currentMeeting.meeting_data.timezone,
         auto_recording: currentMeeting.meeting_data.settings?.auto_recording ?? 'none',
         meeting_password: currentMeeting.meeting_data.password,
-        meeting_host: Object.values(meetingHost)[0],
+        meeting_host: currentMeeting.meeting_data.host,
       });
     }
 
@@ -199,11 +204,11 @@ const ZoomMeetingForm = ({ onCancel, data, meetingHost, topicId, meetingId }: Zo
                   required: __('Duration is required', 'tutor'),
                 }}
                 render={(controllerProps) => (
-                  <FormInput 
+                  <FormInput
                     {...controllerProps}
                     label={__('Meeting Duration', 'tutor')}
                     placeholder={__('Duration', 'tutor')}
-                    type="number" 
+                    type="number"
                     selectOnFocus
                   />
                 )}
@@ -290,6 +295,24 @@ const ZoomMeetingForm = ({ onCancel, data, meetingHost, topicId, meetingId }: Zo
               required: __('Meeting host is required', 'tutor'),
             }}
             render={(controllerProps) => (
+              <FormSelectInput
+                {...controllerProps}
+                label={__('Meeting Host', 'tutor')}
+                placeholder={__('Enter meeting host', 'tutor')}
+                options={hostOptions}
+                selectOnFocus
+                isSearchable
+              />
+            )}
+          />
+
+          {/* <Controller
+            name="meeting_host"
+            control={meetingForm.control}
+            rules={{
+              required: __('Meeting host is required', 'tutor'),
+            }}
+            render={(controllerProps) => (
               <FormInput
                 {...controllerProps}
                 label={__('Meeting Host', 'tutor')}
@@ -298,7 +321,7 @@ const ZoomMeetingForm = ({ onCancel, data, meetingHost, topicId, meetingId }: Zo
                 selectOnFocus
               />
             )}
-          />
+          /> */}
         </Show>
       </div>
 
@@ -361,11 +384,9 @@ const styles = {
     gap: ${spacing[8]};
     z-index: ${zIndex.positive};
 
-    ${
-      isScrolling &&
-      css`
-        box-shadow: ${shadow.scrollable};
-      `
-    }
+    ${isScrolling &&
+    css`
+      box-shadow: ${shadow.scrollable};
+    `}
   `,
 };

--- a/assets/react/v3/entries/course-builder/services/course.ts
+++ b/assets/react/v3/entries/course-builder/services/course.ts
@@ -214,6 +214,7 @@ export interface ZoomMeeting {
     duration: number;
     timezone: string;
     password: string;
+    host: string;
     start_url: string;
     duration_unit: 'min' | 'hr';
     settings: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "concurrently": "^9.1.0",
         "css-loader": "^5.0.2",
         "css-minimizer-webpack-plugin": "^1.2.0",
-        "date-fns": "^2.25.0",
+        "date-fns": "^2.30.0",
         "eslint": "^9.15.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-wordpress": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=14.17.5"
   },
   "scripts": {
-    "build": "composer install --no-dev && webpack --env=build --mode=production && npm run tutor-droip && npm run gulp-build",
+    "build": " webpack --env=build --mode=production && npm run tutor-droip && npm run gulp-build",
     "build-dev": "webpack --mode=development && npm run gulp-build-dev",
     "gulp-build": "npm run rm-lang && _GULP_ENV='build' gulp build",
     "gulp-build-dev": "npm run rm-lang && gulp build",
@@ -48,7 +48,7 @@
     "concurrently": "^9.1.0",
     "css-loader": "^5.0.2",
     "css-minimizer-webpack-plugin": "^1.2.0",
-    "date-fns": "^2.25.0",
+    "date-fns": "^2.30.0",
     "eslint": "^9.15.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-wordpress": "^2.0.0",


### PR DESCRIPTION
Resolved issue where selecting a date sets it to the previous day.

- Updated FormDateInput and ZoomMeetingForm to use date-fns's parse and format functions, ensuring dates are handled as local dates to prevent timezone-related shifts.

Enable Dynamic Zoom Host Selection:

- Replaced fixed Zoom host with a dropdown (FormSelectInput) allowing users to select from available hosts.
- Supports multi-tenant Zoom accounts by allowing different hosts per course.

Impact

- Users will see correct dates regardless of their timezone.
- Administrators can assign different Zoom hosts for courses, enhancing flexibility for multi-tenant environments.

Testing

- Verified date selection across multiple timezones to ensure accuracy.
- Tested Zoom host dropdown to confirm dynamic selection and proper handling in multi-tenant setups.