### PR TITLE
🛠️ Refactor disableExportButton logic in ExportModal

### DIFF
--- a/assets/react/v3/entries/import-export/components/modals/ExportModal.tsx
+++ b/assets/react/v3/entries/import-export/components/modals/ExportModal.tsx
@@ -272,10 +272,6 @@ const ExportModal = ({
   };
 
   const disableExportButton = () => {
-    if (collection?.ID) {
-      return bulkSelectionForm.getValues('content_bank').length === 0;
-    }
-
     return !Object.entries(form.getValues()).some(([key, value]) => {
       if (!key.includes('__')) {
         return value === true;


### PR DESCRIPTION
Simplify the logic in the disableExportButton function by removing an unnecessary condition related to the collection ID.