### PR TITLE
Fix: Admin cannot update student or instructor profile photo

### DIFF
--- a/classes/User.php
+++ b/classes/User.php
@@ -246,7 +246,11 @@ class User {
 		$meta_key = 'cover_photo' == $type ? '_tutor_cover_photo' : '_tutor_profile_photo';
 		$photo_id = get_user_meta( $user_id, $meta_key, true );
 		if ( is_numeric( $photo_id ) ) {
-			wp_delete_attachment( $photo_id, true );
+			$attachment  = get_post( $photo_id );
+			$post_author = (int) $attachment->post_author ?? 0;
+			if ( $user_id === $post_author ) {
+				wp_delete_attachment( $photo_id, true );
+			}
 		}
 		delete_user_meta( $user_id, $meta_key );
 	}
@@ -374,15 +378,6 @@ class User {
 		$_tutor_profile_job_title = Input::post( self::PROFILE_JOB_TITLE_META, '' );
 		$_tutor_profile_bio       = Input::post( self::PROFILE_BIO_META, '', Input::TYPE_KSES_POST );
 		$_tutor_profile_image     = Input::post( self::PROFILE_PHOTO_META, '', Input::TYPE_KSES_POST );
-
-		// Check if the image uploaded is by the same user.
-		if ( is_numeric( $_tutor_profile_image ) ) {
-			$attachment = get_post( $_tutor_profile_image );
-			$author_id  = (int) $attachment->post_author ?? 0;
-			if ( 'attachment' === $attachment->post_type && $user_id !== $author_id ) {
-				return;
-			}
-		}
 
 		update_user_meta( $user_id, self::PROFILE_JOB_TITLE_META, $_tutor_profile_job_title );
 		update_user_meta( $user_id, self::PROFILE_BIO_META, $_tutor_profile_bio );


### PR DESCRIPTION
### Overview

This PR fixes a issue where the site admin cannot assign a profile picture for instructor or student. This was done as a part of security fix so that only user uploaded photo can be updated, they cannot upload admin attachment and delete it. However it was not checked whether user changing photo is admin itself. To fix this i have removed the code that check attachment post author on `profile_update` which is called when profile is updated from backend admin panel. Instead i added this logic on `delete_existing_user_photo` which is used on  ajax calls which can be exploited.