### PR TITLE
Add clear_all_url to Q&A filters and update link

### DIFF
--- a/views/elements/list-filters.php
+++ b/views/elements/list-filters.php
@@ -159,7 +159,7 @@ if ( isset( $data ) ) : ?>
 
 			<?php if ( $filters_count > 0 || strlen( $search_query ) > 0 ) : ?>
 			<div class="tutor-d-flex tutor-flex-wrap tutor-align-center tutor-justify-end tutor-gap-1">
-				<a class="tutor-color-subdued tutor-px-8 tutor-py-4" href="<?php echo esc_url( $url ); ?>">
+				<a class="tutor-color-subdued tutor-px-8 tutor-py-4" href="<?php echo esc_url( ! empty( $data['clear_all_url'] ) ? $data['clear_all_url'] : $url ); ?>">
 					<?php esc_html_e( 'Clear All', 'tutor' ); ?>
 				</a>
 

--- a/views/pages/question_answer.php
+++ b/views/pages/question_answer.php
@@ -34,11 +34,14 @@ $qna            = $qna_object->get_items( $_GET );
 $qna_list       = $qna['items'];
 $qna_pagination = $qna['pagination'];
 
+$current_page = Input::get( 'page', '', Input::TYPE_STRING );
+
 $filters = array(
-	'bulk_action'  => true,
-	'bulk_actions' => $qna_object->get_bulk_actions(),
-	'ajax_action'  => 'tutor_qna_bulk_action',
-	'filters'      => array(
+	'bulk_action'   => true,
+	'bulk_actions'  => $qna_object->get_bulk_actions(),
+	'ajax_action'   => 'tutor_qna_bulk_action',
+	'clear_all_url' => "?page=$current_page",
+	'filters'       => array(
 		array(
 			'label'      => __( 'Courses', 'tutor' ),
 			'field_type' => 'select',


### PR DESCRIPTION
Introduces a 'clear_all_url' parameter to the question_answer page filters and updates the 'Clear All' link in list-filters.php to use it if available. This ensures the clear action redirects to the correct page context.