### PR TITLE
Fix: can user edit course check logic not correctly implement

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -8390,7 +8390,7 @@ class Utils {
 	 * @return boolean
 	 */
 	public function can_user_edit_course( $user_id, $course_id ) {
-		return User::is_admin() || $this->is_instructor_of_this_course( $user_id, $course_id );
+		return User::is_admin( $user_id ) || $this->is_instructor_of_this_course( $user_id, $course_id );
 	}
 
 

--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -8390,7 +8390,7 @@ class Utils {
 	 * @return boolean
 	 */
 	public function can_user_edit_course( $user_id, $course_id ) {
-		return current_user_can( 'edit_tutor_course', $course_id ) || $this->is_instructor_of_this_course( $user_id, $course_id );
+		return User::is_admin() || $this->is_instructor_of_this_course( $user_id, $course_id );
 	}
 
 


### PR DESCRIPTION
- `can_user_edit_course()` was using the logic `current_user_can( 'edit_tutor_course', $course_id ) || $this->is_instructor_of_this_course( $user_id, $course_id );`
- this was allowing instructors to edit admins posts thus causing security issue
- since `current_user_can( 'edit_tutor_course', $course_id )` returns true for instructor as instructor role has this capability