### PR TITLE
✨ Refactor Tooltip to include zIndex prop for improved layering control

### DIFF
--- a/assets/react/v3/shared/atoms/Tooltip.tsx
+++ b/assets/react/v3/shared/atoms/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { borderRadius, colorTokens, fontSize, lineHeight, spacing } from '@TutorShared/config/styles';
+import { borderRadius, colorTokens, fontSize, lineHeight, spacing, zIndex } from '@TutorShared/config/styles';
 import { AnimatedDiv } from '@TutorShared/hooks/useAnimation';
 import type { AnyObject } from '@TutorShared/utils/form';
 import { css } from '@emotion/react';
@@ -69,6 +69,7 @@ const Tooltip = ({
       hideOnClick={hideOnClick}
       placement={placement}
       visible={visible}
+      zIndex={zIndex.highest}
     >
       <div>{children}</div>
     </Tippy>


### PR DESCRIPTION
Add a zIndex prop to the Tooltip component to enhance control over its layering in the UI.