### PR TITLE
✨ feat: add onSelect prop to CourseListModal for course selection handling in ExportModal

### DIFF
--- a/assets/react/v3/entries/import-export/components/modals/CourseListModal/index.tsx
+++ b/assets/react/v3/entries/import-export/components/modals/CourseListModal/index.tsx
@@ -14,9 +14,10 @@ interface CourseListModalProps extends ModalProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   form: UseFormReturn<any, any, undefined>;
   addedCourses: Course[];
+  onSelect: (course: Course[]) => void;
 }
 
-function CourseListModal({ title, closeModal, actions, form, addedCourses }: CourseListModalProps) {
+function CourseListModal({ title, closeModal, actions, form, addedCourses, onSelect }: CourseListModalProps) {
   const _form = useFormWithGlobalError({
     defaultValues: {
       courses: addedCourses,
@@ -29,6 +30,7 @@ function CourseListModal({ title, closeModal, actions, form, addedCourses }: Cou
     const selectedCourses = _form.getValues('courses');
     form.setValue('courses', [...selectedCourses]);
     _form.setValue('courses', []);
+    onSelect(selectedCourses);
     closeModal({ action: 'CONFIRM' });
   };
 

--- a/assets/react/v3/entries/import-export/components/modals/ExportModal.tsx
+++ b/assets/react/v3/entries/import-export/components/modals/ExportModal.tsx
@@ -208,6 +208,13 @@ const ExportModal = ({ onClose, onExport, currentStep, onDownload, progress, fil
                             title: __('Select Courses', 'tutor'),
                             addedCourses: bulkSelectionForm.getValues('courses'),
                             form: bulkSelectionForm,
+                            onSelect: (courses) => {
+                              if (courses.length) {
+                                form.setValue('courses.isChecked', true, {
+                                  shouldDirty: true,
+                                });
+                              }
+                            },
                           },
                         });
                       }}


### PR DESCRIPTION
Introduce an `onSelect` prop in the CourseListModal to handle course selection, enabling the ExportModal to respond to selected courses effectively.