### PR TITLE
Security Fix: Prevent users to delete attachment from admin

### DIFF
--- a/classes/User.php
+++ b/classes/User.php
@@ -244,8 +244,6 @@ class User {
 	 */
 	private function delete_existing_user_photo( $user_id, $type ) {
 		$meta_key = 'cover_photo' == $type ? '_tutor_cover_photo' : '_tutor_profile_photo';
-		$photo_id = get_user_meta( $user_id, $meta_key, true );
-		is_numeric( $photo_id ) ? wp_delete_attachment( $photo_id, true ) : 0;
 		delete_user_meta( $user_id, $meta_key );
 	}
 

--- a/classes/User.php
+++ b/classes/User.php
@@ -283,7 +283,7 @@ class User {
 		/**
 		 * Photo Update from profile
 		 */
-		$photo      = tutor_utils()->array_get( 'photo_file', $_FILES );
+		$photo      = tutor_utils()->array_get( 'photo_file', $_FILES ); //phpcs:ignore -- already sanitized.
 		$photo_size = tutor_utils()->array_get( 'size', $photo );
 		$photo_type = tutor_utils()->array_get( 'type', $photo );
 

--- a/classes/User.php
+++ b/classes/User.php
@@ -244,6 +244,10 @@ class User {
 	 */
 	private function delete_existing_user_photo( $user_id, $type ) {
 		$meta_key = 'cover_photo' == $type ? '_tutor_cover_photo' : '_tutor_profile_photo';
+		$photo_id = get_user_meta( $user_id, $meta_key, true );
+		if ( is_numeric( $photo_id ) ) {
+			wp_delete_attachment( $photo_id, true );
+		}
 		delete_user_meta( $user_id, $meta_key );
 	}
 
@@ -370,6 +374,14 @@ class User {
 		$_tutor_profile_job_title = Input::post( self::PROFILE_JOB_TITLE_META, '' );
 		$_tutor_profile_bio       = Input::post( self::PROFILE_BIO_META, '', Input::TYPE_KSES_POST );
 		$_tutor_profile_image     = Input::post( self::PROFILE_PHOTO_META, '', Input::TYPE_KSES_POST );
+
+		if ( is_numeric( $_tutor_profile_image ) ) {
+			$attachment = get_post( $_tutor_profile_image );
+
+			if ( 'attachment' === $attachment->post_type && $user_id !== $attachment->post_author ) {
+				return;
+			}
+		}
 
 		update_user_meta( $user_id, self::PROFILE_JOB_TITLE_META, $_tutor_profile_job_title );
 		update_user_meta( $user_id, self::PROFILE_BIO_META, $_tutor_profile_bio );


### PR DESCRIPTION
### Overview

Students are able to delete an attachment from admin by calling `tutor_update_profile` ajax call and providing the admin attachment ID. Afterwards, they are able to delete the attachment by calling `tutor_user_photo_remove` action which calls the method `delete_existing_user_photo` which removes the attachment.

### Provided Fix
To fix this  i first check if the id provided is a number, then get the attachment post from the attachment id of the admin, and check if it author matches the current user id, if not then return so that the photo does not get updated