### PR TITLE
🛠️ fix: update export modal to use 'course-bundle' for data handling

### DIFF
--- a/assets/react/v3/entries/import-export/components/modals/ExportModal.tsx
+++ b/assets/react/v3/entries/import-export/components/modals/ExportModal.tsx
@@ -85,7 +85,7 @@ const ExportModal = ({ onClose, onExport, currentStep, onDownload, progress, fil
   useEffect(() => {
     if (getExportableContentQuery.isSuccess && getExportableContentQuery.data) {
       form.setValue('courses.ids', getExportableContentQuery.data.courses?.ids || []);
-      form.setValue('bundles.ids', getExportableContentQuery.data.bundles?.ids || []);
+      form.setValue('bundles.ids', getExportableContentQuery.data['course-bundle']?.ids || []);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getExportableContentQuery.isSuccess]);

--- a/assets/react/v3/entries/import-export/services/import-export.ts
+++ b/assets/react/v3/entries/import-export/services/import-export.ts
@@ -73,7 +73,7 @@ export const convertExportFormDataToPayload = (data: ExportFormData): ExportCont
 
   if (data.bundles.isChecked) {
     payload.export_contents?.push({
-      type: 'bundles',
+      type: 'course-bundle',
       ids: data.bundles.ids,
       sub_contents: [],
     });
@@ -94,7 +94,7 @@ export type ImportExportModalState = 'initial' | 'progress' | 'success' | 'error
 
 export interface ExportableContent {
   courses: ExportableSectionWithItems;
-  bundles: ExportableSectionWithoutItems;
+  'course-bundle': ExportableSectionWithoutItems;
   settings: ExportableSectionWithoutItems;
 }
 
@@ -129,7 +129,7 @@ export const useExportableContentQuery = () => {
 };
 
 interface ExportContentItem {
-  type: 'courses' | 'bundles' | 'settings';
+  type: 'courses' | 'course-bundle' | 'settings';
   ids?: number[];
   sub_contents?: ('lesson' | 'tutor_assignments' | 'quiz' | 'attachment')[];
 }


### PR DESCRIPTION
Update the export modal to replace 'bundles' with 'course-bundle' for improved data management.