### PR TITLE
3.9.6 security issue fixes

### DIFF
--- a/classes/Course_List.php
+++ b/classes/Course_List.php
@@ -273,7 +273,6 @@ class Course_List {
 		$the_query = self::course_list_query( $args, $user_id, $status );
 
 		return ! is_null( $the_query ) && isset( $the_query->found_posts ) ? $the_query->found_posts : $the_query;
-
 	}
 
 	/**
@@ -291,6 +290,8 @@ class Course_List {
 
 		// Check if user is privileged.
 		if ( ! current_user_can( 'administrator' ) ) {
+			$course_ids = explode( ',', $bulk_ids );
+
 			if ( current_user_can( 'edit_tutor_course' ) ) {
 				$can_publish_course = tutor_utils()->get_option( 'instructor_can_publish_course' );
 
@@ -300,6 +301,17 @@ class Course_List {
 			} else {
 				wp_send_json_error( tutor_utils()->error_message() );
 			}
+
+			// Check if the course ids are instructors own course.
+			$course_ids = array_filter(
+				$course_ids,
+				function ( $course_id ) {
+					return tutor_utils()->is_instructor_of_this_course( get_current_user_id(), $course_id );
+				}
+			);
+
+			$bulk_ids = implode( ',', $course_ids );
+
 		}
 
 		if ( '' === $action || '' === $bulk_ids ) {

--- a/ecommerce/CouponController.php
+++ b/ecommerce/CouponController.php
@@ -659,6 +659,8 @@ class CouponController extends BaseController {
 			$this->json_response( tutor_utils()->error_message( 'nonce' ), null, HttpHelper::STATUS_BAD_REQUEST );
 		}
 
+		tutor_utils()->check_current_user_capability();
+
 		$coupon_id = Input::post( 'id' );
 
 		if ( empty( $coupon_id ) ) {


### PR DESCRIPTION
### Issue 1:  missing authorization checks in the `ajax_coupon_details()`
- This allows any user to get coupon details by passing coupon id.
- To fix this i have added `tutor_utils()->check_current_user_capability()` to check if current user is admin.

### Issue 2: Missing course belong to instructor check on `course_list_bulk_action()`
- On the `course_list_bulk_action()` method there is check whether current user is instructor but it is not check if the bulk course ids belong to the instructor, this allows instructor to delete admins course and other instructor course 
- To fix this I at first obtain the list of course ids from the bulk ids
- After that i filter the course_ids array to includes those ids only that the instructor has access using the method `tutor_utils()->is_instructor_of_this_course()` , this method also check if current instructor is a co-author of a course
- After filtering the array the remaining ids are converted into string again and the action is performed