### PR TITLE
🛠️ Refactor: Remove selectOnFocus from form inputs

### DIFF
--- a/assets/react/v3/entries/course-builder/components/additional/meeting/GoogleMeetForm.tsx
+++ b/assets/react/v3/entries/course-builder/components/additional/meeting/GoogleMeetForm.tsx
@@ -154,7 +154,6 @@ const GoogleMeetForm = ({ onCancel, data, topicId, meetingId }: GoogleMeetFormPr
                 {...controllerProps}
                 label={__('Meeting Name', 'tutor')}
                 placeholder={__('Enter meeting name', 'tutor')}
-                selectOnFocus
               />
             )}
           />

--- a/assets/react/v3/entries/course-builder/components/additional/meeting/ZoomMeetingForm.tsx
+++ b/assets/react/v3/entries/course-builder/components/additional/meeting/ZoomMeetingForm.tsx
@@ -141,7 +141,6 @@ const ZoomMeetingForm = ({ onCancel, data, meetingHost, topicId, meetingId }: Zo
                 {...controllerProps}
                 label={__('Meeting Name', 'tutor')}
                 placeholder={__('Enter meeting name', 'tutor')}
-                selectOnFocus
               />
             )}
           />
@@ -278,7 +277,6 @@ const ZoomMeetingForm = ({ onCancel, data, meetingHost, topicId, meetingId }: Zo
                 placeholder={__('Enter meeting password', 'tutor')}
                 type="password"
                 isPassword
-                selectOnFocus
               />
             )}
           />
@@ -295,7 +293,6 @@ const ZoomMeetingForm = ({ onCancel, data, meetingHost, topicId, meetingId }: Zo
                 label={__('Meeting Host', 'tutor')}
                 placeholder={__('Enter meeting host', 'tutor')}
                 disabled
-                selectOnFocus
               />
             )}
           />

--- a/assets/react/v3/entries/course-builder/components/course-basic/CourseBasicSidebar.tsx
+++ b/assets/react/v3/entries/course-builder/components/course-basic/CourseBasicSidebar.tsx
@@ -141,7 +141,6 @@ const CourseBasicSidebar = () => {
               placeholder={__('Enter password', 'tutor')}
               type="password"
               isPassword
-              selectOnFocus
               loading={!!isCourseDetailsFetching && !controllerProps.field.value}
             />
           )}

--- a/assets/react/v3/entries/course-builder/components/curriculum/QuestionConditions.tsx
+++ b/assets/react/v3/entries/course-builder/components/curriculum/QuestionConditions.tsx
@@ -17,7 +17,7 @@ import SVGIcon from '@TutorShared/atoms/SVGIcon';
 import { colorTokens, spacing } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
 import Show from '@TutorShared/controls/Show';
-import { IconCollection } from '@TutorShared/icons/types';
+import { type IconCollection } from '@TutorShared/icons/types';
 import { styleUtils } from '@TutorShared/utils/style-utils';
 
 const questionTypes = {
@@ -218,7 +218,6 @@ const QuestionConditions = () => {
                 type="number"
                 isInlineLabel
                 placeholder="0"
-                selectOnFocus
                 style={css`
                   max-width: 80px;
                 `}

--- a/assets/react/v3/entries/course-builder/components/curriculum/TopicHeader.tsx
+++ b/assets/react/v3/entries/course-builder/components/curriculum/TopicHeader.tsx
@@ -164,12 +164,7 @@ const TopicHeader = ({
                   name="title"
                   rules={{ required: __('Title is required', 'tutor') }}
                   render={(controllerProps) => (
-                    <FormInput
-                      {...controllerProps}
-                      placeholder={__('Add a title', 'tutor')}
-                      isSecondary
-                      selectOnFocus
-                    />
+                    <FormInput {...controllerProps} placeholder={__('Add a title', 'tutor')} isSecondary />
                   )}
                 />
               </div>

--- a/assets/react/v3/entries/course-builder/components/modals/AssignmentModal.tsx
+++ b/assets/react/v3/entries/course-builder/components/modals/AssignmentModal.tsx
@@ -243,7 +243,6 @@ const AssignmentModal = ({
                     placeholder={__('Enter Assignment Title', 'tutor')}
                     generateWithAi={!isTutorPro || isOpenAiEnabled}
                     isClearable
-                    selectOnFocus
                   />
                 )}
               />

--- a/assets/react/v3/entries/course-builder/components/modals/LessonModal.tsx
+++ b/assets/react/v3/entries/course-builder/components/modals/LessonModal.tsx
@@ -271,7 +271,6 @@ const LessonModal = ({
                     label={__('Name', 'tutor')}
                     placeholder={__('Enter Lesson Name', 'tutor')}
                     generateWithAi={!isTutorPro || isOpenAiEnabled}
-                    selectOnFocus
                     isClearable
                   />
                 )}

--- a/assets/react/v3/entries/course-builder/components/modals/QuizModal.tsx
+++ b/assets/react/v3/entries/course-builder/components/modals/QuizModal.tsx
@@ -310,11 +310,7 @@ const QuizModal = ({
                               name="quiz_title"
                               rules={{ required: __('Quiz title is required', 'tutor') }}
                               render={(controllerProps) => (
-                                <FormInput
-                                  {...controllerProps}
-                                  placeholder={__('Add quiz title', 'tutor')}
-                                  selectOnFocus
-                                />
+                                <FormInput {...controllerProps} placeholder={__('Add quiz title', 'tutor')} />
                               )}
                             />
                             <Controller

--- a/assets/react/v3/entries/course-builder/pages/CourseBasic.tsx
+++ b/assets/react/v3/entries/course-builder/pages/CourseBasic.tsx
@@ -68,7 +68,6 @@ const CourseBasic = () => {
                   label={__('Title', 'tutor')}
                   placeholder={__('ex. Learn Photoshop CS6 from scratch', 'tutor')}
                   isClearable
-                  selectOnFocus
                   generateWithAi={!isTutorPro || isOpenAiEnabled}
                   loading={!!isCourseDetailsFetching && !controllerProps.field.value}
                   onChange={(value) => {

--- a/assets/react/v3/shared/components/subscription/OfferSalePrice.tsx
+++ b/assets/react/v3/shared/components/subscription/OfferSalePrice.tsx
@@ -122,7 +122,7 @@ export function OfferSalePrice({ index }: { index: number }) {
                         return undefined;
                       },
                     },
-                    deps: ['sale_price_from_date'],
+                    deps: [`subscriptions.${index}.sale_price_from_date`],
                   }}
                   render={(controllerProps) => (
                     <FormDateInput
@@ -153,7 +153,11 @@ export function OfferSalePrice({ index }: { index: number }) {
                         return undefined;
                       },
                     },
-                    deps: ['sale_price_from_date', 'sale_price_from_time', 'sale_price_to_date'],
+                    deps: [
+                      `subscriptions.${index}.sale_price_from_date`,
+                      `subscriptions.${index}.sale_price_from_time`,
+                      `subscriptions.${index}.sale_price_to_date`,
+                    ],
                   }}
                   render={(controllerProps) => (
                     <FormTimeInput {...controllerProps} interval={60} isClearable={false} placeholder="hh:mm A" />

--- a/assets/react/v3/shared/services/subscription.ts
+++ b/assets/react/v3/shared/services/subscription.ts
@@ -22,7 +22,7 @@ export type Subscription = {
   assign_id: string; // course_id, category_id, or 0 for full site
   plan_name: string;
   recurring_value: string;
-  recurring_interval: Omit<DurationUnit, 'hour'>;
+  recurring_interval: Exclude<DurationUnit, 'hour'>;
   is_featured: '0' | '1';
   regular_price: string;
   sale_price: string;
@@ -145,7 +145,7 @@ export type SubscriptionPayload = {
   assign_id: string; // course_id, category_id, or 0 for full site
   plan_name: string;
   recurring_value?: string;
-  recurring_interval?: Omit<DurationUnit, 'hour'>;
+  recurring_interval?: Exclude<DurationUnit, 'hour'>;
   regular_price: string;
   sale_price?: string;
   sale_price_from?: string; // start date


### PR DESCRIPTION
Eliminate the `selectOnFocus` property from various form inputs to streamline the user experience and improve form behavior.