### PR TITLE
🔧 fix: update dropdown visibility condition to show when items are available

### DIFF
--- a/assets/react/v3/entries/course-builder/components/layouts/header/HeaderActions.tsx
+++ b/assets/react/v3/entries/course-builder/components/layouts/header/HeaderActions.tsx
@@ -390,7 +390,7 @@ const HeaderActions = () => {
       </Show>
 
       <Show
-        when={dropdownItems().length > 1}
+        when={dropdownItems().length > 0}
         fallback={
           <Button
             data-cy="course-builder-submit-button"


### PR DESCRIPTION
Adjust the condition for dropdown visibility to display when there are available items instead of requiring more than one.