### PR TITLE
Security Issue Fixes for 3.9.4

### DIFF
--- a/classes/Course.php
+++ b/classes/Course.php
@@ -2999,14 +2999,12 @@ class Course extends Tutor_Base {
 			}
 
 			/**
-			 * This check was added for a security issue
-			 * where users without purchasing a course can
-			 * enroll into the course by ajax call. To fix this
-			 * the following check was added to check if course is
-			 * paid or not. Furthermore, to check if user has already
-			 * purchased the course another check was added to check
-			 * if user is enrolled in course cause default behavior
-			 * for tutor is user is enrolled in course if purchased.
+			 * This check was added to address a security issue where users could
+			 * enroll in a course via an AJAX call without purchasing it.
+			 *
+			 * To prevent this, we now verify whether the course is paid.
+			 * Additionally, we check if the user is already enrolled, since
+			 * Tutor's default behavior enrolls users automatically upon purchase.
 			 *
 			 * @since 3.9.4
 			 */

--- a/classes/Course.php
+++ b/classes/Course.php
@@ -2806,10 +2806,10 @@ class Course extends Tutor_Base {
 					}
 				}
 				if ( ! $has_passed ) {
-					++$required_assignment_pass;
+					$required_assignment_pass++;
 				}
 			} else {
-				++$required_assignment_pass;
+				$required_assignment_pass++;
 			}
 		}
 

--- a/classes/Course.php
+++ b/classes/Course.php
@@ -3011,11 +3011,6 @@ class Course extends Tutor_Base {
 			if ( tutor_utils()->is_course_purchasable( $course_id ) ) {
 				$is_enrolled = (bool) tutor_utils()->is_enrolled( $course_id, $user_id );
 
-				/**
-				 * Check if user has already purchased course.
-				 * By default tutor enrolls user to course if
-				 * purchased that's why this check is given.
-				 */
 				if ( ! $is_enrolled ) {
 					wp_send_json_error( __( 'Please purchase the course before enrolling', 'tutor' ) );
 				}

--- a/classes/Course.php
+++ b/classes/Course.php
@@ -2119,16 +2119,16 @@ class Course extends Tutor_Base {
 			die( esc_html__( 'Please Sign-In', 'tutor' ) );
 		}
 
+		if ( ! tutor_utils()->is_enrolled( $course_id, $user_id ) ) {
+			die( esc_html__( 'User is not enrolled in course', 'tutor' ) );
+		}
+
 		/**
 		 * Filter hook provided to restrict course completion. This is useful
 		 * for specific cases like prerequisites. WP_Error should be returned
 		 * from the filter value to prevent the completion.
 		 */
 		$can_complete = apply_filters( 'tutor_user_can_complete_course', true, $user_id, $course_id );
-
-		if ( ! tutor_utils()->is_enrolled( $course_id, $user_id ) ) {
-			die( esc_html__( 'User is not enrolled in course', 'tutor' ) );
-		}
 
 		if ( is_wp_error( $can_complete ) ) {
 			tutor_utils()->redirect_to( $permalink, $can_complete->get_error_message(), 'error' );
@@ -2992,13 +2992,15 @@ class Course extends Tutor_Base {
 		$course_id = Input::post( 'course_id', 0, Input::TYPE_INT );
 		$user_id   = get_current_user_id();
 
+		$is_enrolled = (bool) tutor_utils()->is_enrolled( $course_id, $user_id );
+
 		if ( $course_id ) {
 			$password_protected = post_password_required( $course_id );
 			if ( $password_protected ) {
 				wp_send_json_error( __( 'This course is password protected', 'tutor' ) );
 			}
 
-			if ( tutor_utils()->is_course_purchasable( $course_id ) ) {
+			if ( tutor_utils()->is_course_purchasable( $course_id ) && ! $is_enrolled ) {
 				wp_send_json_error( __( 'Please purchase the course before enrolling', 'tutor' ) );
 			}
 

--- a/classes/Course.php
+++ b/classes/Course.php
@@ -2125,6 +2125,11 @@ class Course extends Tutor_Base {
 		 * from the filter value to prevent the completion.
 		 */
 		$can_complete = apply_filters( 'tutor_user_can_complete_course', true, $user_id, $course_id );
+
+		if ( ! tutor_utils()->is_enrolled( $course_id, $user_id ) ) {
+			die( esc_html__( 'User is not enrolled in course', 'tutor' ) );
+		}
+
 		if ( is_wp_error( $can_complete ) ) {
 			tutor_utils()->redirect_to( $permalink, $can_complete->get_error_message(), 'error' );
 		} else {
@@ -2801,10 +2806,10 @@ class Course extends Tutor_Base {
 					}
 				}
 				if ( ! $has_passed ) {
-					$required_assignment_pass++;
+					++$required_assignment_pass;
 				}
 			} else {
-				$required_assignment_pass++;
+				++$required_assignment_pass;
 			}
 		}
 
@@ -2992,6 +2997,11 @@ class Course extends Tutor_Base {
 			if ( $password_protected ) {
 				wp_send_json_error( __( 'This course is password protected', 'tutor' ) );
 			}
+
+			if ( tutor_utils()->is_course_purchasable( $course_id ) ) {
+				wp_send_json_error( __( 'Please purchase the course before enrolling', 'tutor' ) );
+			}
+
 			$enroll = tutor_utils()->do_enroll( $course_id, 0, $user_id );
 			if ( $enroll ) {
 				wp_send_json_success( __( 'Enrollment successfully done!', 'tutor' ) );

--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -283,6 +283,12 @@ class Quiz {
 		$attempt_details = self::attempt_details( Input::post( 'attempt_id', 0, Input::TYPE_INT ) );
 		$feedback        = Input::post( 'feedback', '', Input::TYPE_KSES_POST );
 		$attempt_info    = isset( $attempt_details->attempt_info ) ? $attempt_details->attempt_info : false;
+		$course_id       = tutor_utils()->avalue_dot( 'course_id', $attempt_info, 0 );
+
+		if ( ! tutor_utils()->is_instructor_of_this_course( get_current_user_id(), $course_id ) ) {
+			wp_send_json_error( tutor_utils()->error_message() );
+		}
+
 		if ( $attempt_info ) {
 			//phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
 			$unserialized = unserialize( $attempt_details->attempt_info );

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -577,10 +577,7 @@ class CouponController extends BaseController {
 	 */
 	public function bulk_action_handler() {
 		tutor_utils()->checking_nonce();
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			tutor_utils()->error_message();
-		}
+		tutor_utils()->check_current_user_capability();
 
 		// Get and sanitize input data.
 		$request     = Input::sanitize_array( $_POST ); //phpcs:ignore --sanitized already
@@ -630,9 +627,7 @@ class CouponController extends BaseController {
 	public function coupon_permanent_delete() {
 		tutor_utils()->checking_nonce();
 
-		if ( ! current_user_can( 'manage_options' ) ) {
-			tutor_utils()->error_message();
-		}
+		tutor_utils()->check_current_user_capability();
 
 		// Get and sanitize input data.
 		$id = Input::post( 'id', 0, Input::TYPE_INT );

--- a/ecommerce/OrderController.php
+++ b/ecommerce/OrderController.php
@@ -84,7 +84,7 @@ class OrderController {
 			 *
 			 * @since 3.0.0
 			 */
-			add_action( 'wp_ajax_tutor_order_details', array( $this, 'get_order_by_id' ) );
+			add_action( 'wp_ajax_tutor_order_details', array( $this, 'ajax_get_order_details' ) );
 
 			/**
 			 * Handle AJAX request for marking an order as paid by order ID.
@@ -258,7 +258,7 @@ class OrderController {
 	 *
 	 * @return void
 	 */
-	public function get_order_by_id() {
+	public function ajax_get_order_details() {
 		tutor_utils()->check_nonce();
 		tutor_utils()->check_current_user_capability();
 

--- a/ecommerce/OrderController.php
+++ b/ecommerce/OrderController.php
@@ -259,9 +259,8 @@ class OrderController {
 	 * @return void
 	 */
 	public function get_order_by_id() {
-		if ( ! tutor_utils()->is_nonce_verified() ) {
-			$this->json_response( tutor_utils()->error_message( 'nonce' ), null, HttpHelper::STATUS_BAD_REQUEST );
-		}
+		tutor_utils()->check_nonce();
+		tutor_utils()->check_current_user_capability();
 
 		$order_id = Input::post( 'order_id' );
 

--- a/models/CouponModel.php
+++ b/models/CouponModel.php
@@ -810,7 +810,7 @@ class CouponModel {
 		} else {
 			$coupon = $this->get_coupon(
 				array(
-					'coupon_code'   => $coupon_code,
+					'coupon_code'   => esc_sql( $coupon_code ),
 					'coupon_status' => self::STATUS_ACTIVE,
 				)
 			);

--- a/views/pages/view_attempt.php
+++ b/views/pages/view_attempt.php
@@ -21,12 +21,18 @@ $attempt      = tutor_utils()->get_attempt( $attempt_id );
 $attempt_data = $attempt;
 $user_id      = tutor_utils()->avalue_dot( 'user_id', $attempt_data );
 $quiz_id      = $attempt && isset( $attempt->quiz_id ) ? $attempt->quiz_id : 0;
+$course_id    = tutor_utils()->avalue_dot( 'course_id', $attempt_data );
 if ( ! $attempt ) {
-	tutor_utils()->tutor_empty_state( __( 'Attemp not found', 'tutor' ) );
+	tutor_utils()->tutor_empty_state( __( 'Attempt not found', 'tutor' ) );
 	return;
 }
 if ( 0 === $quiz_id ) {
-	tutor_utils()->tutor_empty_state( __( 'Attemp not found', 'tutor' ) );
+	tutor_utils()->tutor_empty_state( __( 'Attempt not found', 'tutor' ) );
+	return;
+}
+
+if ( ! tutor_utils()->is_instructor_of_this_course( get_current_user_id(), $course_id ) ) {
+	tutor_utils()->tutor_empty_state();
 	return;
 }
 


### PR DESCRIPTION
# Security Issue Fix for 3.9.4

## Issue 1
 - Inside `CouponController` class for both ajax method `bulk_action_handler` and `coupon_permanent_delete` there is  a check for user capability however the error message is not returned, the method `tutor_utils()->error_message()` is called but not returned thus it is not returning from the methods
 
 - To fix this i have use the method `tutor_utils()->check_current_user_capability()` which correctly checks user capability and returns a json error if unauthorized.
 
 ## Issue 2
 - On the `pay_now` action which is called during checkout you can inject SQL on the `coupon_code` argument when passing the form data during checkout
 - This in-turn runs a SQL query when trying to query the data of the coupon code by calling the `get_coupon` method inside `CouponModel` class
 - This calls the `QueryHelper::get_row` method which takes a where clause, and when preparing the where clause the malicious SQL code gets added.
 
 - To fix this i have put coupon_code inside an `esc_sql` inside `get_coupon_details_for_checkout` method which calls the `get_coupon` method and passes the coupon_code
 
 ## Issue 3
 - On the `tutor_order_details` action the method it calls has nonce check but no capability check
 - After looking over everything this action was called i have found out that it is only used for admin users not any other users
 
 - So to fix it i added `tutor_utils()->check_current_user_capability()` method so that only admin can view the order details
 
 ## Issue 4
 - On `mark_course_complete()` method no check was provided whether user is enrolled, allowing any user to mark course as complete even if it is paid course
 
 - To fix it added a check if user is enrolled using `tutor_utils()->is_enrolled()`, if not then exit from the function
 
 
 ## Issue 5
 - On `course_enrollment()` method there is no check if the course is purchasable allowing user to enroll in course with ajax call.
 
 - To fix this i added the `tutor_utils()->is_course_purchasable()` check to check if user is need to purchase the course before enrollment
 
 ## Issue 6
 - On reviewing quiz attempt details by instructor on the backend admin panel, any attempt done by students in a course of one instructor can be viewed by other instructor simply by copying the link
 - To fix this i obtained the `course_id` from the attempt details and check if the course id belong to the specific instructor using the method `tutor_utils()->is_instructor_of_this_course`
 
 - On the `tutor_instructor_feedback` ajax call any other instructor can add their own feedback
 - To fix this i added the same check by getting the `course_id` from attempt details and checking if the attempt is in a course by the instructor