### PR TITLE
Refactor ModalWrapper and BasicModalWrapper to simplify structure

### DIFF
--- a/assets/react/v3/shared/components/modals/BasicModalWrapper.tsx
+++ b/assets/react/v3/shared/components/modals/BasicModalWrapper.tsx
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 
 import SVGIcon from '@TutorShared/atoms/SVGIcon';
 import ErrorBoundary from '@TutorShared/components/ErrorBoundary';
-import FocusTrap from '@TutorShared/components/FocusTrap';
 
 import { modal } from '@TutorShared/config/constants';
 import { Breakpoint, borderRadius, colorTokens, shadow, spacing } from '@TutorShared/config/styles';
@@ -48,56 +47,54 @@ const BasicModalWrapper = ({
   }, []);
 
   return (
-    <FocusTrap>
+    <div
+      css={[styles.container({ isFullScreen: fullScreen }), modalStyle]}
+      style={{
+        maxWidth: `${maxWidth}px`,
+      }}
+    >
       <div
-        css={[styles.container({ isFullScreen: fullScreen }), modalStyle]}
-        style={{
-          maxWidth: `${maxWidth}px`,
-        }}
+        css={styles.header({
+          hasEntireHeader: !!entireHeader,
+        })}
       >
+        <Show when={!entireHeader} fallback={entireHeader}>
+          <div css={styles.headerContent}>
+            <div css={styles.iconWithTitle}>
+              <Show when={icon}>{icon}</Show>
+              <Show when={title}>
+                <p css={styles.title}>{title}</p>
+              </Show>
+            </div>
+            <Show when={subtitle}>
+              <span css={styles.subtitle}>{subtitle}</span>
+            </Show>
+          </div>
+        </Show>
+
         <div
-          css={styles.header({
+          css={styles.actionsWrapper({
             hasEntireHeader: !!entireHeader,
           })}
         >
-          <Show when={!entireHeader} fallback={entireHeader}>
-            <div css={styles.headerContent}>
-              <div css={styles.iconWithTitle}>
-                <Show when={icon}>{icon}</Show>
-                <Show when={title}>
-                  <p css={styles.title}>{title}</p>
-                </Show>
-              </div>
-              <Show when={subtitle}>
-                <span css={styles.subtitle}>{subtitle}</span>
+          <Show
+            when={actions}
+            fallback={
+              <Show when={isCloseAble}>
+                <button type="button" css={styles.closeButton} onClick={onClose}>
+                  <SVGIcon name="timesThin" width={24} height={24} />
+                </button>
               </Show>
-            </div>
-          </Show>
-
-          <div
-            css={styles.actionsWrapper({
-              hasEntireHeader: !!entireHeader,
-            })}
+            }
           >
-            <Show
-              when={actions}
-              fallback={
-                <Show when={isCloseAble}>
-                  <button type="button" css={styles.closeButton} onClick={onClose}>
-                    <SVGIcon name="timesThin" width={24} height={24} />
-                  </button>
-                </Show>
-              }
-            >
-              {actions}
-            </Show>
-          </div>
-        </div>
-        <div css={styles.content({ isFullScreen: fullScreen })}>
-          <ErrorBoundary>{children}</ErrorBoundary>
+            {actions}
+          </Show>
         </div>
       </div>
-    </FocusTrap>
+      <div css={styles.content({ isFullScreen: fullScreen })}>
+        <ErrorBoundary>{children}</ErrorBoundary>
+      </div>
+    </div>
   );
 };
 

--- a/assets/react/v3/shared/components/modals/ModalWrapper.tsx
+++ b/assets/react/v3/shared/components/modals/ModalWrapper.tsx
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 
 import SVGIcon from '@TutorShared/atoms/SVGIcon';
 import ErrorBoundary from '@TutorShared/components/ErrorBoundary';
-import FocusTrap from '@TutorShared/components/FocusTrap';
 
 import { modal } from '@TutorShared/config/constants';
 import { Breakpoint, borderRadius, colorTokens, shadow, spacing, zIndex } from '@TutorShared/config/styles';
@@ -44,60 +43,58 @@ const ModalWrapper = ({
   }, []);
 
   return (
-    <FocusTrap>
+    <div
+      css={styles.container({
+        maxWidth,
+      })}
+    >
       <div
-        css={styles.container({
-          maxWidth,
+        css={styles.header({
+          hasHeaderChildren: !!headerChildren,
         })}
       >
-        <div
-          css={styles.header({
-            hasHeaderChildren: !!headerChildren,
-          })}
+        <Show
+          when={entireHeader}
+          fallback={
+            <>
+              <div css={styles.headerContent}>
+                <div css={styles.iconWithTitle}>
+                  <Show when={icon}>{icon}</Show>
+                  <Show when={title}>
+                    <h6 css={styles.title} title={typeof title === 'string' ? title : ''}>
+                      {title}
+                    </h6>
+                  </Show>
+                </div>
+                <Show when={subtitle}>
+                  <span css={styles.subtitle}>{subtitle}</span>
+                </Show>
+              </div>
+              <div css={styles.headerChildren}>
+                <Show when={headerChildren}>{headerChildren}</Show>
+              </div>
+              <div css={styles.actionsWrapper}>
+                <Show
+                  when={actions}
+                  fallback={
+                    <button type="button" css={styles.closeButton} onClick={onClose}>
+                      <SVGIcon name="times" width={14} height={14} />
+                    </button>
+                  }
+                >
+                  {actions}
+                </Show>
+              </div>
+            </>
+          }
         >
-          <Show
-            when={entireHeader}
-            fallback={
-              <>
-                <div css={styles.headerContent}>
-                  <div css={styles.iconWithTitle}>
-                    <Show when={icon}>{icon}</Show>
-                    <Show when={title}>
-                      <h6 css={styles.title} title={typeof title === 'string' ? title : ''}>
-                        {title}
-                      </h6>
-                    </Show>
-                  </div>
-                  <Show when={subtitle}>
-                    <span css={styles.subtitle}>{subtitle}</span>
-                  </Show>
-                </div>
-                <div css={styles.headerChildren}>
-                  <Show when={headerChildren}>{headerChildren}</Show>
-                </div>
-                <div css={styles.actionsWrapper}>
-                  <Show
-                    when={actions}
-                    fallback={
-                      <button type="button" css={styles.closeButton} onClick={onClose}>
-                        <SVGIcon name="times" width={14} height={14} />
-                      </button>
-                    }
-                  >
-                    {actions}
-                  </Show>
-                </div>
-              </>
-            }
-          >
-            {entireHeader}
-          </Show>
-        </div>
-        <div css={styles.content}>
-          <ErrorBoundary>{children}</ErrorBoundary>
-        </div>
+          {entireHeader}
+        </Show>
       </div>
-    </FocusTrap>
+      <div css={styles.content}>
+        <ErrorBoundary>{children}</ErrorBoundary>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
Remove the FocusTrap component from both wrappers and streamline the header rendering for improved clarity and maintainability.