### PR TITLE
🛠️ Refactor supportRandomize question types by removing 'ordering'

### DIFF
--- a/assets/react/v3/entries/course-builder/components/curriculum/QuestionConditions.tsx
+++ b/assets/react/v3/entries/course-builder/components/curriculum/QuestionConditions.tsx
@@ -61,7 +61,7 @@ const questionTypes = {
 
 type QuestionTypes = Omit<QuizQuestionType, 'single_choice' | 'image_matching'>;
 
-const supportRandomize: QuestionTypes[] = ['multiple_choice', 'matching', 'image_answering', 'ordering'];
+const supportRandomize: QuestionTypes[] = ['multiple_choice', 'matching', 'image_answering'];
 
 const QuestionConditions = () => {
   const { activeQuestionIndex, activeQuestionId, validationError, setValidationError } = useQuizModalContext();

--- a/templates/single/quiz/parts/question.php
+++ b/templates/single/quiz/parts/question.php
@@ -94,6 +94,8 @@
 						$question_settings = maybe_unserialize( $question->question_settings );
 						if ( isset( $question_settings['randomize_question'] ) && '1' === $question_settings['randomize_question'] ) {
 							$rand_choice = true;
+						} else if ( 'ordering' === $question_type ) {
+							$rand_choice = true;
 						}
 					}
 

--- a/templates/single/quiz/parts/question.php
+++ b/templates/single/quiz/parts/question.php
@@ -90,13 +90,13 @@
 					$question_type = $question->question_type;
 
 					$rand_choice = false;
-					if ( 'matching' !== $question_type && 'image_matching' !== $question_type ) { // Note: Randomize will be done in specific template.
-						$question_settings = maybe_unserialize( $question->question_settings );
-						if ( isset( $question_settings['randomize_question'] ) && '1' === $question_settings['randomize_question'] ) {
-							$rand_choice = true;
-						} else if ( 'ordering' === $question_type ) {
-							$rand_choice = true;
-						}
+					if ( ! in_array( $question_type, array( 'matching', 'image_matching' ), true ) ) {
+							if ( 'ordering' === $question_type ) {
+									$rand_choice = true;
+							} else {
+									$question_settings = maybe_unserialize( $question->question_settings );
+									$rand_choice       = ( isset( $question_settings['randomize_question'] ) && '1' === $question_settings['randomize_question'] );
+							}
 					}
 
 					$answers            = \Tutor\Models\QuizModel::get_answers_by_quiz_question( $question->question_id, $rand_choice );

--- a/templates/single/quiz/parts/question.php
+++ b/templates/single/quiz/parts/question.php
@@ -90,7 +90,7 @@
 					$question_type = $question->question_type;
 
 					$rand_choice = false;
-					if ( ! in_array( $question_type, array( 'matching', 'image_matching' ), true ) ) {
+					if ( 'matching' !== $question_type && 'image_matching' !== $question_type ) { // Note: Randomize will be done in specific template.
 						if ( 'ordering' === $question_type ) {
 							$rand_choice = true;
 						} else {

--- a/templates/single/quiz/parts/question.php
+++ b/templates/single/quiz/parts/question.php
@@ -91,12 +91,12 @@
 
 					$rand_choice = false;
 					if ( ! in_array( $question_type, array( 'matching', 'image_matching' ), true ) ) {
-							if ( 'ordering' === $question_type ) {
-									$rand_choice = true;
-							} else {
-									$question_settings = maybe_unserialize( $question->question_settings );
-									$rand_choice       = ( isset( $question_settings['randomize_question'] ) && '1' === $question_settings['randomize_question'] );
-							}
+						if ( 'ordering' === $question_type ) {
+							$rand_choice = true;
+						} else {
+							$question_settings = maybe_unserialize( $question->question_settings );
+							$rand_choice       = ( isset( $question_settings['randomize_question'] ) && '1' === $question_settings['randomize_question'] );
+						}
 					}
 
 					$answers            = \Tutor\Models\QuizModel::get_answers_by_quiz_question( $question->question_id, $rand_choice );


### PR DESCRIPTION
Eliminate 'ordering' from the supportRandomize question types to streamline the available options.