### PR TITLE
Added prepare statement when building where clause

### DIFF
--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -246,21 +246,6 @@ class QueryHelper {
 	}
 
 	/**
-	 * Prepare BETWEEN and NOT BETWEEN sql clauses.
-	 *
-	 * @since 3.9.7
-	 *
-	 * @param array $values the array of values.
-	 *
-	 * @return string
-	 */
-	public static function prepare_between_clause( array $values ): string {
-		$values = array_map( fn( $val ) => self::prepare_value( $val ), $values );
-		$value  = implode( ' AND ', $values );
-		return $value;
-	}
-
-	/**
 	 * Make tge where clause base on its column operator and values.
 	 *
 	 * If the operator is IN then make the clause like `WHERE column_name IN (value1, value2, ...)`
@@ -277,10 +262,15 @@ class QueryHelper {
 		list ( $field, $operator, $value ) = $where;
 
 		$upper_operator = strtoupper( $operator );
+
+		if ( is_array( $value ) ) {
+			$value = array_map( fn( $val ) => self::prepare_value( $val ), $value );
+		}
+
 		if ( in_array( $upper_operator, array( 'IN', 'NOT IN' ), true ) ) {
-			$value = '(' . self::prepare_in_clause( $value ) . ')';
+			$value = '(' . implode( ',', $value ) . ')';
 		} elseif ( in_array( $upper_operator, array( 'BETWEEN', 'NOT BETWEEN' ), true ) ) {
-			$value = self::prepare_between_clause( $value );
+			$value = implode( ' AND ', $value );
 		} elseif ( strtoupper( $value ) === 'NULL' ) {
 			$value = 'NULL';
 		} else {
@@ -962,13 +952,7 @@ class QueryHelper {
 	 * @return string
 	 */
 	public static function prepare_in_clause( array $arr ) {
-		$escaped = array_map(
-			function( $value ) {
-				return self::prepare_value( $value );
-			},
-			$arr
-		);
-	
+		$escaped = array_map( fn( $value ) => self::prepare_value( $value ), $arr );
 		return implode( ',', $escaped );
 	}
 

--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -929,7 +929,7 @@ class QueryHelper {
 		$escaped_value = null;
 		if ( is_int( $value ) ) {
 			$escaped_value = $wpdb->prepare( '%d', $value );
-		} else if( is_float( $value ) ) {
+		} elseif( is_float( $value ) ) {
 			list( $whole, $decimal ) = explode( '.', $value );
 			$expression = '%.'. strlen( $decimal ) . 'f';
 			$escaped_value = $wpdb->prepare( $expression, $value );

--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -263,13 +263,10 @@ class QueryHelper {
 
 		$upper_operator = strtoupper( $operator );
 
-		if ( is_array( $value ) ) {
-			$value = array_map( fn( $val ) => self::prepare_value( $val ), $value );
-		}
-
 		if ( in_array( $upper_operator, array( 'IN', 'NOT IN' ), true ) ) {
-			$value = '(' . implode( ',', $value ) . ')';
+			$value = '(' . self::prepare_in_clause( $value ) . ')';
 		} elseif ( in_array( $upper_operator, array( 'BETWEEN', 'NOT BETWEEN' ), true ) ) {
+			$value = array_map( fn( $val ) => self::prepare_value( $val ), $value );
 			$value = implode( ' AND ', $value );
 		} elseif ( strtoupper( $value ) === 'NULL' ) {
 			$value = 'NULL';

--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -929,7 +929,7 @@ class QueryHelper {
 		$escaped_value = null;
 		if ( is_int( $value ) ) {
 			$escaped_value = $wpdb->prepare( '%d', $value );
-		} elseif( is_float( $value ) ) {
+		} elseif ( is_float( $value ) ) {
 			list( $whole, $decimal ) = explode( '.', $value );
 			$expression = '%.'. strlen( $decimal ) . 'f';
 			$escaped_value = $wpdb->prepare( $expression, $value );

--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -246,6 +246,19 @@ class QueryHelper {
 	}
 
 	/**
+	 * Prepare BETWEEN and NOT BETWEEN sql clauses.
+	 *
+	 * @param array $values the array of values.
+	 *
+	 * @return string
+	 */
+	public static function prepare_between_clause( array $values ): string {
+		$values = array_map( fn( $val ) => self::prepare_value( $val ), $values );
+		$value  = implode( ' AND ', $values );
+		return $value;
+	}
+
+	/**
 	 * Make tge where clause base on its column operator and values.
 	 *
 	 * If the operator is IN then make the clause like `WHERE column_name IN (value1, value2, ...)`
@@ -259,25 +272,17 @@ class QueryHelper {
 	 * @return string
 	 */
 	public static function make_clause( array $where ) {
-		global $wpdb;
 		list ( $field, $operator, $value ) = $where;
 
 		$upper_operator = strtoupper( $operator );
 		if ( in_array( $upper_operator, array( 'IN', 'NOT IN' ), true ) ) {
 			$value = '(' . self::prepare_in_clause( $value ) . ')';
 		} elseif ( in_array( $upper_operator, array( 'BETWEEN', 'NOT BETWEEN' ), true ) ) {
-			$values = explode( 'AND', $value );
-			if ( is_numeric( $values[0] ) && is_numeric( $values[1] ) ) {
-				$value = $wpdb->prepare( '%d AND %d', trim( $values[0] ), trim( $values[1] ) );
-			} else {
-				$value = $wpdb->prepare( '%s AND %s', trim( $values[0] ), trim( $values[1] ) );
-			}
+			$value = self::prepare_between_clause( $value );
 		} elseif ( strtoupper( $value ) === 'NULL' ) {
 			$value = 'NULL';
-		} elseif ( is_numeric( $value ) ) {
-			$value = $wpdb->prepare( '%d', trim( $value ) );
 		} else {
-			$value = $wpdb->prepare( '%s', trim( $value ) );
+			$value = self::prepare_value( $value );
 		}
 
 		return "{$field} {$upper_operator} {$value}";
@@ -361,9 +366,7 @@ class QueryHelper {
 					case 'BETWEEN':
 					case 'NOT BETWEEN':
 						if ( is_array( $val ) && count( $val ) === 2 ) {
-							$val1   = $val[0];
-							$val2   = $val[1];
-							$clause = array( $field, $operator, "{$val1} AND {$val2}" );
+							$clause = array( $field, $operator, $val );
 						}
 						break;
 
@@ -924,27 +927,42 @@ class QueryHelper {
 	}
 
 	/**
+	 * Prepare value before using in query.
+	 *
+	 * @since 3.9.7
+	 *
+	 * @param string|int|float $value the value to prepare.
+	 *
+	 * @return mixed
+	 */
+	public static function prepare_value( $value ) {
+		global $wpdb;
+		$escaped_value = null;
+		if ( is_int( $value ) ) {
+			$escaped_value = $wpdb->prepare( '%d', $value );
+		} else if( is_float( $value ) ) {
+			list( $whole, $decimal ) = explode( '.', $value );
+			$expression = '%.'. strlen( $decimal ) . 'f';
+			$escaped_value = $wpdb->prepare( $expression, $value );
+		} else {
+			$escaped_value = $wpdb->prepare( '%s', $value );
+		}
+		return $escaped_value;
+	}
+
+	/**
 	 * Make sanitized SQL IN clause value from an array
 	 *
-	 * @param array $arr a sequential array.
-	 * @return string
 	 * @since 2.1.1
+	 *
+	 * @param array $arr a sequential array.
+	 *
+	 * @return string
 	 */
 	public static function prepare_in_clause( array $arr ) {
 		$escaped = array_map(
 			function( $value ) {
-				global $wpdb;
-				$escaped_value = null;
-				if ( is_int( $value ) ) {
-					$escaped_value = $wpdb->prepare( '%d', $value );
-				} else if( is_float( $value ) ) {
-					list( $whole, $decimal ) = explode( '.', $value );
-					$expression = '%.'. strlen( $decimal ) . 'f';
-					$escaped_value = $wpdb->prepare( $expression, $value );
-				} else {
-					$escaped_value = $wpdb->prepare( '%s', $value );
-				}
-				return $escaped_value;
+				return self::prepare_value( $value );
 			},
 			$arr
 		);

--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -252,17 +252,32 @@ class QueryHelper {
 	 * Otherwise the clause would be `WHERE column_name = 'value'`
 	 *
 	 * @since 3.0.0
+	 * @since 3.9.7 added prepared statement for value.
 	 *
 	 * @param array $where  The where clause array. e.g. array( 'id', 'IN', array(1, 2, 3) ) or array( 'id', '=', 1 ).
 	 *
 	 * @return string
 	 */
 	public static function make_clause( array $where ) {
+		global $wpdb;
 		list ( $field, $operator, $value ) = $where;
 
 		$upper_operator = strtoupper( $operator );
 		if ( in_array( $upper_operator, array( 'IN', 'NOT IN' ), true ) ) {
 			$value = '(' . self::prepare_in_clause( $value ) . ')';
+		} elseif ( in_array( $upper_operator, array( 'BETWEEN', 'NOT BETWEEN' ), true ) ) {
+			$values = explode( 'AND', $value );
+			if ( is_numeric( $values[0] ) && is_numeric( $values[1] ) ) {
+				$value = $wpdb->prepare( '%d AND %d', trim( $values[0] ), trim( $values[1] ) );
+			} else {
+				$value = $wpdb->prepare( '%s AND %s', trim( $values[0] ), trim( $values[1] ) );
+			}
+		} elseif ( strtoupper( $value ) === 'NULL' ) {
+			$value = 'NULL';
+		} elseif ( is_numeric( $value ) ) {
+			$value = $wpdb->prepare( '%d', trim( $value ) );
+		} else {
+			$value = $wpdb->prepare( '%s', trim( $value ) );
 		}
 
 		return "{$field} {$upper_operator} {$value}";
@@ -346,15 +361,15 @@ class QueryHelper {
 					case 'BETWEEN':
 					case 'NOT BETWEEN':
 						if ( is_array( $val ) && count( $val ) === 2 ) {
-							$val1   = is_numeric( $val[0] ) ? $val[0] : "'" . $val[0] . "'";
-							$val2   = is_numeric( $val[1] ) ? $val[1] : "'" . $val[1] . "'";
+							$val1   = $val[0];
+							$val2   = $val[1];
 							$clause = array( $field, $operator, "{$val1} AND {$val2}" );
 						}
 						break;
 
 					case 'IS':
 					case 'IS NOT':
-						$val    = strtoupper( $val ) === 'NULL' ? 'NULL' : "'" . $val . "'";
+						$val    = strtoupper( $val ) === 'NULL' ? 'NULL' : $val;
 						$clause = array( $field, $operator, $val );
 						break;
 					case 'RAW':
@@ -365,16 +380,14 @@ class QueryHelper {
 						$clause = $final_query;
 						break;
 					default: // =, !=, <, >, <=, >=, LIKE, NOT LIKE, <>
-						$val    = is_numeric( $val ) ? $val : "'" . $val . "'";
 						$clause = array( $field, $operator, $val );
 						break;
 				}
 			} elseif ( is_array( $value ) ) {
 				$clause = array( $field, 'IN', $value );
 			} elseif ( 'null' === strtolower( $value ) ) {
-					$clause = array( $field, 'IS', 'NULL' );
+				$clause = array( $field, 'IS', 'NULL' );
 			} else {
-				$value  = is_numeric( $value ) ? $value : "'" . $value . "'";
 				$clause = array( $field, '=', $value );
 			}
 

--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -248,6 +248,8 @@ class QueryHelper {
 	/**
 	 * Prepare BETWEEN and NOT BETWEEN sql clauses.
 	 *
+	 * @since 3.9.7
+	 *
 	 * @param array $values the array of values.
 	 *
 	 * @return string

--- a/models/CouponModel.php
+++ b/models/CouponModel.php
@@ -810,7 +810,7 @@ class CouponModel {
 		} else {
 			$coupon = $this->get_coupon(
 				array(
-					'coupon_code'   => esc_sql( $coupon_code ),
+					'coupon_code'   => $coupon_code,
 					'coupon_status' => self::STATUS_ACTIVE,
 				)
 			);

--- a/tests/phpunit/QueryHelperTest.php
+++ b/tests/phpunit/QueryHelperTest.php
@@ -68,6 +68,53 @@ class QueryHelperTest extends \WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
+	public function test_prepare_where_clause() {
+
+		$test1   = array(
+			'age'     => 18,
+			'height'  => array( '>=', '5feet7inch' ),
+			'hobbies' => array( 'coding', 'biking', 'swimming' ),
+		);
+		$expect1 = "age = 18 AND height >= '5feet7inch' AND hobbies IN ('coding','biking','swimming')";
+		$actual1 = QueryHelper::prepare_where_clause( $test1 );
+
+		$test2 = array(
+			'salary' => array( 'BETWEEN', array( 10, 20 ) ),
+			'name'   => array( 'NOT BETWEEN', array( 'b', 'c' ) ),
+		);
+
+		$expect2 = "salary BETWEEN 10 AND 20 AND name NOT BETWEEN 'b' AND 'c'";
+		$actual2 = QueryHelper::prepare_where_clause( $test2 );
+
+		$test3 = array(
+			'name' => array( 'LIKE', 'test' ),
+			'age'  => array( 'NOT IN', array( 18, 19, 20 ) ),
+		);
+
+		$expect3 = "name LIKE 'test' AND age NOT IN (18,19,20)";
+		$actual3 = QueryHelper::prepare_where_clause( $test3 );
+
+		$test4 = array(
+			'name' => 'NULL',
+			'age'  => array( 'IS NOT', 'NULL' ),
+		);
+
+		$expect4 = 'name IS NULL AND age IS NOT NULL';
+		$actual4 = QueryHelper::prepare_where_clause( $test4 );
+
+		$this->assertEquals( $expect1, trim( $actual1 ) );
+		$this->assertEquals( $expect2, trim( $actual2 ) );
+		$this->assertEquals( $expect3, trim( $actual3 ) );
+		$this->assertEquals( $expect4, trim( $actual4 ) );
+	}
+
+	/**
+	 * Test QueryHelper Raw query.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return void
+	 */
 	public function test_prepare_raw_query() {
 		$case_1 = array(
 			"username = '%s'" => array(
@@ -88,7 +135,7 @@ class QueryHelperTest extends \WP_UnitTestCase {
 		);
 
 		$case_3 = array(
-			'id'          => array(
+			'id' => array(
 				'BETWEEN',
 				array( 10, 20 ),
 			),


### PR DESCRIPTION
### Overview
As a part of security fix in 3.9.4, where sql injection was possible through the `coupon_code` parameter a fix was added where `esc_sql` was called to remove any kind of sql injection, however this was not the correct fix. The correct fix is using prepare statement in `prepare_where_clause` method where any user value can be passed. Therefore, I have updated the method specifically the `make_clause` method that is being used in `prepare_where_clause` only, which creates the final clause, here i have checked whether the value is string or integer and added appropriate prepare statement for each type. I have also added some new unit test cases to check the `prepare_where_clause` output making sure it doesn't break the query. 

### Test Case Results
<img width="727" height="249" alt="Screenshot 2026-02-09 at 5 44 05 PM" src="https://github.com/user-attachments/assets/0cf96416-af4e-4a3f-a995-659685315b03" />
