### PR TITLE
Hook: New filter hook to check if user can complete course

### DIFF
--- a/classes/Course.php
+++ b/classes/Course.php
@@ -2095,6 +2095,9 @@ class Course extends Tutor_Base {
 	 * Mark complete completed
 	 *
 	 * @since 1.0.0
+	 *
+	 * @since 3.7.1 Filter hook: tutor_user_can_complete_course added
+	 *
 	 * @return void
 	 */
 	public function mark_course_complete() {
@@ -2103,6 +2106,8 @@ class Course extends Tutor_Base {
 		if ( 'tutor_complete_course' !== $tutor_action || ! $course_id ) {
 			return;
 		}
+
+		$permalink = get_the_permalink( $course_id );
 
 		// Checking nonce.
 		tutor_utils()->checking_nonce();
@@ -2114,15 +2119,22 @@ class Course extends Tutor_Base {
 			die( esc_html__( 'Please Sign-In', 'tutor' ) );
 		}
 
-		CourseModel::mark_course_as_completed( $course_id, $user_id );
+		/**
+		 * Filter hook provided to restrict course completion. This is useful
+		 * for specific cases like prerequisites. WP_Error should be returned
+		 * from the filter value to prevent the completion.
+		 */
+		$can_complete = apply_filters( 'tutor_user_can_complete_course', null, $user_id, $course_id );
+		if ( ! is_null( $can_complete ) && is_wp_error( $can_complete ) ) {
+			tutor_utils()->redirect_to( $permalink, $can_complete->get_error_message(), 'error' );
+		} else {
+			CourseModel::mark_course_as_completed( $course_id, $user_id );
+			// Set temporary identifier to show review pop up.
+			self::set_review_popup_data( $user_id, $course_id, $permalink );
 
-		$permalink = get_the_permalink( $course_id );
-
-		// Set temporary identifier to show review pop up.
-		self::set_review_popup_data( $user_id, $course_id, $permalink );
-
-		wp_safe_redirect( $permalink );
-		exit;
+			wp_safe_redirect( $permalink );
+			exit;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This hook added to prevent the user to complete the course. If the hook return `wp_error` then the error message will be shown as toast message.