### PR TITLE
🧹 Refactor: Remove unused properties from ExportFormData interface

### DIFF
--- a/assets/react/v3/entries/import-export/components/Import.tsx
+++ b/assets/react/v3/entries/import-export/components/Import.tsx
@@ -14,10 +14,7 @@ import { convertToErrorMessage, noop } from '@TutorShared/utils/util';
 
 import generateImportExportMessage from '@ImportExport/utils/utils';
 import importInitialImage from '@SharedImages/import-export/import-initial.webp';
-import { tutorConfig } from '@TutorShared/config/config';
 import { type ErrorResponse } from 'react-router-dom';
-
-const isTutorPro = !!tutorConfig.tutor_pro_url;
 
 const Import = () => {
   const { showModal, updateModal, closeModal } = useModal();

--- a/assets/react/v3/entries/import-export/services/import-export.ts
+++ b/assets/react/v3/entries/import-export/services/import-export.ts
@@ -18,7 +18,6 @@ export interface ExportFormData {
   courses__lesson: boolean;
   courses__tutor_quiz: boolean;
   courses__tutor_assignments: boolean;
-  courses__attachments: boolean;
   keep_media_files: boolean;
 }
 
@@ -31,7 +30,6 @@ export const defaultExportFormData: ExportFormData = {
   courses__lesson: true,
   courses__tutor_quiz: true,
   courses__tutor_assignments: true,
-  courses__attachments: true,
   keep_media_files: false,
 };
 


### PR DESCRIPTION
Eliminate unnecessary properties from the ExportFormData interface to streamline the codebase.