### PR TITLE
New: query() method added to database query with flexible arguments.

### DIFF
--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -1001,23 +1001,11 @@ class QueryHelper {
 	) {
 		global $wpdb;
 
-		$select_clause = implode( ', ', $select_columns );
-		$from_clause   = self::prepare_table_name( $primary_table );
-
-		$join_clauses = '';
-		foreach ( $joining_tables as $relation ) {
-			$join_table    = self::prepare_table_name( $relation['table'] );
-			$join_clauses .= " {$relation['type']} JOIN {$join_table} ON {$relation['on']}";
-		}
-
-		$where_clause = !empty($where) ? 'WHERE ' . self::build_where_clause($where) : '';
-
-		if ( ! empty( $search ) ) {
-			$search_clause = self::build_like_clause( $search );
-			$where_clause .= !empty($where_clause) ? ' AND (' . $search_clause . ')' : 'WHERE ' . $search_clause;
-		}
-
-		$order_by_clause = !empty($order_by) ? "ORDER BY {$order_by} {$order}" : '';
+		$select_clause   = implode( ', ', $select_columns );
+		$from_clause     = self::prepare_table_name( $primary_table );
+		$join_clauses    = self::build_join_clause( $joining_tables );
+		$where_clause    = self::build_where_search_clause( $where, $search );
+		$order_by_clause = ! empty( $order_by ) ? "ORDER BY {$order_by} {$order}" : '';
 
 		// Query to get total count.
 		$count_query = "

--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -1115,24 +1115,9 @@ class QueryHelper {
 	public static function get_joined_count(string $primary_table, array $joining_tables, array $where = [], array $search = [], string $count_column = '*'): int {
 		global $wpdb;
 		
-		$from_clause = self::prepare_table_name( $primary_table );
-		
-		$join_clauses = '';
-		foreach ($joining_tables as $relation) {
-			$join_table    = self::prepare_table_name( $relation['table'] );
-			$join_clauses .= " {$relation['type']} JOIN {$join_table} ON {$relation['on']}";
-		}
-		
-		$where_clause  = ! empty( $where ) ? 'WHERE ' . self::build_where_clause( $where ) : '';
-		$search_clause = ! empty( $search ) ? self::build_like_clause( $search, 'AND' ) : '';
-
-		if ( ! empty( $search_clause ) ) {
-			if ( ! empty( $where_clause ) ) {
-				$where_clause .= ' AND (' . $search_clause . ')';
-			} else {
-				$where_clause = 'WHERE ' . $search_clause;
-			}
-		}
+		$from_clause  = self::prepare_table_name( $primary_table );
+		$join_clauses = self::build_join_clause( $joining_tables );
+		$where_clause = self::build_where_search_clause( $where, $search, 'AND' );
 
 		$count_query = "
 			SELECT COUNT($count_column) as total_count


### PR DESCRIPTION
We now have a simple and efficient `query()` method that supports every scenario with a variety of clauses, including:
- SELECT
- JOIN
- WHERE
- SEARCH
- GROUP BY
- HAVING
- ORDER BY
- PAGINATION
It can return a full result set, a single row, or just the count.

```php
$args = array();
$results = QueryHelper::query( 'posts', $args );
```