### PR TITLE
Adjust top position of left bar in FormCategoriesInput

### DIFF
--- a/assets/react/v3/shared/components/fields/FormCategoriesInput.tsx
+++ b/assets/react/v3/shared/components/fields/FormCategoriesInput.tsx
@@ -371,7 +371,7 @@ const styles = {
       height: ${leftBarHeight};
       width: 1px;
       left: 9px;
-      top: 26px;
+      top: 25px;
       background-color: ${colorTokens.stroke.divider};
       z-index: ${zIndex.level};
     }


### PR DESCRIPTION
Changed the CSS 'top' property of the left bar from 26px to 25px to improve alignment in the FormCategoriesInput component.

<img width="425" height="97" alt="CleanShot 2025-09-15 at 6  06 49" src="https://github.com/user-attachments/assets/76d7b8a2-be29-4404-8ffb-c2a0a4c3c6d5" />
