### PR TITLE
🔧 Fix string comparison for IDs in modals and refactor edit mode condition

### DIFF
--- a/assets/react/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
+++ b/assets/react/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
@@ -256,7 +256,7 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
                       topics.reduce((topics, topic) => {
                         topics.push({
                           ...topic,
-                          contents: topic.contents.filter((content) => content.ID !== quizId),
+                          contents: topic.contents.filter((content) => String(content.ID) !== String(quizId)),
                         });
 
                         return topics;

--- a/assets/react/v3/entries/course-builder/components/fields/quiz/FormFillinTheBlanks.tsx
+++ b/assets/react/v3/entries/course-builder/components/fields/quiz/FormFillinTheBlanks.tsx
@@ -6,12 +6,12 @@ import Button from '@TutorShared/atoms/Button';
 import SVGIcon from '@TutorShared/atoms/SVGIcon';
 import Tooltip from '@TutorShared/atoms/Tooltip';
 
+import { useQuizModalContext } from '@CourseBuilderContexts/QuizModalContext';
+import { QuizDataStatus, type QuizQuestionOption, calculateQuizDataStatus } from '@CourseBuilderServices/quiz';
 import { borderRadius, colorTokens, spacing } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
 import For from '@TutorShared/controls/For';
 import Show from '@TutorShared/controls/Show';
-import { useQuizModalContext } from '@CourseBuilderContexts/QuizModalContext';
-import { QuizDataStatus, type QuizQuestionOption, calculateQuizDataStatus } from '@CourseBuilderServices/quiz';
 import type { FormControllerProps } from '@TutorShared/utils/form';
 import { styleUtils } from '@TutorShared/utils/style-utils';
 import { isDefined } from '@TutorShared/utils/types';
@@ -81,7 +81,7 @@ const FormFillInTheBlanks = ({ field }: FormFillInTheBlanksProps) => {
         </div>
         <div css={styles.optionBody}>
           <Show
-            when={isEditing}
+            when={!inputValue.is_saved || isEditing}
             fallback={
               <div css={styles.placeholderWrapper}>
                 <div css={styles.optionPlaceholder({ isTitle: !!inputValue.answer_title })}>

--- a/assets/react/v3/entries/course-builder/components/modals/AssignmentModal.tsx
+++ b/assets/react/v3/entries/course-builder/components/modals/AssignmentModal.tsx
@@ -340,10 +340,10 @@ const AssignmentModal = ({
                       placeholder={__('Select Prerequisite', 'tutor')}
                       options={
                         topics.reduce((topics, topic) => {
-                          if (topic.id === topicId) {
+                          if (String(topic.id) === String(topicId)) {
                             topics.push({
                               ...topic,
-                              contents: topic.contents.filter((content) => content.ID !== assignmentId),
+                              contents: topic.contents.filter((content) => String(content.ID) !== String(assignmentId)),
                             });
                           } else {
                             topics.push(topic);

--- a/assets/react/v3/entries/course-builder/components/modals/LessonModal.tsx
+++ b/assets/react/v3/entries/course-builder/components/modals/LessonModal.tsx
@@ -492,10 +492,10 @@ const LessonModal = ({
                       placeholder={__('Select Prerequisite', 'tutor')}
                       options={
                         topics.reduce((topics, topic) => {
-                          if (topic.id === topicId) {
+                          if (String(topic.id) === String(topicId)) {
                             topics.push({
                               ...topic,
-                              contents: topic.contents.filter((content) => content.ID !== lessonId),
+                              contents: topic.contents.filter((content) => String(content.ID) !== String(lessonId)),
                             });
                           } else {
                             topics.push(topic);


### PR DESCRIPTION
Ensure consistent string comparison for IDs in `QuizSettings`, `AssignmentModal`, and `LessonModal`. Update the condition for `edit mode` in `FormFillInTheBlanks` to improve functionality.