### PR TITLE
.min extension removed from js files

### DIFF
--- a/classes/Assets.php
+++ b/classes/Assets.php
@@ -211,7 +211,7 @@ class Assets {
 		wp_enqueue_script( 'jquery-ui-datepicker' );
 
 		wp_enqueue_script( 'tutor-select2', tutor()->url . 'assets/lib/select2/select2.full.min.js', array( 'jquery' ), TUTOR_VERSION, true );
-		wp_enqueue_script( 'tutor-admin', tutor()->url . 'assets/js/tutor-admin.min.js', array( 'jquery', 'tutor-script', 'wp-color-picker', 'wp-i18n', 'wp-data' ), TUTOR_VERSION, true );
+		wp_enqueue_script( 'tutor-admin', tutor()->url . 'assets/js/tutor-admin.js', array( 'jquery', 'tutor-script', 'wp-color-picker', 'wp-i18n', 'wp-data' ), TUTOR_VERSION, true );
 
 		// Tutor order detail & coupon scripts.
 		$page     = Input::get( 'page', '' );
@@ -222,32 +222,32 @@ class Assets {
 
 		if ( tutor_utils()->is_monetize_by_tutor() ) {
 			if ( OrderController::PAGE_SLUG === $page && 'edit' === $action ) {
-				wp_enqueue_script( 'tutor-order-details', tutor()->url . 'assets/js/tutor-order-details.min.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
+				wp_enqueue_script( 'tutor-order-details', tutor()->url . 'assets/js/tutor-order-details.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
 			}
 
 			if ( CouponController::PAGE_SLUG === $page && in_array( $action, $allowed_actions, true ) ) {
-				wp_enqueue_script( 'tutor-coupon', tutor()->url . 'assets/js/tutor-coupon.min.js', array( 'wp-date', 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
+				wp_enqueue_script( 'tutor-coupon', tutor()->url . 'assets/js/tutor-coupon.js', array( 'wp-date', 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
 			}
 
 			// @since 3.0.0 add tax react app on the settings page.
 			if ( 'tutor_settings' === $page && ! Input::has( 'edit' ) ) {
 				wp_enqueue_editor();
-				wp_enqueue_script( 'tutor-tax-settings', tutor()->url . 'assets/js/tutor-tax-settings.min.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
-				wp_enqueue_script( 'tutor-payment-settings', tutor()->url . 'assets/js/tutor-payment-settings.min.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
+				wp_enqueue_script( 'tutor-tax-settings', tutor()->url . 'assets/js/tutor-tax-settings.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
+				wp_enqueue_script( 'tutor-payment-settings', tutor()->url . 'assets/js/tutor-payment-settings.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
 			}
 		}
 
 		if ( 'tutor-tools' === $page && 'import_export' === $sub_page ) {
-				wp_enqueue_script( 'tutor-import-export', tutor()->url . 'assets/js/tutor-import-export.min.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
+				wp_enqueue_script( 'tutor-import-export', tutor()->url . 'assets/js/tutor-import-export.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
 		}
 
 		if ( 'tutor-addons' === $page ) {
-			wp_enqueue_script( 'tutor-coupon', tutor()->url . 'assets/js/tutor-addon-list.min.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
+			wp_enqueue_script( 'tutor-coupon', tutor()->url . 'assets/js/tutor-addon-list.js', array( 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
 		}
 
 		if ( 'tutor-themes' === $page ) {
 			wp_enqueue_style( 'tutor-template-import', tutor()->url . 'assets/css/tutor-template-import.min.css', array(), TUTOR_VERSION, 'all' );
-			wp_enqueue_script( 'tutor-template-import-js', tutor()->url . 'assets/js/tutor-template-import-script.min.js', array( 'wp-i18n' ), TUTOR_VERSION, true );
+			wp_enqueue_script( 'tutor-template-import-js', tutor()->url . 'assets/js/tutor-template-import-script.js', array( 'wp-i18n' ), TUTOR_VERSION, true );
 		}
 	}
 
@@ -322,7 +322,7 @@ class Assets {
 		 * @since 1.9.0
 		 */
 		wp_enqueue_style( 'tutor-frontend', tutor()->url . 'assets/css/tutor-front.min.css', array(), TUTOR_VERSION );
-		wp_enqueue_script( 'tutor-frontend', tutor()->url . 'assets/js/tutor-front.min.js', array( 'jquery', 'wp-i18n', 'wp-date' ), TUTOR_VERSION, true );
+		wp_enqueue_script( 'tutor-frontend', tutor()->url . 'assets/js/tutor-front.js', array( 'jquery', 'wp-i18n', 'wp-date' ), TUTOR_VERSION, true );
 
 		/**
 		 * Load frontend dashboard style
@@ -425,7 +425,7 @@ class Assets {
 		 *
 		 * @since v2.0.0
 		 */
-		wp_enqueue_script( 'tutor-script', tutor()->url . 'assets/js/tutor.min.js', array( 'jquery', 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
+		wp_enqueue_script( 'tutor-script', tutor()->url . 'assets/js/tutor.js', array( 'jquery', 'wp-i18n', 'wp-element' ), TUTOR_VERSION, true );
 
 		/**
 		 * Enqueue datetime countdown scripts & styles

--- a/classes/Course.php
+++ b/classes/Course.php
@@ -1399,7 +1399,7 @@ class Course extends Tutor_Base {
 		wp_enqueue_editor();
 
 		wp_enqueue_media();
-		wp_enqueue_script( 'tutor-course-builder', tutor()->url . 'assets/js/tutor-course-builder.min.js', array( 'wp-date', 'wp-i18n', 'wp-element', 'wp-api' ), TUTOR_VERSION, true );
+		wp_enqueue_script( 'tutor-course-builder', tutor()->url . 'assets/js/tutor-course-builder.js', array( 'wp-date', 'wp-i18n', 'wp-element', 'wp-api' ), TUTOR_VERSION, true );
 		wp_set_script_translations( 'tutor-course-builder', 'tutor', tutor()->path . 'languages/' );
 
 		wp_localize_script(

--- a/classes/Tutor_Setup.php
+++ b/classes/Tutor_Setup.php
@@ -838,7 +838,7 @@ class Tutor_Setup {
 		$page = Input::get( 'page', '' );
 		if ( 'tutor-setup' === $page ) {
 			wp_enqueue_style( 'tutor-setup', tutor()->url . 'assets/css/tutor-setup.min.css', array(), TUTOR_VERSION );
-			wp_register_script( 'tutor-setup', tutor()->url . 'assets/js/tutor-setup.min.js', array( 'jquery', 'wp-i18n' ), TUTOR_VERSION, true );
+			wp_register_script( 'tutor-setup', tutor()->url . 'assets/js/tutor-setup.js', array( 'jquery', 'wp-i18n' ), TUTOR_VERSION, true );
 			wp_localize_script( 'tutor-setup', '_tutorobject', array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) ) );
 			wp_set_script_translations( 'tutor-setup', 'tutor', tutor()->path . 'languages/' );
 		}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,19 +92,19 @@ module.exports = (env, options) => {
         {
             dest_path: './assets/js',
             src_files: {
-                'tutor.min': './assets/react/v2/common.js',
-                'tutor-front.min': './assets/react/front/tutor-front.js',
-                'tutor-admin.min': './assets/react/admin-dashboard/tutor-admin.js',
-                'tutor-setup.min': './assets/react/admin-dashboard/tutor-setup.js',
+                'tutor': './assets/react/v2/common.js',
+                'tutor-front': './assets/react/front/tutor-front.js',
+                'tutor-admin': './assets/react/admin-dashboard/tutor-admin.js',
+                'tutor-setup': './assets/react/admin-dashboard/tutor-setup.js',
                 'tutor-gutenberg': './assets/react/gutenberg/index.js',
-                'tutor-course-builder.min': './assets/react/v3/entries/course-builder/index.tsx',
-                'tutor-order-details.min': './assets/react/v3/entries/order-details/index.tsx',
-                'tutor-coupon.min': './assets/react/v3/entries/coupon-details/index.tsx',
-                'tutor-tax-settings.min': './assets/react/v3/entries/tax-settings/index.tsx',
-                'tutor-payment-settings.min': './assets/react/v3/entries/payment-settings/index.tsx',
-                'tutor-addon-list.min': './assets/react/v3/entries/addon-list/index.tsx',
-                'tutor-template-import-script.min': './assets/react/admin-dashboard/template-import-script.js',
-                'tutor-import-export.min': './assets/react/v3/entries/import-export/index.tsx',
+                'tutor-course-builder': './assets/react/v3/entries/course-builder/index.tsx',
+                'tutor-order-details': './assets/react/v3/entries/order-details/index.tsx',
+                'tutor-coupon': './assets/react/v3/entries/coupon-details/index.tsx',
+                'tutor-tax-settings': './assets/react/v3/entries/tax-settings/index.tsx',
+                'tutor-payment-settings': './assets/react/v3/entries/payment-settings/index.tsx',
+                'tutor-addon-list': './assets/react/v3/entries/addon-list/index.tsx',
+                'tutor-template-import-script': './assets/react/admin-dashboard/template-import-script.js',
+                'tutor-import-export': './assets/react/v3/entries/import-export/index.tsx',
             }
         }
     ];
@@ -123,9 +123,9 @@ module.exports = (env, options) => {
                     chunkFilename: (pathData) => {
                         if (pathData.chunk.name && pathData.chunk.name.startsWith('icon-')) {
                             const name = pathData.chunk.name.replace(/^icon-/, '');
-                            return `icons/${name}.min.js?ver=${version}`;
+                            return `icons/${name}.js?ver=${version}`;
                         }
-                        return `lazy-chunks/[name].min.js?ver=${version}`;
+                        return `lazy-chunks/[name].js?ver=${version}`;
                     },
                     clean: true,
                 },


### PR DESCRIPTION
https://translate.wordpress.org/ does not include text in js files has .min extension. 