### PR TITLE
🔧 Fix: update icons array to be a readonly tuple for TS suggestion

### DIFF
--- a/assets/react/v3/shared/icons/types.ts
+++ b/assets/react/v3/shared/icons/types.ts
@@ -220,6 +220,6 @@ export const icons = [
   'uploadFile',
   'attachmentLine',
   'primeCheckCircle',
-];
+] as const;
 
 export type IconCollection = (typeof icons)[number];


### PR DESCRIPTION
This solution uses the as const assertion, which tells TypeScript to treat the array as a readonly tuple with specific string literal values. When we then access typeof icons[number], TypeScript will correctly extract a union type of all the specific string literals in the array, rather than just inferring the type as string.

Now when you use IconCollection in your code, TypeScript will show it as a union of all the specific icon names, providing proper type checking and autocomplete for valid icon names.