### PR TITLE
🛠️ Rename excludedIds to exclude in course list parameters

### DIFF
--- a/assets/react/v3/entries/course-builder/pages/Additional.tsx
+++ b/assets/react/v3/entries/course-builder/pages/Additional.tsx
@@ -66,7 +66,7 @@ const Additional = () => {
 
   const prerequisiteCoursesQuery = useCourseListQuery({
     params: {
-      excludedIds: [String(courseId), ...prerequisiteCourseIds],
+      exclude: [String(courseId), ...prerequisiteCourseIds],
       limit: -1,
     },
     isEnabled: !!isPrerequisiteAddonEnabled && !isCourseDetailsFetching,

--- a/assets/react/v3/shared/services/course.ts
+++ b/assets/react/v3/shared/services/course.ts
@@ -13,7 +13,7 @@ export interface Course {
 }
 
 interface CourseListParams extends PaginatedParams {
-  excludedIds: string[];
+  exclude: string[];
 }
 
 const getCourseList = (params: CourseListParams) => {
@@ -27,7 +27,7 @@ export const useCourseListQuery = ({ params, isEnabled }: { params: CourseListPa
     queryKey: ['PrerequisiteCourses', params],
     queryFn: () =>
       getCourseList({
-        excludedIds: params.excludedIds,
+        exclude: params.exclude,
         limit: params.limit,
         offset: params.offset,
         filter: params.filter,


### PR DESCRIPTION
Update the course list parameters to use 'exclude' instead of 'excludedIds' for clarity and consistency.