### PR TITLE
💳 Add `net-payment` condition to handle PaymentActionButton

### DIFF
--- a/assets/react/v3/entries/order-details/components/order/OrderItem.tsx
+++ b/assets/react/v3/entries/order-details/components/order/OrderItem.tsx
@@ -1,3 +1,7 @@
+import { css } from '@emotion/react';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+
 import type { OrderSummaryItem } from '@OrderServices/order';
 import coursePlaceholder from '@SharedImages/course-placeholder.png';
 import SVGIcon from '@TutorShared/atoms/SVGIcon';
@@ -5,9 +9,6 @@ import { borderRadius, colorTokens, spacing } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
 import Show from '@TutorShared/controls/Show';
 import { formatPrice } from '@TutorShared/utils/currency';
-import { css } from '@emotion/react';
-import { __ } from '@wordpress/i18n';
-import React from 'react';
 
 interface OrderItemProps extends React.HTMLAttributes<HTMLDivElement> {
   item: OrderSummaryItem;

--- a/assets/react/v3/entries/order-details/components/order/OrderItem.tsx
+++ b/assets/react/v3/entries/order-details/components/order/OrderItem.tsx
@@ -1,9 +1,9 @@
+import type { OrderSummaryItem } from '@OrderServices/order';
+import coursePlaceholder from '@SharedImages/course-placeholder.png';
 import SVGIcon from '@TutorShared/atoms/SVGIcon';
 import { borderRadius, colorTokens, spacing } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
 import Show from '@TutorShared/controls/Show';
-import coursePlaceholder from '@SharedImages/course-placeholder.png';
-import type { OrderSummaryItem } from '@OrderServices/order';
 import { formatPrice } from '@TutorShared/utils/currency';
 import { css } from '@emotion/react';
 import { __ } from '@wordpress/i18n';
@@ -71,6 +71,8 @@ const styles = {
     width: 48px;
     height: 48px;
     border-radius: ${borderRadius[4]};
+    object-fit: cover;
+    object-position: center;
   `,
   discount: css`
     display: flex;

--- a/assets/react/v3/entries/order-details/components/order/Payment.tsx
+++ b/assets/react/v3/entries/order-details/components/order/Payment.tsx
@@ -28,9 +28,9 @@ function PaymentActionButton({
   order: Order;
   onClick: (buttonType: 'refund' | 'mark-as-paid') => void;
 }) {
-  const { payment_status, total_price, net_payment } = order || {};
+  const { payment_status, total_price } = order || {};
 
-  if (total_price <= 0 || net_payment <= 0) {
+  if (total_price <= 0) {
     return null;
   }
 

--- a/assets/react/v3/entries/order-details/components/order/Payment.tsx
+++ b/assets/react/v3/entries/order-details/components/order/Payment.tsx
@@ -28,9 +28,9 @@ function PaymentActionButton({
   order: Order;
   onClick: (buttonType: 'refund' | 'mark-as-paid') => void;
 }) {
-  const { payment_status, total_price } = order || {};
+  const { payment_status, net_payment } = order || {};
 
-  if (total_price <= 0) {
+  if (net_payment <= 0) {
     return null;
   }
 

--- a/assets/react/v3/entries/order-details/components/order/Payment.tsx
+++ b/assets/react/v3/entries/order-details/components/order/Payment.tsx
@@ -1,3 +1,8 @@
+import DiscountModal from '@OrderComponents/modals/DiscountModal';
+import MarkAsPaidModal from '@OrderComponents/modals/MarkAsPaidModal';
+import RefundModal from '@OrderComponents/modals/RefundModal';
+import { useOrderContext } from '@OrderContexts/order-context';
+import type { PaymentStatus } from '@OrderServices/order';
 import { Box, BoxTitle } from '@TutorShared/atoms/Box';
 import Button from '@TutorShared/atoms/Button';
 import SVGIcon from '@TutorShared/atoms/SVGIcon';
@@ -6,11 +11,6 @@ import { colorTokens, fontWeight, spacing } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
 import For from '@TutorShared/controls/For';
 import Show from '@TutorShared/controls/Show';
-import DiscountModal from '@OrderComponents/modals/DiscountModal';
-import MarkAsPaidModal from '@OrderComponents/modals/MarkAsPaidModal';
-import RefundModal from '@OrderComponents/modals/RefundModal';
-import { useOrderContext } from '@OrderContexts/order-context';
-import type { PaymentStatus } from '@OrderServices/order';
 import { calculateDiscountValue, formatPrice } from '@TutorShared/utils/currency';
 import { styleUtils } from '@TutorShared/utils/style-utils';
 import { css } from '@emotion/react';
@@ -20,10 +20,16 @@ import { PaymentBadge } from './PaymentBadge';
 function PaymentActionButton({
   status,
   onClick,
+  total_price,
 }: {
   status: PaymentStatus;
   onClick: (buttonType: 'refund' | 'mark-as-paid') => void;
+  total_price: number;
 }) {
+  if (total_price <= 0) {
+    return null;
+  }
+
   switch (status) {
     case 'paid':
     case 'partially-refunded':
@@ -224,6 +230,7 @@ function Payment() {
         <div css={styles.markAsPaid}>
           <PaymentActionButton
             status={order.payment_status}
+            total_price={order.total_price}
             onClick={(buttonType) => {
               if (buttonType === 'refund') {
                 return showModal({

--- a/assets/react/v3/entries/order-details/components/order/Payment.tsx
+++ b/assets/react/v3/entries/order-details/components/order/Payment.tsx
@@ -1,20 +1,24 @@
+import { css } from '@emotion/react';
+import { __, sprintf } from '@wordpress/i18n';
+
+import { Box, BoxTitle } from '@TutorShared/atoms/Box';
+import Button from '@TutorShared/atoms/Button';
+import SVGIcon from '@TutorShared/atoms/SVGIcon';
+import { useModal } from '@TutorShared/components/modals/Modal';
+
 import DiscountModal from '@OrderComponents/modals/DiscountModal';
 import MarkAsPaidModal from '@OrderComponents/modals/MarkAsPaidModal';
 import RefundModal from '@OrderComponents/modals/RefundModal';
 import { useOrderContext } from '@OrderContexts/order-context';
 import type { PaymentStatus } from '@OrderServices/order';
-import { Box, BoxTitle } from '@TutorShared/atoms/Box';
-import Button from '@TutorShared/atoms/Button';
-import SVGIcon from '@TutorShared/atoms/SVGIcon';
-import { useModal } from '@TutorShared/components/modals/Modal';
+
 import { colorTokens, fontWeight, spacing } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
 import For from '@TutorShared/controls/For';
 import Show from '@TutorShared/controls/Show';
 import { calculateDiscountValue, formatPrice } from '@TutorShared/utils/currency';
 import { styleUtils } from '@TutorShared/utils/style-utils';
-import { css } from '@emotion/react';
-import { __, sprintf } from '@wordpress/i18n';
+
 import { PaymentBadge } from './PaymentBadge';
 
 function PaymentActionButton({

--- a/assets/react/v3/entries/order-details/components/order/Payment.tsx
+++ b/assets/react/v3/entries/order-details/components/order/Payment.tsx
@@ -10,7 +10,7 @@ import DiscountModal from '@OrderComponents/modals/DiscountModal';
 import MarkAsPaidModal from '@OrderComponents/modals/MarkAsPaidModal';
 import RefundModal from '@OrderComponents/modals/RefundModal';
 import { useOrderContext } from '@OrderContexts/order-context';
-import type { PaymentStatus } from '@OrderServices/order';
+import type { Order } from '@OrderServices/order';
 
 import { colorTokens, fontWeight, spacing } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
@@ -22,19 +22,19 @@ import { styleUtils } from '@TutorShared/utils/style-utils';
 import { PaymentBadge } from './PaymentBadge';
 
 function PaymentActionButton({
-  status,
+  order,
   onClick,
-  total_price,
 }: {
-  status: PaymentStatus;
+  order: Order;
   onClick: (buttonType: 'refund' | 'mark-as-paid') => void;
-  total_price: number;
 }) {
-  if (total_price <= 0) {
+  const { payment_status, total_price, net_payment } = order || {};
+
+  if (total_price <= 0 || net_payment <= 0) {
     return null;
   }
 
-  switch (status) {
+  switch (payment_status) {
     case 'paid':
     case 'partially-refunded':
     case 'failed':
@@ -233,8 +233,7 @@ function Payment() {
 
         <div css={styles.markAsPaid}>
           <PaymentActionButton
-            status={order.payment_status}
-            total_price={order.total_price}
+            order={order}
             onClick={(buttonType) => {
               if (buttonType === 'refund') {
                 return showModal({

--- a/assets/react/v3/entries/order-details/components/order/Payment.tsx
+++ b/assets/react/v3/entries/order-details/components/order/Payment.tsx
@@ -30,19 +30,20 @@ function PaymentActionButton({
 }) {
   const { payment_status, net_payment } = order || {};
 
-  if (net_payment <= 0) {
-    return null;
-  }
-
   switch (payment_status) {
     case 'paid':
     case 'partially-refunded':
-    case 'failed':
+    case 'failed': {
+      if (net_payment <= 0) {
+        return null;
+      }
+
       return (
         <Button variant="tertiary" size="small" isOutlined onClick={() => onClick('refund')}>
           {__('Refund', 'tutor')}
         </Button>
       );
+    }
     case 'unpaid':
       return (
         <Button variant="primary" size="small" isOutlined onClick={() => onClick('mark-as-paid')}>


### PR DESCRIPTION
Implement net payment to handle the PaymentActionButton component and update relevant imports. This change ensures that the button does not render when the net payment is zero or less.

Single Purchase using 100% coupon
![image](https://github.com/user-attachments/assets/c788823f-60ce-42a7-bee5-573cb9972ba0)

Subscription using 100% coupon
![image](https://github.com/user-attachments/assets/4d95f245-afbb-4c97-b13c-a60d5552c5ce)

Membership with trial
![image](https://github.com/user-attachments/assets/ea801a8f-b784-4658-bc4c-92756f11a1b8)
