### PR TITLE
Add 'pending' to PaymentStatus and PaymentBadge

### DIFF
--- a/assets/react/v3/entries/order-details/components/order/PaymentBadge.tsx
+++ b/assets/react/v3/entries/order-details/components/order/PaymentBadge.tsx
@@ -8,8 +8,9 @@ const badgeMap: Record<PaymentStatus, { label: string; type: Variant }> = {
   'partially-refunded': { label: __('Partially refunded', 'tutor'), type: 'secondary' },
   refunded: { label: __('Refunded', 'tutor'), type: 'critical' },
   unpaid: { label: __('Unpaid', 'tutor'), type: 'warning' },
+  pending: { label: __('Pending', 'tutor'), type: 'warning' },
 };
 
 export function PaymentBadge({ status }: { status: PaymentStatus }) {
-  return <TutorBadge variant={badgeMap[status].type}>{badgeMap[status].label}</TutorBadge>;
+  return <TutorBadge variant={badgeMap[status]?.type ?? 'secondary'}>{badgeMap[status]?.label ?? status}</TutorBadge>;
 }

--- a/assets/react/v3/entries/order-details/services/order.ts
+++ b/assets/react/v3/entries/order-details/services/order.ts
@@ -41,7 +41,7 @@ interface OrderCoursePlan extends OrderSummary {
 export type OrderSummaryItem = Prettify<OrderCourse | OrderBundle | OrderCoursePlan>;
 
 export type DiscountType = 'flat' | 'percentage';
-export type PaymentStatus = 'paid' | 'unpaid' | 'failed' | 'partially-refunded' | 'refunded';
+export type PaymentStatus = 'pending' | 'paid' | 'unpaid' | 'failed' | 'partially-refunded' | 'refunded';
 export type OrderStatus = 'incomplete' | 'completed' | 'cancelled' | 'trash';
 export type ActivityType =
   | 'order-placed'


### PR DESCRIPTION
Introduces 'pending' as a valid PaymentStatus type and updates PaymentBadge to handle it. Also adds fallback handling for unknown payment statuses in the PaymentBadge component.