### PR TITLE
Fix Course Rating and Reviews

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -4066,11 +4066,13 @@ class Utils {
 				WHERE	comments.comment_post_ID = %d
 						AND comments.comment_type = %s
 						AND commentmeta.meta_key = %s
+						AND comments.comment_approved = %s
 				GROUP BY CAST(commentmeta.meta_value AS SIGNED);
 				",
 					$course_id,
 					'tutor_course_rating',
-					'tutor_rating'
+					'tutor_rating',
+					'approved'
 				)
 			);
 

--- a/templates/single/course/reviews.php
+++ b/templates/single/course/reviews.php
@@ -25,7 +25,7 @@ $offset       = ( $current_page - 1 ) * $per_page;
 $current_user_id = get_current_user_id();
 $course_id       = Input::post( 'course_id', get_the_ID(), Input::TYPE_INT );
 $reviews         = tutor_utils()->get_course_reviews( $course_id, $offset, $per_page, false, array( 'approved' ), $current_user_id );
-$reviews_total   = tutor_utils()->get_course_reviews( $course_id, null, null, true, array( 'approved' ), $current_user_id );
+$reviews_total   = tutor_utils()->get_course_reviews( $course_id, null, null, true, array( 'approved' ) );
 $my_rating       = tutor_utils()->get_reviews_by_user( 0, 0, 150, false, $course_id, array( 'approved', 'hold' ) );
 
 if ( Input::has( 'course_id' ) ) {


### PR DESCRIPTION
### Overview

The `get_course_rating` method in Utils class was returning all the rating regardless of whether it is published or unpublished this led to a mismatch to the total rating count and actual course rating.

### Provided Fix

To fix this issue I have added `{$wpdb->comments}.comment_approved = %s` this line and made the value approved in the sql query to get only those ratings that are approved.

Further, to fix the count when user is enrolled into course and gives a review but it is pending, it should show user comment and it has status pending but the count should be only for approved review, i have removed the `current_user_id` parameter from `get_course_review` method so to only get the approved reviews