### PR TITLE
Fix Vimeo autoplay sound issue on mobile devices

### DIFF
--- a/assets/react/helper/utils.js
+++ b/assets/react/helper/utils.js
@@ -12,3 +12,7 @@ export async function fetchCountriesData() {
         return [];
     }
 }
+
+export function isMobileDevice() {
+	return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}


### PR DESCRIPTION
Added logic to start Vimeo videos muted on mobile devices to comply with autoplay policies, and automatically unmute after first user interaction. Introduced isMobileDevice utility for device detection.