### PR TITLE
Fix: Profile not updating due to type mismatch

### DIFF
--- a/classes/User.php
+++ b/classes/User.php
@@ -375,10 +375,11 @@ class User {
 		$_tutor_profile_bio       = Input::post( self::PROFILE_BIO_META, '', Input::TYPE_KSES_POST );
 		$_tutor_profile_image     = Input::post( self::PROFILE_PHOTO_META, '', Input::TYPE_KSES_POST );
 
+		// Check if the image uploaded is by the same user.
 		if ( is_numeric( $_tutor_profile_image ) ) {
 			$attachment = get_post( $_tutor_profile_image );
-
-			if ( 'attachment' === $attachment->post_type && $user_id !== $attachment->post_author ) {
+			$author_id  = (int) $attachment->post_author ?? 0;
+			if ( 'attachment' === $attachment->post_type && $user_id !== $author_id ) {
 				return;
 			}
 		}


### PR DESCRIPTION
### Overview
The logic that was added to verify whether user has uploaded the profile picture as a part of security fix was not working due to there being a mismatch between the types of `user_id` and `$attachment->post_author` as one was int and other was string and since i was strictly checking with type thats why it was returning false. To fix this i have type casted the `$attachment->post_author` to be int