### PR TITLE
🔧 Refactor endpoint name from SYNC_FROM_COURSES to IMPORT_FROM_COURSES

### DIFF
--- a/assets/react/v3/shared/services/import-export.ts
+++ b/assets/react/v3/shared/services/import-export.ts
@@ -23,7 +23,7 @@ export interface ExportableContent {
 
 interface ExportableContentParams {
   course_ids?: number[];
-  context?: 'content-bank';
+  context?: 'content_bank';
 }
 
 const getExportableContent = ({ course_ids, context }: ExportableContentParams) => {

--- a/assets/react/v3/shared/utils/endpoints.ts
+++ b/assets/react/v3/shared/utils/endpoints.ts
@@ -150,7 +150,7 @@ const endpoints = {
   DUPLICATE_CONTENT_BANK_CONTENT: 'tutor_content_bank_content_duplicate',
   MOVE_CONTENT_BANK_CONTENT: 'tutor_content_bank_content_move',
   DUPLICATE_CONTENT_BANK_COLLECTION: 'tutor_content_bank_collection_duplicate',
-  SYNC_FROM_COURSES: 'tutor_content_bank_content_synchronize',
+  IMPORT_FROM_COURSES: 'tutor_content_bank_content_synchronize',
 } as const;
 
 export default endpoints;


### PR DESCRIPTION
Rename the endpoint for clarity and update the context parameter to use an underscore instead of a hyphen.