### PR TITLE
Fixed The _load_textdomain_just_in_time Notice Error

### DIFF
--- a/classes/Admin.php
+++ b/classes/Admin.php
@@ -53,8 +53,6 @@ class Admin {
 
 		// Admin Footer Text.
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
-		// Register Course Widget.
-		add_action( 'widgets_init', array( $this, 'register_course_widget' ) );
 
 		// Handle flash toast message for redirect_to util helper.
 		add_action( 'admin_head', array( new Utils(), 'handle_flash_message' ), 999 );
@@ -63,6 +61,8 @@ class Admin {
 		add_action( 'admin_bar_menu', array( $this, 'add_toolbar_items' ), 100 );
 
 		add_action( 'wp_ajax_tutor_do_not_show_feature_page', array( $this, 'handle_do_not_show_feature_page' ) );
+
+		add_action( 'widgets_init', array( $this, 'register_course_widget' ) );
 	}
 
 	/**
@@ -593,7 +593,7 @@ class Admin {
 	 * @return void
 	 */
 	public function register_course_widget() {
-		register_widget( 'Tutor\Course_Widget' );
+		register_widget( Course_Widget::class );
 	}
 
 	/**

--- a/classes/Announcements.php
+++ b/classes/Announcements.php
@@ -49,7 +49,13 @@ class Announcements {
 	 * @return void
 	 */
 	public function __construct() {
-		$this->page_title = __( 'Announcements', 'tutor' );
+		add_action(
+			'init',
+			function() {
+				$this->page_title = __( 'Announcements', 'tutor' );
+			}
+		);
+
 		/**
 		 * Handle bulk action
 		 *

--- a/classes/Course_List.php
+++ b/classes/Course_List.php
@@ -51,7 +51,13 @@ class Course_List {
 	 * @since 2.0.0
 	 */
 	public function __construct() {
-		$this->page_title = __( 'Courses', 'tutor' );
+		add_action(
+			'init',
+			function() {
+				$this->page_title = __( 'Courses', 'tutor' );
+			}
+		);
+
 		/**
 		 * Handle bulk action
 		 *

--- a/classes/Course_Widget.php
+++ b/classes/Course_Widget.php
@@ -32,8 +32,8 @@ class Course_Widget extends \WP_Widget {
 	public function __construct() {
 		parent::__construct(
 			'tutor_course_widget', // Base ID.
-			'Tutor Course',
-			array( 'description' => 'Display courses wherever widget support is available.' )
+			_x( 'Tutor Course', 'widget title', 'tutor' ),
+			array( 'description' => _x( 'Display courses wherever widget support is available.', 'widget description', 'tutor' ) )
 		);
 	}
 

--- a/classes/Course_Widget.php
+++ b/classes/Course_Widget.php
@@ -32,8 +32,8 @@ class Course_Widget extends \WP_Widget {
 	public function __construct() {
 		parent::__construct(
 			'tutor_course_widget', // Base ID.
-			esc_html__( 'Tutor Course', 'tutor' ), // Name.
-			array( 'description' => esc_html__( 'Display courses wherever widget support is available.', 'tutor' ) ) // Args.
+			'Tutor Course',
+			array( 'description' => 'Display courses wherever widget support is available.' )
 		);
 	}
 

--- a/classes/Instructors_List.php
+++ b/classes/Instructors_List.php
@@ -59,7 +59,12 @@ class Instructors_List {
 	 * @return void
 	 */
 	public function __construct() {
-		$this->page_title = __( 'Instructor', 'tutor' );
+		add_action(
+			'init',
+			function() {
+				$this->page_title = __( 'Instructor', 'tutor' );
+			}
+		);
 
 		/**
 		 * Handle bulk action

--- a/classes/Quiz_Attempts_List.php
+++ b/classes/Quiz_Attempts_List.php
@@ -143,7 +143,7 @@ class Quiz_Attempts_List {
 				$select_stmt = "SELECT COUNT( DISTINCT attempt_id)
 								FROM {$wpdb->prefix}tutor_quiz_attempts quiz_attempts
 								INNER JOIN {$wpdb->posts} quiz ON quiz_attempts.quiz_id = quiz.ID
-								-- INNER JOIN {$wpdb->prefix}tutor_quiz_attempt_answers AS ans ON quiz_attempts.attempt_id = ans.quiz_attempt_id";
+								INNER JOIN {$wpdb->prefix}tutor_quiz_attempt_answers AS ans ON quiz_attempts.attempt_id = ans.quiz_attempt_id";
 
 				$count_obj->pass = (int) $wpdb->get_var(
 					$wpdb->prepare(

--- a/classes/Quiz_Attempts_List.php
+++ b/classes/Quiz_Attempts_List.php
@@ -55,8 +55,13 @@ class Quiz_Attempts_List {
 	 * @param boolean $register_hook should register hook or not.
 	 */
 	public function __construct( $register_hook = true ) {
+		add_action(
+			'init',
+			function() {
+				$this->page_title = __( 'Quiz Attempts', 'tutor' );
+			}
+		);
 
-		$this->page_title = __( 'Quiz Attempts', 'tutor' );
 		if ( ! $register_hook ) {
 			return;
 		}
@@ -182,7 +187,7 @@ class Quiz_Attempts_List {
 				$attempt_cache->set_cache();
 			}
 		}
-		
+
 		$all      = $count_obj->pass + $count_obj->fail + $count_obj->pending;
 		$pass     = $count_obj->pass;
 		$fail     = $count_obj->fail;
@@ -205,7 +210,7 @@ class Quiz_Attempts_List {
 	 * @return array
 	 */
 	public function tabs_key_value( $user_id, $course_id, $date, $search ): array {
-		$url   = apply_filters( 'tutor_data_tab_base_url', get_pagenum_link());
+		$url   = apply_filters( 'tutor_data_tab_base_url', get_pagenum_link() );
 		$stats = $this->get_quiz_attempts_stat();
 
 		$tabs = array(

--- a/classes/Students_List.php
+++ b/classes/Students_List.php
@@ -61,7 +61,13 @@ class Students_List {
 	 * @since 2.0.0
 	 */
 	public function __construct() {
-		$this->page_title = __( 'Students', 'tutor' );
+		add_action(
+			'init',
+			function() {
+				$this->page_title = __( 'Students', 'tutor' );
+			}
+		);
+
 		/**
 		 * Handle bulk action
 		 *

--- a/classes/Tutor.php
+++ b/classes/Tutor.php
@@ -518,7 +518,6 @@ final class Tutor {
 		$this->gutenberg             = new Gutenberg();
 		$this->course_settings_tabs  = new Course_Settings_Tabs();
 		$this->withdraw              = new Withdraw();
-		$this->course_widget         = new Course_Widget();
 		$this->upgrader              = new Upgrader();
 		$this->dashboard             = new Dashboard();
 		$this->form_handler          = new FormHandler();

--- a/classes/Withdraw_Requests_List.php
+++ b/classes/Withdraw_Requests_List.php
@@ -44,7 +44,13 @@ class Withdraw_Requests_List {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
-		$this->page_title = __( 'Withdraw Request', 'tutor' );
+		add_action(
+			'init',
+			function() {
+				$this->page_title = __( 'Withdraw Request', 'tutor' );
+			}
+		);
+
 		/**
 		 * Approve or reject withdraw request
 		 */

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -89,7 +89,13 @@ class CouponController extends BaseController {
 	 * @return void
 	 */
 	public function __construct( $register_hooks = true ) {
-		$this->page_title = __( 'Coupons', 'tutor' );
+		add_action(
+			'init',
+			function() {
+				$this->page_title = __( 'Coupons', 'tutor' );
+			}
+		);
+
 		$this->model      = new CouponModel();
 
 		if ( $register_hooks ) {

--- a/ecommerce/OrderController.php
+++ b/ecommerce/OrderController.php
@@ -83,8 +83,14 @@ class OrderController {
 	 * @return void
 	 */
 	public function __construct( $register_hooks = true ) {
-		$this->page_title = __( 'Orders', 'tutor' );
-		$this->model      = new OrderModel();
+		add_action(
+			'init',
+			function() {
+				$this->page_title = __( 'Orders', 'tutor' );
+			}
+		);
+
+		$this->model = new OrderModel();
 
 		if ( $register_hooks ) {
 			/**


### PR DESCRIPTION
**Problem:**
WordPress _load_textdomain_just_in_time load the translation after the initialization of WP. When the translation functions like __, esc_html_e get called before loading the translation functions it throws error.

**Solution:**
Calling the translation functions after loading WP solved the issue. Used the `init` action hook. Thanks to the WP hooks. Below is an example of solution:

**Previous Code:**
`$this->page_title = __( 'Quiz Attempts', 'tutor' );`

**Current Code:**
```
		add_action(
			'init',
			function() {
				$this->page_title = __( 'Quiz Attempts', 'tutor' );
			}
		);
```