### PR TITLE
Update Json Response fail and response data

### DIFF
--- a/traits/JsonResponse.php
+++ b/traits/JsonResponse.php
@@ -78,8 +78,9 @@ trait JsonResponse {
 	public function response_fail( $message, $status_code = 200 ) {
 		wp_send_json(
 			array(
-				'success' => false,
-				'message' => $message,
+				'status_code' => $status_code,
+				'success'     => false,
+				'message'     => $message,
 			),
 			$status_code
 		);
@@ -96,8 +97,9 @@ trait JsonResponse {
 	public function response_data( $data, $status_code = 200 ) {
 		wp_send_json(
 			array(
-				'success' => true,
-				'data'    => $data,
+				'status_code' => $status_code,
+				'success'     => true,
+				'data'        => $data,
 			),
 			$status_code
 		);


### PR DESCRIPTION
This pr updates the JsonResponse method `response_fail` and `response_data` by adding status code to the array before sending it `wp_send_json`