### PR TITLE
🔧 Rename course_id to object_id in subscription service methods

### DIFF
--- a/assets/react/v3/shared/services/subscription.ts
+++ b/assets/react/v3/shared/services/subscription.ts
@@ -206,7 +206,7 @@ export const useSaveCourseSubscriptionMutation = (objectId: number) => {
 const deleteCourseSubscription = (objectId: number, subscriptionId: number) => {
   return wpAjaxInstance.post<
     {
-      course_id: number;
+      object_id: number;
       id: number;
     },
     TutorMutationResponse<ID>
@@ -244,12 +244,12 @@ export const useDeleteCourseSubscriptionMutation = (objectId: number) => {
 const duplicateCourseSubscription = (objectId: number, subscriptionId: number) => {
   return wpAjaxInstance.post<
     {
-      course_id: number;
+      object_id: number;
       id: number;
     },
     TutorMutationResponse<ID>
   >(endpoints.DUPLICATE_SUBSCRIPTION, {
-    course_id: objectId,
+    object_id: objectId,
     id: subscriptionId,
   });
 };
@@ -278,15 +278,15 @@ export const useDuplicateCourseSubscriptionMutation = (objectId: number) => {
   });
 };
 
-const sortCourseSubscriptions = (courseId: number, subscriptionIds: number[]) => {
+const sortCourseSubscriptions = (objectId: number, subscriptionIds: number[]) => {
   return wpAjaxInstance.post<
     {
-      course_id: number;
+      object_id: number;
       plan_ids: number[];
     },
     TutorMutationResponse<ID>
   >(endpoints.SORT_SUBSCRIPTION, {
-    course_id: courseId,
+    object_id: objectId,
     plan_ids: subscriptionIds,
   });
 };


### PR DESCRIPTION
Update subscription service methods to use object_id instead of course_id for improved clarity and consistency.