### PR TITLE
🛠️ Improve slug generation function for better input handling and character support

### DIFF
--- a/assets/react/v3/shared/utils/util.ts
+++ b/assets/react/v3/shared/utils/util.ts
@@ -410,6 +410,7 @@ export const convertToSlug = (value: string): string => {
       .normalize('NFKD') // Normalize accented characters into base forms + diacritics
       .replace(/[\u0300-\u036f]/g, '') // Remove combining diacritical marks
       .toLowerCase()
+      // Remove special characters !~@#$%^&*(){}[]|\;:"',./?
       // Remove characters that are NOT:
       // - Basic Latin letters and numbers (a-z, 0-9)
       // - Spaces and hyphens


### PR DESCRIPTION
Enhance the `convertToSlug` function to handle invalid inputs and support additional Hangul characters, improving overall slug generation robustness.

For context:
During slug generation for course URLs, we observed inconsistent handling of non-Latin characters, particularly for Korean and Japanese titles. In tests: Korean-only examples (completely removed): 1. “캔바 강의” → Slug becomes: (empty) 2. “썸네일 디자인 2025” → Slug becomes: 2025. Japanese-only examples (partially preserved or removed): 1. “サムネイル講座” → Slug becomes: 講座 2. “デザイン講義2025” → Slug becomes: 講義2025. It appears that Korean Hangul is entirely stripped during slug generation, while Japanese Kanji characters are partially retained, but Katakana and Hiragana are often removed.