### PR TITLE
Reset Divi Content when switching to default WP Editor

### DIFF
--- a/classes/Course.php
+++ b/classes/Course.php
@@ -1174,6 +1174,19 @@ class Course extends Tutor_Base {
 			delete_post_meta( $course_id, '_elementor_edit_mode' );
 		} elseif ( 'droip' === $builder ) {
 			delete_post_meta( $course_id, 'droip_editor_mode' );
+		} elseif ( 'divi' === $builder ) {
+			$old_post_content     = get_post_meta( $course_id, '_et_pb_old_content', true );
+			$course               = get_post( $course_id );
+			$course->post_content = $old_post_content;
+			$result               = wp_update_post( $course );
+
+			if ( $result && ! is_wp_error( $result ) ) {
+				update_post_meta( $course_id, '_et_pb_use_builder', 'off' );
+				update_post_meta( $course_id, '_et_pb_old_content', '' );
+				delete_post_meta( $course_id, '_et_dynamic_cached_shortcodes' );
+				delete_post_meta( $course_id, '_et_dynamic_cached_attributes' );
+				delete_post_meta( $course_id, '_et_builder_module_features_cache' );
+			}
 		}
 
 		$this->json_response(
@@ -1762,7 +1775,7 @@ class Course extends Tutor_Base {
 			if ( is_array( $order ) && count( $order ) ) {
 				$i = 0;
 				foreach ( $order as $topic ) {
-					$i++;
+					++$i;
 					$wpdb->update(
 						$wpdb->posts,
 						array( 'menu_order' => $i ),
@@ -2806,10 +2819,10 @@ class Course extends Tutor_Base {
 					}
 				}
 				if ( ! $has_passed ) {
-					$required_assignment_pass++;
+					++$required_assignment_pass;
 				}
 			} else {
-				$required_assignment_pass++;
+				++$required_assignment_pass;
 			}
 		}
 
@@ -2825,11 +2838,11 @@ class Course extends Tutor_Base {
 					$earned_percentage = QuizModel::calculate_attempt_earned_percentage( $attempt );
 
 					if ( $earned_percentage < $passing_grade ) {
-						$required_quiz_pass++;
+						++$required_quiz_pass;
 						$is_quiz_pass = false;
 					}
 				} else {
-					$required_quiz_pass++;
+					++$required_quiz_pass;
 					$is_quiz_pass = false;
 				}
 			}

--- a/classes/Course.php
+++ b/classes/Course.php
@@ -1775,7 +1775,7 @@ class Course extends Tutor_Base {
 			if ( is_array( $order ) && count( $order ) ) {
 				$i = 0;
 				foreach ( $order as $topic ) {
-					++$i;
+					$i++;
 					$wpdb->update(
 						$wpdb->posts,
 						array( 'menu_order' => $i ),
@@ -2819,10 +2819,10 @@ class Course extends Tutor_Base {
 					}
 				}
 				if ( ! $has_passed ) {
-					++$required_assignment_pass;
+					$required_assignment_pass++;
 				}
 			} else {
-				++$required_assignment_pass;
+				$required_assignment_pass++;
 			}
 		}
 
@@ -2838,11 +2838,11 @@ class Course extends Tutor_Base {
 					$earned_percentage = QuizModel::calculate_attempt_earned_percentage( $attempt );
 
 					if ( $earned_percentage < $passing_grade ) {
-						++$required_quiz_pass;
+						$required_quiz_pass++;
 						$is_quiz_pass = false;
 					}
 				} else {
-					++$required_quiz_pass;
+					$required_quiz_pass++;
 					$is_quiz_pass = false;
 				}
 			}


### PR DESCRIPTION
### Overview

After editing a content in divi and when switching to default wordpress editor from tutor course builder the divi content stays. To fix this i have added the necessary logic to remove the divi content, for this i have removed some post_meta that divi creates, furthermore, to revert back to old post_content i have use the meta value of `_et_pb_old_content` and update the post with old content