### PR TITLE
Fixed multiple issues to `array_avalue_dot` helper

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -328,21 +328,21 @@ class Utils {
 	 * @return array|bool|mixed
 	 */
 	public function avalue_dot( $key = null, $array = array(), $default = false ) {
-		$array = (array) $array;
-		if ( ! $key || ! count( $array ) ) {
+		if ( '' === $key || null === $key || ! $this->count( $array ) ) {
 			return $default;
 		}
-		$option_key_array = explode( '.', $key );
 
+		$keys  = explode( '.', $key );
 		$value = $array;
 
-		foreach ( $option_key_array as $dot_key ) {
+		foreach ( $keys as $dot_key ) {
 			if ( isset( $value[ $dot_key ] ) ) {
 				$value = $value[ $dot_key ];
 			} else {
 				return $default;
 			}
 		}
+
 		return $value;
 	}
 


### PR DESCRIPTION
This PR addresses the below issues and fixed.

### Issues
1. Sequential array zero-index is not accessable.
```php
$arr = array( 100, 300, 400 );
avalue_dot( 0, $arr ); // output: false, it should be 100;
avalue_dot( 1, $arr ); //output: 300 (ok)
avalue_dot( 2, $arr ); //output: 400 (ok)
```
2. Non-array value casting as array and it makes non array value to array
```php
$v = 123;
$v = (array) $v; // output: [ 33 ];
avalue_dot( 0, $v ); // output: 33, it should be false
```