### PR TITLE
🔧 Disable caching in base configuration

### DIFF
--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -61,6 +61,7 @@ const createConfig = (env, options) => {
 
   const baseConfig = {
     mode,
+    cache: false,
     module: {
       rules: [
         {


### PR DESCRIPTION
Disable caching in the base configuration to ensure fresh builds without stored data.