### PR TITLE
🎉  All common SQL comparison operators support added to QueryHelper

### DIFF
--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -215,7 +215,8 @@ class QueryHelper {
 	public static function make_clause( array $where ) {
 		list ( $field, $operator, $value ) = $where;
 
-		if ( 'IN' === strtoupper( $operator ) ) {
+		$upper_operator = strtoupper( $operator );
+		if ( in_array( $upper_operator, array( 'IN', 'NOT IN' ), true ) ) {
 			$value = '(' . self::prepare_in_clause( $value ) . ')';
 		}
 
@@ -223,32 +224,107 @@ class QueryHelper {
 	}
 
 	/**
+	 * Check operator is supported.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @param string $operator operator like =, !=, > , < etc.
+	 *
+	 * @return boolean
+	 */
+	public static function is_support_operator( $operator ) {
+		$operator = strtoupper( $operator );
+
+		return in_array(
+			$operator,
+			array(
+				'=',
+				'!=',
+				'<>',
+				'>',
+				'<',
+				'>=',
+				'<=',
+				'LIKE',
+				'NOT LIKE',
+				'IN',
+				'NOT IN',
+				'IS',
+				'IS NOT',
+				'BETWEEN',
+				'NOT BETWEEN',
+			),
+			true
+		);
+	}
+
+	/**
 	 * Build where clause string
 	 *
-	 * @param   array $where assoc array with field and value.
-	 * @return  string
-	 *
 	 * @since 2.0.9
+	 * @since 3.0.0 Null value support added, if need to check with null: [name => 'null']
+	 * @since 3.5.0 All common SQL comparison operators support added.
+	 *              $where = array(
+	 *                  'id'         => ['BETWEEN', [10, 20]],
+	 *                  'status'     => ['!=', 'draft'],
+	 *                  'email'      => ['LIKE', '%@gmail.com'],
+	 *                  'type'       => ['NOT IN', ['test', 'sample']],
+	 *                  'age'        => ['>=', 18],
+	 *                  'active'     => true,
+	 *                  'deleted_at' => 'null',
+	 *                  'role'       => 'editor',
+	 *              )
 	 *
-	 * @since 3.0.0
-	 * Null value support added, if need to check with
-	 * null: [name => 'null'] we can pass
+	 * @param   array $where assoc array with field and value.
+	 *
+	 * @return  string
 	 */
 	public static function build_where_clause( array $where ) {
 		$arr = array();
 		foreach ( $where as $field => $value ) {
-			if ( is_array( $value ) ) {
-				$value = array( $field, 'IN', $value );
+			if ( is_array( $value ) && isset( $value[0] ) && is_string( $value[0] ) && self::is_support_operator( $value[0] ) ) {
+				$operator = strtoupper( $value[0] );
+				$val      = $value[1];
+				switch ( $operator ) {
+					case 'IN':
+					case 'NOT IN':
+						if ( is_array( $val ) ) {
+							$clause = array( $field, $operator, $val );
+						}
+						break;
+
+					case 'BETWEEN':
+					case 'NOT BETWEEN':
+						if ( is_array( $val ) && count( $val ) === 2 ) {
+							$val1   = is_numeric( $val[0] ) ? $val[0] : "'" . $val[0] . "'";
+							$val2   = is_numeric( $val[1] ) ? $val[1] : "'" . $val[1] . "'";
+							$clause = array( $field, $operator, "{$val1} AND {$val2}" );
+						}
+						break;
+
+					case 'IS':
+					case 'IS NOT':
+						$val    = strtoupper( $val ) === 'NULL' ? 'NULL' : "'" . $val . "'";
+						$clause = array( $field, $operator, $val );
+						break;
+
+					default: // =, !=, <, >, <=, >=, LIKE, NOT LIKE, <>
+						$val    = is_numeric( $val ) ? $val : "'" . $val . "'";
+						$clause = array( $field, $operator, $val );
+						break;
+				}
+			} elseif ( is_array( $value ) ) {
+				$clause = array( $field, 'IN', $value );
 			} else {
-				if ( 'null' == $value ) {
-					$value = array( $field, 'IS', 'NULL' );
+				if ( 'null' === strtolower( $value ) ) {
+					$clause = array( $field, 'IS', 'NULL' );
 				} else {
-					$value = is_numeric( $value ) ? $value : "'" . $value . "'";
-					$value = array( $field, '=', $value );
+					$value  = is_numeric( $value ) ? $value : "'" . $value . "'";
+					$clause = array( $field, '=', $value );
 				}
 			}
 
-			$arr[] = self::make_clause( $value );
+			$arr[] = self::make_clause( $clause );
 		}
 
 		return implode( ' AND ', $arr );

--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -220,7 +220,7 @@ class QueryHelper {
 			$value = '(' . self::prepare_in_clause( $value ) . ')';
 		}
 
-		return "{$field} {$operator} {$value}";
+		return "{$field} {$upper_operator} {$value}";
 	}
 
 	/**


### PR DESCRIPTION
Currently `QueryHelper::build_where_clause` only support `=`, and `IN` operator.

This PR resolves the previous limitation and adds support for all common SQL comparison operators.
```php
$where = array(
    'id'         => ['BETWEEN', [10, 20]],
    'status'     => ['!=', 'draft'],
    'email'      => ['LIKE', '%@gmail.com'],
    'type'       => ['NOT IN', ['test', 'sample']],
    'age'        => ['>=', 18],
    'active'     => true,
    'deleted_at' => 'null',
    'role'       => 'editor',
 )

QueryHelper::build_where_clause( $where );
```