### PR TITLE
✨ feat: add default values for tax settings fields

### DIFF
--- a/assets/react/v3/entries/tax-settings/components/App.tsx
+++ b/assets/react/v3/entries/tax-settings/components/App.tsx
@@ -33,7 +33,7 @@ function App() {
         <ToastProvider position="bottom-right">
           <ModalProvider>
             <Global styles={createGlobalCss()} />
-              <TaxSettingsPage />
+            <TaxSettingsPage />
           </ModalProvider>
         </ToastProvider>
       </QueryClientProvider>

--- a/assets/react/v3/entries/tax-settings/components/TaxSettings.tsx
+++ b/assets/react/v3/entries/tax-settings/components/TaxSettings.tsx
@@ -21,12 +21,14 @@ import { useCountrySelectModal } from './modals/CountrySelectModal';
 const TaxSettingsPage = () => {
   const form = useFormWithGlobalError<TaxSettings>({
     defaultValues: {
+      enable_tax: true,
       rates: [],
       apply_tax_on: 'product',
       active_country: null,
       show_price_with_tax: false,
       charge_tax_on_shipping: false,
       is_tax_included_in_price: 0,
+      enable_individual_tax_control: false,
     },
   });
   const { reset } = form;


### PR DESCRIPTION
Introduce default values for `enable_tax` and `enable_individual_tax_control` in the `TaxSettingsPage` to enhance tax configuration options.