### PR TITLE
Add new course icon to icon set

### DIFF
--- a/assets/icons/course.svg
+++ b/assets/icons/course.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 5C6 3.89543 6.89543 3 8 3H17C18.1046 3 19 3.89543 19 5V12H6V5Z" fill="transparent"/>
+<path d="M6 5C6 3.89543 6.89543 3 8 3H17C18.1046 3 19 3.89543 19 5V19C19 20.1046 18.1046 21 17 21H8C6.89543 21 6 20.1046 6 19V5Z" fill="transparent"/>
+<path d="M19 5V12H6V5M19 5C19 3.89543 18.1046 3 17 3H8C6.89543 3 6 3.89543 6 5M19 5V19C19 20.1046 18.1046 21 17 21H8C6.89543 21 6 20.1046 6 19V5M8 14H15.5M8 16H12" stroke="white" stroke-linecap="round" fill="none"/>
+</svg>

--- a/assets/react/v3/shared/icons/types.ts
+++ b/assets/react/v3/shared/icons/types.ts
@@ -51,6 +51,7 @@ export const icons = [
   'copy',
   'copyPaste',
   'coupon',
+  'course',
   'cross',
   'crossCircle',
   'crown',

--- a/classes/Icon.php
+++ b/classes/Icon.php
@@ -67,6 +67,7 @@ final class Icon {
 	const COPY                       = 'copy';
 	const COPY_PASTE                 = 'copy-paste';
 	const COUPON                     = 'coupon';
+	const COURSE                     = 'course';
 	const CROSS                      = 'cross';
 	const CROSS_CIRCLE               = 'cross-circle';
 	const CROWN                      = 'crown';


### PR DESCRIPTION
Introduced a new 'course' SVG icon, registered it in the TypeScript icon list and the Icon PHP class. This allows the course icon to be used throughout the application where icons are referenced.