### PR TITLE
Fix: Normalize the case of the authorization header to Authorization in tutor_getallheaders()

### DIFF
--- a/includes/tutor-general-functions.php
+++ b/includes/tutor-general-functions.php
@@ -1240,6 +1240,16 @@ if ( ! function_exists( 'tutor_getallheaders' ) ) {
 			}
 		}
 
+		if ( ! isset( $headers['Authorization'] ) ) {
+			foreach ( $headers as $name => $value ) {
+				if ( strtolower( $name ) === 'authorization' ) {
+					unset( $headers[$name] );
+					$headers['Authorization'] = $value;
+					break;
+				}
+			}
+		}
+
 		return $headers;
 	}
 }

--- a/restapi/RestAuth.php
+++ b/restapi/RestAuth.php
@@ -303,7 +303,7 @@ class RestAuth {
 	 * @return boolean
 	 */
 	public static function process_api_request() {
-		$headers = apache_request_headers();
+		$headers = tutor_getallheaders();
 
 		if ( isset( $headers['Authorization'] ) ) {
 			$authorization_header = $headers['Authorization'];


### PR DESCRIPTION
Fixes #2063

Normalizes any `authorization` header to `Authorization` in `tutor_getallheaders()` and changes `RestAuth.process_api_request` to use this function. This should resolve the case sensitivity issue for this header in both tutor and tutor-pro (which uses this `tutor_getallheaders()` function).
