### PR TITLE
✨ Enhance Button component with icon-only support and accessibility improvements

### DIFF
--- a/assets/react/v3/entries/import-export/components/modals/CollectionList/CollectionListTable.tsx
+++ b/assets/react/v3/entries/import-export/components/modals/CollectionList/CollectionListTable.tsx
@@ -193,6 +193,7 @@ const CollectionListTable = ({ form }: CourseListTableProps) => {
         },
       },
     ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       areAllItemsSelected,
       fetchedItems.length,

--- a/assets/react/v3/shared/atoms/Button.tsx
+++ b/assets/react/v3/shared/atoms/Button.tsx
@@ -283,6 +283,7 @@ const styles = {
       &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
+          color: ${colorTokens.text.white};
           background-color: ${colorTokens.action.primary.hover};
         }
         &:active {
@@ -355,6 +356,7 @@ const styles = {
         &:focus,
         &:active {
           background-color: ${colorTokens.background.status.errorFail};
+          color: ${colorTokens.text.error};
         }
       }
     `,
@@ -366,6 +368,7 @@ const styles = {
         &:hover,
         &:focus {
           background-color: ${colorTokens.action.primary.wp_hover};
+          color: ${colorTokens.text.white};
         }
         &:active {
           background-color: ${colorTokens.action.primary.wp};

--- a/assets/react/v3/shared/atoms/Button.tsx
+++ b/assets/react/v3/shared/atoms/Button.tsx
@@ -1,11 +1,11 @@
-import { type SerializedStyles, css, keyframes } from '@emotion/react';
+import { css, keyframes, type SerializedStyles } from '@emotion/react';
 import React, { type ReactNode } from 'react';
 
 import SVGIcon from '@TutorShared/atoms/SVGIcon';
 
 import { borderRadius, colorTokens, shadow, spacing, zIndex } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
-import { createVariation } from '@TutorShared/utils/create-variation';
+import { createVariation, type VariantProps } from '@TutorShared/utils/create-variation';
 import { styleUtils } from '@TutorShared/utils/style-utils';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'text' | 'WP';
@@ -13,7 +13,7 @@ export type ButtonSize = 'large' | 'regular' | 'small';
 export type ButtonIconPosition = 'left' | 'right';
 
 // Base props that are common to both button and anchor elements
-interface BaseButtonProps {
+interface BaseButtonProps extends VariantProps<typeof buttonVariants> {
   variant?: ButtonVariant;
   isOutlined?: boolean;
   size?: ButtonSize;
@@ -24,10 +24,6 @@ interface BaseButtonProps {
   buttonCss?: SerializedStyles;
   buttonContentCss?: SerializedStyles;
   id?: string;
-  'aria-label'?: string;
-  'aria-describedby'?: string;
-  'aria-expanded'?: boolean;
-  'aria-pressed'?: boolean;
 }
 
 // Props for regular buttons with children
@@ -47,7 +43,7 @@ interface IconOnlyButtonProps extends BaseButtonProps {
 }
 
 // Button element specific props
-interface ButtonElementProps {
+interface ButtonElementProps extends React.HTMLAttributes<HTMLButtonElement> {
   as?: 'button';
   type?: 'submit' | 'button' | 'reset';
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -62,7 +58,7 @@ interface ButtonElementProps {
 }
 
 // Anchor element specific props
-interface AnchorElementProps {
+interface AnchorElementProps extends React.HTMLAttributes<HTMLAnchorElement> {
   as: 'a';
   href: string;
   target?: '_blank' | '_self' | '_parent' | '_top';
@@ -108,7 +104,7 @@ const Button = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPro
       outlined: isOutlined ? variant : 'none',
       size,
       isLoading: loading ? 'true' : 'false',
-      isIconOnly: isIconOnly ? 'true' : 'false',
+      iconOnly: isIconOnly ? 'true' : 'false',
     }),
     buttonCss,
   ];
@@ -617,7 +613,7 @@ const buttonVariants = createVariation(
         true: styles.isLoading.true,
         false: styles.isLoading.false,
       },
-      isIconOnly: {
+      iconOnly: {
         true: styles.isIconOnly.true,
         false: styles.isIconOnly.false,
       },
@@ -644,7 +640,7 @@ const buttonVariants = createVariation(
       outlined: 'none',
       size: 'regular',
       isLoading: 'false',
-      isIconOnly: 'false',
+      iconOnly: 'false',
     },
   },
   styles.base,

--- a/assets/react/v3/shared/atoms/Button.tsx
+++ b/assets/react/v3/shared/atoms/Button.tsx
@@ -5,66 +5,116 @@ import SVGIcon from '@TutorShared/atoms/SVGIcon';
 
 import { borderRadius, colorTokens, shadow, spacing, zIndex } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
-import { type VariantProps, createVariation } from '@TutorShared/utils/create-variation';
+import { createVariation } from '@TutorShared/utils/create-variation';
 import { styleUtils } from '@TutorShared/utils/style-utils';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'text' | 'WP';
 export type ButtonSize = 'large' | 'regular' | 'small';
 export type ButtonIconPosition = 'left' | 'right';
 
-interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
-  children?: ReactNode;
+// Base props that are common to both button and anchor elements
+interface BaseButtonProps {
   variant?: ButtonVariant;
   isOutlined?: boolean;
-  type?: 'submit' | 'button';
   size?: ButtonSize;
-  icon?: React.ReactNode;
   iconPosition?: ButtonIconPosition;
   disabled?: boolean;
   loading?: boolean;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   tabIndex?: number;
   buttonCss?: SerializedStyles;
   buttonContentCss?: SerializedStyles;
+  id?: string;
+  'aria-label'?: string;
+  'aria-describedby'?: string;
+  'aria-expanded'?: boolean;
+  'aria-pressed'?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      variant = 'primary',
-      isOutlined = false,
-      size = 'regular',
-      loading = false,
-      children,
-      type = 'button',
-      disabled = false,
-      icon,
-      iconPosition = 'left',
-      buttonCss,
-      buttonContentCss,
-      onClick,
-      tabIndex,
-      ...props
-    },
-    ref,
-  ) => (
-    <button
-      type={type}
-      ref={ref}
-      css={[
-        buttonVariants({
-          variant,
-          outlined: isOutlined ? variant : 'none',
-          size,
-          isLoading: loading ? 'true' : 'false',
-        }),
-        buttonCss,
-      ]}
-      disabled={disabled || loading}
-      onClick={onClick}
-      tabIndex={tabIndex}
-      {...props}
-    >
+// Props for regular buttons with children
+interface RegularButtonProps extends BaseButtonProps {
+  isIconOnly?: false;
+  children: ReactNode;
+  icon?: React.ReactNode;
+}
+
+// Props for icon-only buttons
+interface IconOnlyButtonProps extends BaseButtonProps {
+  isIconOnly: true;
+  children?: never; // TypeScript will error if children is provided
+  iconPosition?: never; // Icon position is not applicable for icon-only buttons
+  icon: React.ReactNode; // Icon is required
+  'aria-label': string; // aria-label is required for accessibility
+}
+
+// Button element specific props
+interface ButtonElementProps {
+  as?: 'button';
+  type?: 'submit' | 'button' | 'reset';
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  form?: string;
+  name?: string;
+  value?: string;
+  // Explicitly forbid anchor-specific props
+  href?: never;
+  target?: never;
+  rel?: never;
+  download?: never;
+}
+
+// Anchor element specific props
+interface AnchorElementProps {
+  as: 'a';
+  href: string;
+  target?: '_blank' | '_self' | '_parent' | '_top';
+  rel?: string;
+  download?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  // Explicitly forbid button-specific props
+  type?: never;
+  form?: never;
+  name?: never;
+  value?: never;
+}
+
+// Combine content props with element props
+type ButtonWithRegularContent = (RegularButtonProps & ButtonElementProps) | (RegularButtonProps & AnchorElementProps);
+type ButtonWithIconOnlyContent =
+  | (IconOnlyButtonProps & ButtonElementProps)
+  | (IconOnlyButtonProps & AnchorElementProps);
+
+export type ButtonProps = ButtonWithRegularContent | ButtonWithIconOnlyContent;
+
+const Button = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>((props, ref) => {
+  const {
+    variant = 'primary',
+    isOutlined = false,
+    size = 'regular',
+    loading = false,
+    children,
+    disabled = false,
+    icon,
+    iconPosition = 'left',
+    buttonCss,
+    buttonContentCss,
+    as = 'button',
+    tabIndex,
+    isIconOnly = false,
+    ...restProps
+  } = props;
+
+  const baseStyles = [
+    buttonVariants({
+      variant,
+      outlined: isOutlined ? variant : 'none',
+      size,
+      isLoading: loading ? 'true' : 'false',
+      isIconOnly: isIconOnly ? 'true' : 'false',
+    }),
+    buttonCss,
+  ];
+
+  const content = (
+    <>
       {loading && !disabled && (
         <span css={styles.spinner}>
           <SVGIcon name="spinner" width={18} height={18} />
@@ -79,9 +129,66 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           <span css={styles.buttonIcon({ iconPosition, loading, hasChildren: !!children })}>{icon}</span>
         )}
       </span>
+    </>
+  );
+
+  if (as === 'a') {
+    const { href, target, rel, download, onClick, ...anchorProps } = restProps as Omit<
+      AnchorElementProps,
+      keyof BaseButtonProps | 'as'
+    >;
+
+    // Auto-add security attributes for external links
+    const isExternalLink = typeof href === 'string' && (href.startsWith('http') || href.startsWith('//'));
+    const finalRel = target === '_blank' && isExternalLink ? `${rel ? `${rel} ` : ''}noopener noreferrer` : rel;
+
+    return (
+      <a
+        ref={ref as React.ForwardedRef<HTMLAnchorElement>}
+        css={baseStyles}
+        href={disabled || loading ? undefined : href}
+        target={disabled || loading ? undefined : target}
+        rel={finalRel}
+        download={disabled || loading ? undefined : download}
+        tabIndex={disabled || loading ? -1 : tabIndex}
+        aria-disabled={disabled || loading}
+        onClick={disabled || loading ? (e) => e.preventDefault() : onClick}
+        role="button"
+        data-size={size}
+        {...anchorProps}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  const {
+    type = 'button',
+    onClick,
+    form,
+    name,
+    value,
+    ...buttonProps
+  } = restProps as Omit<ButtonElementProps, keyof BaseButtonProps | 'as'>;
+
+  return (
+    <button
+      ref={ref as React.ForwardedRef<HTMLButtonElement>}
+      type={type}
+      css={baseStyles}
+      disabled={disabled || loading}
+      tabIndex={tabIndex}
+      onClick={onClick}
+      form={form}
+      name={name}
+      value={value}
+      data-size={size}
+      {...buttonProps}
+    >
+      {content}
     </button>
-  ),
-);
+  );
+});
 
 Button.displayName = 'Button';
 
@@ -99,7 +206,8 @@ const spin = keyframes`
 
 const disabledStyles = {
   notOutlined: css`
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       background-color: ${colorTokens.action.primary.disable};
       color: ${colorTokens.text.disable};
       svg {
@@ -108,7 +216,8 @@ const disabledStyles = {
     }
   `,
   outlined: css`
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       background-color: transparent;
       border: none;
       box-shadow: inset 0px 0px 0px 1px ${colorTokens.action.outline.disable};
@@ -119,7 +228,8 @@ const disabledStyles = {
     }
   `,
   text: css`
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       color: ${colorTokens.text.disable};
       svg {
         color: ${colorTokens.icon.disable.default};
@@ -152,18 +262,21 @@ const styles = {
       color: ${colorTokens.icon.white};
     }
 
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       cursor: not-allowed;
     }
 
-    &:focus {
-      box-shadow: ${shadow.focus};
-    }
+    &:not(:disabled):not([aria-disabled='true']) {
+      &:focus {
+        box-shadow: ${shadow.focus};
+      }
 
-    &:focus-visible {
-      box-shadow: none;
-      outline: 2px solid ${colorTokens.stroke.brand};
-      outline-offset: 1px;
+      &:focus-visible {
+        box-shadow: none;
+        outline: 2px solid ${colorTokens.stroke.brand};
+        outline-offset: 1px;
+      }
     }
   `,
   variant: {
@@ -171,7 +284,7 @@ const styles = {
       background-color: ${colorTokens.action.primary.default};
       ${disabledStyles.notOutlined};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           background-color: ${colorTokens.action.primary.hover};
@@ -193,7 +306,7 @@ const styles = {
       }
       ${disabledStyles.notOutlined};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           background-color: ${colorTokens.action.secondary.hover};
@@ -213,7 +326,7 @@ const styles = {
       }
       ${disabledStyles.outlined};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           background-color: ${colorTokens.background.hover};
@@ -241,7 +354,7 @@ const styles = {
       }
       ${disabledStyles.notOutlined};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus,
         &:active {
@@ -253,7 +366,7 @@ const styles = {
       background-color: ${colorTokens.action.primary.wp};
       ${disabledStyles.notOutlined};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           background-color: ${colorTokens.action.primary.wp_hover};
@@ -272,7 +385,7 @@ const styles = {
       }
       ${disabledStyles.text};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           background-color: transparent;
@@ -300,7 +413,7 @@ const styles = {
       }
       ${disabledStyles.outlined};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           color: ${colorTokens.text.white};
@@ -320,7 +433,7 @@ const styles = {
       }
       ${disabledStyles.outlined};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           background-color: ${colorTokens.action.secondary.hover};
@@ -336,7 +449,7 @@ const styles = {
       border: 1px solid ${colorTokens.stroke.danger};
       ${disabledStyles.outlined};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           background-color: ${colorTokens.background.status.errorFail};
@@ -352,7 +465,7 @@ const styles = {
       }
       ${disabledStyles.outlined};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           background-color: ${colorTokens.action.primary.wp_hover};
@@ -370,7 +483,7 @@ const styles = {
       color: ${colorTokens.text.primary};
       ${disabledStyles.text};
 
-      &:not(:disabled) {
+      &:not(:disabled):not([aria-disabled='true']) {
         &:hover,
         &:focus {
           color: ${colorTokens.text.brand};
@@ -384,17 +497,38 @@ const styles = {
       padding: ${spacing[8]} ${spacing[32]};
       ${typography.caption('medium')};
       color: ${colorTokens.text.white};
+      min-height: 40px;
     `,
     large: css`
       padding: ${spacing[12]} ${spacing[40]};
       ${typography.body('medium')};
       color: ${colorTokens.text.white};
+      min-height: 48px;
     `,
     small: css`
       padding: ${spacing[6]} ${spacing[16]};
       ${typography.small('medium')};
       color: ${colorTokens.text.white};
+      min-height: 32px;
     `,
+  },
+  isIconOnly: {
+    true: css`
+      aspect-ratio: 1 / 1;
+      &[data-size='regular'] {
+        padding: ${spacing[8]};
+        width: 40px;
+      }
+      &[data-size='large'] {
+        padding: ${spacing[12]};
+        width: 48px;
+      }
+      &[data-size='small'] {
+        padding: ${spacing[6]};
+        width: 32px;
+      }
+    `,
+    false: css``,
   },
   isLoading: {
     true: css`
@@ -411,9 +545,18 @@ const styles = {
       order: 1;
     `,
   },
-  buttonContent: ({ loading, disabled }: { loading: boolean; disabled: boolean }) => css`
+  buttonContent: ({
+    loading,
+    disabled,
+    isIconOnly,
+  }: {
+    loading: boolean;
+    disabled: boolean;
+    isIconOnly?: boolean;
+  }) => css`
     ${styleUtils.display.flex()};
     align-items: center;
+    ${isIconOnly && 'justify-content: center;'}
 
     ${loading &&
     !disabled &&
@@ -474,6 +617,10 @@ const buttonVariants = createVariation(
         true: styles.isLoading.true,
         false: styles.isLoading.false,
       },
+      isIconOnly: {
+        true: styles.isIconOnly.true,
+        false: styles.isIconOnly.false,
+      },
       variant: {
         primary: styles.variant.primary,
         secondary: styles.variant.secondary,
@@ -497,6 +644,7 @@ const buttonVariants = createVariation(
       outlined: 'none',
       size: 'regular',
       isLoading: 'false',
+      isIconOnly: 'false',
     },
   },
   styles.base,

--- a/assets/react/v3/shared/components/FocusTrap.tsx
+++ b/assets/react/v3/shared/components/FocusTrap.tsx
@@ -89,6 +89,7 @@ const FocusTrap = ({ children, blurPrevious = false }: FocusTrapProps) => {
         previousActiveElementRef.current.focus();
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return cloneElement(Children.only(children) as ReactElement, {

--- a/stories/atoms/Button.stories.tsx
+++ b/stories/atoms/Button.stories.tsx
@@ -3,6 +3,7 @@ import Button from '@TutorShared/atoms/Button';
 import SVGIcon from '@TutorShared/atoms/SVGIcon';
 import { type IconCollection, icons } from '@TutorShared/icons/types';
 import type { Meta, StoryObj } from 'storybook-react-rsbuild';
+import { expect, within } from 'storybook/test';
 
 const meta = {
   title: 'Atoms/Button',
@@ -26,6 +27,10 @@ const meta = {
       control: 'boolean',
       description: 'If true, renders the outlined style for the variant.',
     },
+    isIconOnly: {
+      control: 'boolean',
+      description: 'If true, renders the button as an icon-only button.',
+    },
     size: {
       control: 'select',
       options: ['large', 'regular', 'small'],
@@ -48,12 +53,13 @@ const meta = {
       control: 'radio',
       options: ['left', 'right'],
       description: 'Position of the icon.',
+      if: { arg: 'isIconOnly', eq: false },
     },
     children: {
       control: 'text',
       description: 'Button content.',
     },
-    onClick: { action: 'clicked', description: 'Click handler.' },
+    onClick: { control: false, action: 'clicked', description: 'Click handler.' },
     tabIndex: {
       control: 'number',
       description: 'Tab index for accessibility.',
@@ -66,6 +72,32 @@ const meta = {
       control: false,
       table: { disable: true },
     },
+    as: {
+      control: 'select',
+      options: ['button', 'a'],
+      description: 'The HTML element to use.',
+    },
+    href: {
+      control: 'text',
+      description: 'Href for anchor element (required if as="a").',
+      if: { arg: 'as', eq: 'a' },
+    },
+    target: {
+      control: 'select',
+      options: ['_blank', '_self', '_parent', '_top'],
+      description: 'Target for anchor element.',
+      if: { arg: 'as', eq: 'a' },
+    },
+    rel: {
+      control: 'text',
+      description: 'Rel for anchor element.',
+      if: { arg: 'as', eq: 'a' },
+    },
+    download: {
+      control: 'text',
+      description: 'Download attribute for anchor element.',
+      if: { arg: 'as', eq: 'a' },
+    },
   },
   args: {
     children: 'Button',
@@ -76,7 +108,9 @@ const meta = {
     loading: false,
     icon: undefined,
     iconPosition: 'left',
+    isIconOnly: false,
     tabIndex: 0,
+    as: 'button',
   },
   render: (args) => {
     const { icon, buttonCss, buttonContentCss, ...rest } = args;
@@ -97,6 +131,37 @@ const meta = {
     return (
       <Button {...rest} icon={iconElement} buttonCss={buttonCssStyles} buttonContentCss={buttonContentCssStyles} />
     );
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const buttonLabel = typeof args.children === 'string' ? args.children : '';
+    const button = await canvas.findByRole('button', { name: new RegExp(buttonLabel, 'i') });
+
+    const styles = window.getComputedStyle(button);
+
+    const expectedStats: Record<string, { height: string; fontSize: string }> = {
+      large: {
+        height: '48px',
+        fontSize: '16px',
+      },
+      regular: {
+        height: '40px',
+        fontSize: '15.008px',
+      },
+      small: {
+        height: '32px',
+        fontSize: '13.008px',
+      },
+    };
+
+    if (args.size && expectedStats[args.size]) {
+      expect(styles.height).toBe(expectedStats[args.size].height);
+      expect(styles.fontSize).toBe(expectedStats[args.size].fontSize);
+
+      if (args.isIconOnly) {
+        expect(styles.height).toBe(styles.width);
+      }
+    }
   },
 } satisfies Meta<typeof Button>;
 
@@ -154,6 +219,15 @@ export const Outlined = {
   },
 } satisfies Story;
 
+export const IconOnly = {
+  args: {
+    isIconOnly: true,
+    'aria-label': 'Icon Only Button',
+    icon: 'plus',
+    children: undefined,
+  },
+} satisfies Story;
+
 export const Loading = {
   args: {
     children: 'Loading Button',
@@ -195,5 +269,16 @@ export const Small = {
   args: {
     children: 'Small Button',
     size: 'small',
+  },
+} satisfies Story;
+
+export const AsAnchor = {
+  args: {
+    children: 'Anchor Button',
+    as: 'a',
+    href: 'https://example.com',
+    target: '_blank',
+    rel: 'noopener noreferrer',
+    variant: 'primary',
   },
 } satisfies Story;


### PR DESCRIPTION
✨ New Features & Improvements
- Polymorphic Button/Anchor Support
 	- The Button can now render as either a `<button>` or an `<a>` element, controlled by the as prop. 
	- When `as="a"`, the href prop is required and button-specific props are forbidden. 
	- When as is not `"a"`, anchor-specific props are forbidden.
	- TypeScript enforces these rules, preventing invalid prop combinations at compile time.

- Icon-Only Button Mode (isIconOnly)
	- Added isIconOnly prop to render a button with only an icon, no children. 
	- When isIconOnly is true, `children` is forbidden and `icon` is required (enforced by TypeScript).
	- Requires an aria-label for accessibility in icon-only mode.
	
- Improved Accessibility
	- Uses both `:disabled` and `[aria-disabled="true"]` selectors to ensure correct styling and accessibility for both <button> and <a> elements.
	- Anchor elements use `aria-disabled` and are made non-interactive when disabled.

- Type-Safe Prop Enforcement
	- Discriminated unions and explicit prop exclusions (`href?: never`, etc.) ensure only valid prop combinations are allowed.
	- TypeScript will error if `href` is provided without `as="a"`, or if `as="a"` is provided without href.

- Consistent Styling & Variants
	- Supports multiple `variants`, `outlined` styles, `sizes`, loading state, and icon positions.
	- The `buttonVariants` system now supports the` iconOnly` variant for proper styling of icon-only buttons.

- Cleaner, More Maintainable Code
	- Improved modularity and readability.
	- Early returns and descriptive variable names throughout.
	
	
<img width="2038" height="389" alt="image" src="https://github.com/user-attachments/assets/f12699bd-37c7-456a-ab03-b0b5b94091bf" />
