### PR TITLE
🔧 Prevent search display when input is disabled

### DIFF
--- a/assets/react/v3/shared/components/fields/FormCategoriesInput.tsx
+++ b/assets/react/v3/shared/components/fields/FormCategoriesInput.tsx
@@ -124,7 +124,7 @@ const FormMultiLevelInput = ({
           <>
             <div css={[styles.options, optionsWrapperStyle]}>
               <div css={styles.categoryListWrapper} ref={scrollElementRef}>
-                <Show when={hasCategories || debouncedSearchValue}>
+                <Show when={!disabled && (hasCategories || debouncedSearchValue)}>
                   <Controller
                     name="search"
                     control={form.control}


### PR DESCRIPTION
Ensure the search functionality does not appear when the input is disabled, improving user experience and preventing unnecessary interactions.