### PR TITLE
Enhance docblock to avoid warnings

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -9924,7 +9924,7 @@ class Utils {
 	/**
 	 * Get course meta data.
 	 *
-	 * @param int $course_id course id.
+	 * @param int|int[] $course_id course id.
 	 *
 	 * @return mixed
 	 */


### PR DESCRIPTION
The current warning is:
> Expected parameter of type 'int', 'array' provided"

from:
`tutor_utils()->get_course_meta_data( $course_ids );`