### PR TITLE
🔧 Fix logic for selecting default options in resetConfirmation function

### DIFF
--- a/assets/react/admin-dashboard/segments/reset.js
+++ b/assets/react/admin-dashboard/segments/reset.js
@@ -57,7 +57,7 @@ const resetConfirmation = () => {
 
 									let elementOptions = elementItem.options;
 									[...elementOptions].forEach((elementOption) => {
-										elementOption.selected = String(item.default).includes(elementOption.value) ? true : false;
+										elementOption.selected = typeof item.default === 'number' ? elementOption.value === item.default : item.default.includes(elementOption.value);
 									});
 
 								} else if (item.type == 'color_preset') {


### PR DESCRIPTION
Refine the logic for selecting default options in the resetConfirmation function to handle both single numeric values and arrays correctly.