### PR TITLE
🔧 Fix WcProducts query invalidation after course update

### DIFF
--- a/assets/react/v3/entries/course-builder/services/course.ts
+++ b/assets/react/v3/entries/course-builder/services/course.ts
@@ -756,6 +756,10 @@ export const useUpdateCourseMutation = () => {
         queryClient.invalidateQueries({
           queryKey: ['InstructorList', String(response.data)],
         });
+
+        queryClient.invalidateQueries({
+          queryKey: ['WcProducts'],
+        });
       }
     },
     onError: (error: ErrorResponse) => {


### PR DESCRIPTION
Invalidate the WcProducts query when a course is updated to ensure data consistency.