### PR TITLE
🛠️ Prevent `coupon_type` from changing and validation added for specific_courses/bundles/categories type coupon

### DIFF
--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -174,6 +174,7 @@ class CouponController extends BaseController {
 				HttpHelper::STATUS_UNPROCESSABLE_ENTITY
 			);
 		}
+		
 		$this->validate_applies_to_item( $data );
 
 		if ( $this->model->get_coupon( array( 'coupon_code' => $data['coupon_code'] ) ) ) {
@@ -246,6 +247,7 @@ class CouponController extends BaseController {
 				HttpHelper::STATUS_UNPROCESSABLE_ENTITY
 			);
 		}
+
 		$this->validate_applies_to_item( $data );
 
 		unset( $data['coupon_id'] );

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -273,7 +273,6 @@ class CouponController extends BaseController {
 		$data['updated_by'] = get_current_user_id();
 
 		try {
-
 			$update = $this->model->update_coupon( $coupon_id, $data );
 			if ( $update ) {
 				$coupon_data = $this->model->get_coupon( array( 'id' => $coupon_id ) );

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -235,20 +235,21 @@ class CouponController extends BaseController {
 		$data['updated_by'] = get_current_user_id();
 
 		try {
+			$is_specific_applies_to = $this->model->is_specific_applies_to( $data['applies_to'] );
+			$has_applies_to_items   = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
+
+			if ( $is_specific_applies_to && ! $has_applies_to_items ) {
+				$this->json_response(
+					__( 'Add items first', 'tutor' ),
+					null,
+					HttpHelper::STATUS_UNPROCESSABLE_ENTITY
+				);
+			}
+
 			$update = $this->model->update_coupon( $coupon_id, $data );
 			if ( $update ) {
-				$coupon_data            = $this->model->get_coupon( array( 'id' => $coupon_id ) );
-				$is_specific_applies_to = $this->model->is_specific_applies_to( $data['applies_to'] );
-				$has_applies_to_items   = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
+				$coupon_data = $this->model->get_coupon( array( 'id' => $coupon_id ) );
 				$this->model->delete_applies_to( $coupon_data->coupon_code );
-
-				if ( $is_specific_applies_to && ! $has_applies_to_items ) {
-					$this->json_response(
-						__( 'Add items first', 'tutor' ),
-						null,
-						HttpHelper::STATUS_UNPROCESSABLE_ENTITY
-					);
-				}
 
 				if ( $has_applies_to_items ) {
 					$this->model->insert_applies_to( $data['applies_to'], $data['applies_to_items'], $coupon_data->coupon_code );

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -152,7 +152,7 @@ class CouponController extends BaseController {
 	public function validate_applies_to_item( $data ) {
 		$is_specific_applies_to = $this->model->is_specific_applies_to( $data['applies_to'] );
 
-		if ( $is_specific_applies_to && ! $this->has_applies_to_items( $data['applies_to_items'] ) ) {
+		if ( $is_specific_applies_to && ! $this->has_applies_to_items( $data ) ) {
 			$this->json_response(
 				__( 'Add items first', 'tutor' ),
 				null,
@@ -279,7 +279,7 @@ class CouponController extends BaseController {
 				$coupon_data = $this->model->get_coupon( array( 'id' => $coupon_id ) );
 				$this->model->delete_applies_to( $coupon_data->coupon_code );
 
-				if ( $this->has_applies_to_items( $data['applies_to_items'] ) ) {
+				if ( $this->has_applies_to_items( $data ) ) {
 					$this->model->insert_applies_to( $data['applies_to'], $data['applies_to_items'], $coupon_data->coupon_code );
 				}
 

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -128,6 +128,19 @@ class CouponController extends BaseController {
 	}
 
 	/**
+	 * Check if applies to items exist and are valid
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param array $data The data array to check
+	 *
+	 * @return bool Whether applies to items exist and are valid
+	 */
+	private function has_applies_to_items( $data ) {
+		return isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
+	}
+
+	/**
 	 * Validate applies to item
 	 *
 	 * @since 3.5.0
@@ -138,9 +151,8 @@ class CouponController extends BaseController {
 	 */
 	public function validate_applies_to_item( $data ) {
 		$is_specific_applies_to = $this->model->is_specific_applies_to( $data['applies_to'] );
-		$has_applies_to_items   = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
 
-		if ( $is_specific_applies_to && ! $has_applies_to_items ) {
+		if ( $is_specific_applies_to && ! $this->has_applies_to_items( $data['applies_to_items'] ) ) {
 			$this->json_response(
 				__( 'Add items first', 'tutor' ),
 				null,
@@ -261,14 +273,13 @@ class CouponController extends BaseController {
 		$data['updated_by'] = get_current_user_id();
 
 		try {
-			$has_applies_to_items   = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
 
 			$update = $this->model->update_coupon( $coupon_id, $data );
 			if ( $update ) {
 				$coupon_data = $this->model->get_coupon( array( 'id' => $coupon_id ) );
 				$this->model->delete_applies_to( $coupon_data->coupon_code );
 
-				if ( $has_applies_to_items ) {
+				if ( $this->has_applies_to_items( $data['applies_to_items'] ) ) {
 					$this->model->insert_applies_to( $data['applies_to'], $data['applies_to_items'], $coupon_data->coupon_code );
 				}
 

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -237,10 +237,19 @@ class CouponController extends BaseController {
 		try {
 			$update = $this->model->update_coupon( $coupon_id, $data );
 			if ( $update ) {
-				$coupon_data = $this->model->get_coupon( array( 'id' => $coupon_id ) );
-				$this->model->delete_applies_to( $coupon_data->coupon_code );
-				if ( isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] ) ) {
-					$this->model->insert_applies_to( $data['applies_to'], $data['applies_to_items'], $coupon_data->coupon_code );
+				$isSpecificAppliesTo = $this->model->is_specific_applies_to( $data['applies_to'] );
+				$hasAppliesToItems = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
+
+				if ( $isSpecificAppliesTo && ! $hasAppliesToItems) {
+					return $this->json_response(
+						__( 'Add items first', 'tutor' ),
+						null,
+						HttpHelper::STATUS_UNPROCESSABLE_ENTITY
+					);
+				}
+
+				if ( $hasAppliesToItems ) {
+					$this->model->insert_applies_to($data['applies_to'], $data['applies_to_items'], $coupon_data->coupon_code);
 				}
 
 				$this->json_response( __( 'Coupon updated successfully!', 'tutor' ) );

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -237,11 +237,10 @@ class CouponController extends BaseController {
 		try {
 			$update = $this->model->update_coupon( $coupon_id, $data );
 			if ( $update ) {
-				$coupon_data 						= $this->model->get_coupon( array( 'id' => $coupon_id ) );
+				$coupon_data            = $this->model->get_coupon( array( 'id' => $coupon_id ) );
 				$is_specific_applies_to = $this->model->is_specific_applies_to( $data['applies_to'] );
 				$has_applies_to_items   = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
 				$this->model->delete_applies_to( $coupon_data->coupon_code );
-				
 
 				if ( $is_specific_applies_to && ! $has_applies_to_items ) {
 					$this->json_response(

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -132,7 +132,7 @@ class CouponController extends BaseController {
 	 *
 	 * @since 3.5.0
 	 *
-	 * @param array $data The data array to check
+	 * @param array $data The data to validate.
 	 *
 	 * @return bool Whether applies to items exist and are valid
 	 */

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -128,6 +128,28 @@ class CouponController extends BaseController {
 	}
 
 	/**
+	 * Validate applies to item
+	 * 
+	 * @since 3.5.0
+	 * 
+	 * @param array $data The data to validate.
+	 * 
+	 * @return void send wp_json response when validation fails
+	 */
+	public function validate_applies_to_item( $data ) {
+		$is_specific_applies_to = $this->model->is_specific_applies_to( $data['applies_to'] );
+		$has_applies_to_items   = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
+
+		if ( $is_specific_applies_to && ! $has_applies_to_items ) {
+			$this->json_response(
+				__( 'Add items first', 'tutor' ),
+				null,
+				HttpHelper::STATUS_UNPROCESSABLE_ENTITY
+			);
+		}
+	}
+
+	/**
 	 * Handle ajax request for creating coupon
 	 *
 	 * @since 3.0.0
@@ -152,6 +174,7 @@ class CouponController extends BaseController {
 				HttpHelper::STATUS_UNPROCESSABLE_ENTITY
 			);
 		}
+		$this->validate_applies_to_item( $data );
 
 		if ( $this->model->get_coupon( array( 'coupon_code' => $data['coupon_code'] ) ) ) {
 			$this->json_response(
@@ -223,6 +246,7 @@ class CouponController extends BaseController {
 				HttpHelper::STATUS_UNPROCESSABLE_ENTITY
 			);
 		}
+		$this->validate_applies_to_item( $data );
 
 		unset( $data['coupon_id'] );
 		unset( $data['coupon_type'] );
@@ -235,16 +259,7 @@ class CouponController extends BaseController {
 		$data['updated_by'] = get_current_user_id();
 
 		try {
-			$is_specific_applies_to = $this->model->is_specific_applies_to( $data['applies_to'] );
 			$has_applies_to_items   = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
-
-			if ( $is_specific_applies_to && ! $has_applies_to_items ) {
-				$this->json_response(
-					__( 'Add items first', 'tutor' ),
-					null,
-					HttpHelper::STATUS_UNPROCESSABLE_ENTITY
-				);
-			}
 
 			$update = $this->model->update_coupon( $coupon_id, $data );
 			if ( $update ) {

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -237,11 +237,14 @@ class CouponController extends BaseController {
 		try {
 			$update = $this->model->update_coupon( $coupon_id, $data );
 			if ( $update ) {
+				$coupon_data 						= $this->model->get_coupon( array( 'id' => $coupon_id ) );
 				$is_specific_applies_to = $this->model->is_specific_applies_to( $data['applies_to'] );
 				$has_applies_to_items   = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
+				$this->model->delete_applies_to( $coupon_data->coupon_code );
+				
 
 				if ( $is_specific_applies_to && ! $has_applies_to_items ) {
-					return $this->json_response(
+					$this->json_response(
 						__( 'Add items first', 'tutor' ),
 						null,
 						HttpHelper::STATUS_UNPROCESSABLE_ENTITY
@@ -249,7 +252,7 @@ class CouponController extends BaseController {
 				}
 
 				if ( $has_applies_to_items ) {
-					$this->model->insert_applies_to( $data['applies_to'], $data['applies_to_items'], $data['coupon_id'] ); // Updated to use $data['coupon_id']
+					$this->model->insert_applies_to( $data['applies_to'], $data['applies_to_items'], $coupon_data->coupon_code );
 				}
 
 				$this->json_response( __( 'Coupon updated successfully!', 'tutor' ) );

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -225,6 +225,7 @@ class CouponController extends BaseController {
 		}
 
 		unset( $data['coupon_id'] );
+		unset( $data['coupon_type']);
 
 		if ( ! isset( $data['expire_date_gmt'] ) ) {
 			$data['expire_date_gmt'] = null;

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -129,11 +129,11 @@ class CouponController extends BaseController {
 
 	/**
 	 * Validate applies to item
-	 * 
+	 *
 	 * @since 3.5.0
-	 * 
+	 *
 	 * @param array $data The data to validate.
-	 * 
+	 *
 	 * @return void send wp_json response when validation fails
 	 */
 	public function validate_applies_to_item( $data ) {

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -174,7 +174,7 @@ class CouponController extends BaseController {
 				HttpHelper::STATUS_UNPROCESSABLE_ENTITY
 			);
 		}
-		
+
 		$this->validate_applies_to_item( $data );
 
 		if ( $this->model->get_coupon( array( 'coupon_code' => $data['coupon_code'] ) ) ) {

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -225,7 +225,7 @@ class CouponController extends BaseController {
 		}
 
 		unset( $data['coupon_id'] );
-		unset( $data['coupon_type']);
+		unset( $data['coupon_type'] );
 
 		if ( ! isset( $data['expire_date_gmt'] ) ) {
 			$data['expire_date_gmt'] = null;
@@ -237,10 +237,10 @@ class CouponController extends BaseController {
 		try {
 			$update = $this->model->update_coupon( $coupon_id, $data );
 			if ( $update ) {
-				$isSpecificAppliesTo = $this->model->is_specific_applies_to( $data['applies_to'] );
-				$hasAppliesToItems = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
+				$is_specific_applies_to = $this->model->is_specific_applies_to( $data['applies_to'] );
+				$has_applies_to_items   = isset( $data['applies_to_items'] ) && is_array( $data['applies_to_items'] ) && count( $data['applies_to_items'] );
 
-				if ( $isSpecificAppliesTo && ! $hasAppliesToItems) {
+				if ( $is_specific_applies_to && ! $has_applies_to_items ) {
 					return $this->json_response(
 						__( 'Add items first', 'tutor' ),
 						null,
@@ -248,8 +248,8 @@ class CouponController extends BaseController {
 					);
 				}
 
-				if ( $hasAppliesToItems ) {
-					$this->model->insert_applies_to($data['applies_to'], $data['applies_to_items'], $coupon_data->coupon_code);
+				if ( $has_applies_to_items ) {
+					$this->model->insert_applies_to( $data['applies_to'], $data['applies_to_items'], $data['coupon_id'] ); // Updated to use $data['coupon_id']
 				}
 
 				$this->json_response( __( 'Coupon updated successfully!', 'tutor' ) );


### PR DESCRIPTION
Eliminate the coupon_type from the data before processing to streamline coupon handling.