### PR TITLE
✨ feat: Enhance FocusTrap and Modal components with blur control props

### DIFF
--- a/assets/react/v3/shared/components/FocusTrap.tsx
+++ b/assets/react/v3/shared/components/FocusTrap.tsx
@@ -1,6 +1,11 @@
 import { Children, cloneElement, useEffect, useRef, type ReactElement, type ReactNode } from 'react';
 
-const FocusTrap = ({ children }: { children: ReactNode }) => {
+interface FocusTrapProps {
+  children: ReactNode;
+  blurPrevious?: boolean;
+}
+
+const FocusTrap = ({ children, blurPrevious = false }: FocusTrapProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
 
@@ -13,7 +18,7 @@ const FocusTrap = ({ children }: { children: ReactNode }) => {
 
     previousActiveElementRef.current = document.activeElement as HTMLElement;
 
-    if (previousActiveElementRef.current && previousActiveElementRef.current !== document.body) {
+    if (blurPrevious && previousActiveElementRef.current && previousActiveElementRef.current !== document.body) {
       previousActiveElementRef.current.blur();
     }
 

--- a/assets/react/v3/shared/components/fields/quiz/FormQuestionTitle.tsx
+++ b/assets/react/v3/shared/components/fields/quiz/FormQuestionTitle.tsx
@@ -178,7 +178,11 @@ const FormQuestionTitle = ({
                   {...additionalAttributes}
                   className="tutor-input-field"
                   rows={2}
-                  ref={inputRef}
+                  ref={(element) => {
+                    field.ref(element);
+                    // @ts-ignore
+                    inputRef.current = element; // this is not ideal but it is the only way to set ref to the input element
+                  }}
                   value={inputValue}
                   placeholder={placeholder}
                   onChange={(event) => {

--- a/assets/react/v3/shared/components/modals/BasicModalWrapper.tsx
+++ b/assets/react/v3/shared/components/modals/BasicModalWrapper.tsx
@@ -39,7 +39,7 @@ const BasicModalWrapper = ({
   modalStyle,
   maxWidth = modal.BASIC_MODAL_MAX_WIDTH,
   isCloseAble = true,
-  blurTriggerElement: blurTrigger = true,
+  blurTriggerElement = true,
 }: BasicModalWrapperProps) => {
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -50,7 +50,7 @@ const BasicModalWrapper = ({
   }, []);
 
   return (
-    <FocusTrap blurPrevious={blurTrigger}>
+    <FocusTrap blurPrevious={blurTriggerElement}>
       <div
         css={[styles.container({ isFullScreen: fullScreen }), modalStyle]}
         style={{

--- a/assets/react/v3/shared/components/modals/BasicModalWrapper.tsx
+++ b/assets/react/v3/shared/components/modals/BasicModalWrapper.tsx
@@ -24,6 +24,7 @@ interface BasicModalWrapperProps {
   modalStyle?: SerializedStyles;
   maxWidth?: number;
   isCloseAble?: boolean;
+  blurTriggerElement?: boolean;
 }
 
 const BasicModalWrapper = ({
@@ -38,6 +39,7 @@ const BasicModalWrapper = ({
   modalStyle,
   maxWidth = modal.BASIC_MODAL_MAX_WIDTH,
   isCloseAble = true,
+  blurTriggerElement: blurTrigger = true,
 }: BasicModalWrapperProps) => {
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -48,7 +50,7 @@ const BasicModalWrapper = ({
   }, []);
 
   return (
-    <FocusTrap>
+    <FocusTrap blurPrevious={blurTrigger}>
       <div
         css={[styles.container({ isFullScreen: fullScreen }), modalStyle]}
         style={{

--- a/assets/react/v3/shared/components/modals/ModalWrapper.tsx
+++ b/assets/react/v3/shared/components/modals/ModalWrapper.tsx
@@ -22,6 +22,7 @@ interface ModalWrapperProps {
   headerChildren?: React.ReactNode;
   entireHeader?: React.ReactNode;
   maxWidth?: number;
+  blurTriggerElement?: boolean;
 }
 
 const ModalWrapper = ({
@@ -34,6 +35,7 @@ const ModalWrapper = ({
   entireHeader,
   actions,
   maxWidth = 1218,
+  blurTriggerElement: blurTrigger = true,
 }: ModalWrapperProps) => {
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -44,7 +46,7 @@ const ModalWrapper = ({
   }, []);
 
   return (
-    <FocusTrap>
+    <FocusTrap blurPrevious={blurTrigger}>
       <div
         css={styles.container({
           maxWidth,

--- a/assets/react/v3/shared/components/modals/ModalWrapper.tsx
+++ b/assets/react/v3/shared/components/modals/ModalWrapper.tsx
@@ -35,7 +35,7 @@ const ModalWrapper = ({
   entireHeader,
   actions,
   maxWidth = 1218,
-  blurTriggerElement: blurTrigger = true,
+  blurTriggerElement = true,
 }: ModalWrapperProps) => {
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -46,7 +46,7 @@ const ModalWrapper = ({
   }, []);
 
   return (
-    <FocusTrap blurPrevious={blurTrigger}>
+    <FocusTrap blurPrevious={blurTriggerElement}>
       <div
         css={styles.container({
           maxWidth,


### PR DESCRIPTION
Add `blurPrevious` prop to `FocusTrap` for controlling previous element blurring. Update `FormQuestionTitle` ref handling for input elements. Introduce `blurTriggerElement` prop in `BasicModalWrapper` and `ModalWrapper` to manage `FocusTrap` behavior.