### PR TITLE
get_allowed_html_tags() function added in BaseComponent class

### DIFF
--- a/components/BaseComponent.php
+++ b/components/BaseComponent.php
@@ -13,6 +13,8 @@
 
 namespace Tutor\Components;
 
+use TUTOR\Input;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -58,32 +60,6 @@ abstract class BaseComponent {
 	 * @var array
 	 */
 	protected $attributes = array();
-
-
-	/**
-	 * Allowed HTML tags and Alpine.js attributes
-	 *
-	 * @since 4.0.0
-	 *
-	 * @var array
-	 */
-	protected $allowed_attributes = array();
-
-	/**
-	 * Allowed Alpine.js HTML attributes.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @var array
-	 */
-	protected const ALLOWED_ALPINE_ATTRS = array(
-		'x-data',
-		'x-text',
-		'x-show',
-		'x-cloak',
-		'x-ref',
-		'x-transition',
-	);
 
 	/**
 	 * Set or merge multiple HTML attributes.
@@ -168,44 +144,36 @@ abstract class BaseComponent {
 	}
 
 	/**
-	 * Returns the allowed HTML attributes.
+	 * Retrieve the list of allowed HTML tags and attributes.
+	 *
+	 * Provides a base set of safe HTML tags and merges additional
+	 * SVG tags and any custom tags passed
+	 * through the $extra_tags parameter.
 	 *
 	 * @since 4.0.0
 	 *
-	 * @return array
+	 * @param array<string, array<string, bool>> $extra_tags Optional.
+	 *        Additional HTML tags and their allowed attributes
+	 *        in KSES-compatible format.
+	 *
+	 * @return array<string, array<string, bool>> Allowed HTML tags
+	 *         and attributes formatted for wp_kses().
 	 */
-	public function allowed_attributes() {
+	protected function get_allowed_html_tags( $extra_tags = array() ) {
 
-		if ( empty( $this->allowed_attributes ) ) {
-			return wp_kses_allowed_html( 'post' );
-		}
+		$allowed_html_tags = array(
+			'div'    => array(),
+			'b'      => array(),
+			'strong' => array(),
+			'i'      => array(),
+			'em'     => array(),
+			'span'   => array(),
+		);
 
-		return $this->allowed_attributes;
-	}
+		$allowed_html_tags = wp_parse_args( Input::allow_svg( array() ), $allowed_html_tags );
+		$allowed_html_tags = wp_parse_args( $extra_tags, $allowed_html_tags );
 
-	/**
-	 * Add Alpine.js attributes to the allowed attribute-list.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @param array $attributes attribute map.
-	 *
-	 * @return $this
-	 */
-	public function add_x_attrs( array $attributes ) {
-
-		$allowed_attributes = self::allowed_attributes();
-
-		foreach ( $attributes as $tag => $attr ) {
-			$tag = sanitize_key( $tag );
-
-			if ( ! isset( $allowed_attributes[ $tag ][ $attr ] ) && in_array( $attr, self::ALLOWED_ALPINE_ATTRS, true ) ) {
-				$allowed_attributes[ $tag ][ $attr ] = true;
-			}
-		}
-
-		$this->allowed_attributes = $allowed_attributes;
-		return $this;
+		return $allowed_html_tags;
 	}
 
 	/**

--- a/components/BaseComponent.php
+++ b/components/BaseComponent.php
@@ -76,7 +76,7 @@ abstract class BaseComponent {
 	 *
 	 * @var array
 	 */
-	private const ALLOWED_ALPINE_ATTRS = array(
+	protected const ALLOWED_ALPINE_ATTRS = array(
 		'x-data',
 		'x-text',
 		'x-show',

--- a/components/BaseComponent.php
+++ b/components/BaseComponent.php
@@ -59,6 +59,32 @@ abstract class BaseComponent {
 	 */
 	protected $attributes = array();
 
+
+	/**
+	 * Allowed HTML tags and Alpine.js attributes
+	 *
+	 * @since 4.0.0
+	 *
+	 * @var array
+	 */
+	protected $allowed_attributes = array();
+
+	/**
+	 * Allowed Alpine.js HTML attributes.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @var array
+	 */
+	private const ALLOWED_ALPINE_ATTRS = array(
+		'x-data',
+		'x-text',
+		'x-show',
+		'x-cloak',
+		'x-ref',
+		'x-transition',
+	);
+
 	/**
 	 * Set or merge multiple HTML attributes.
 	 *
@@ -139,6 +165,47 @@ abstract class BaseComponent {
 	 */
 	protected function esc( $value, $esc_fn = 'esc_html' ): string {
 		return call_user_func( $esc_fn, $value );
+	}
+
+	/**
+	 * Returns the allowed HTML attributes.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @return array
+	 */
+	public function allowed_attributes() {
+
+		if ( empty( $this->allowed_attributes ) ) {
+			return wp_kses_allowed_html( 'post' );
+		}
+
+		return $this->allowed_attributes;
+	}
+
+	/**
+	 * Add Alpine.js attributes to the allowed attribute-list.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param array $attributes attribute map.
+	 *
+	 * @return $this
+	 */
+	public function add_x_attrs( array $attributes ) {
+
+		$allowed_attributes = self::allowed_attributes();
+
+		foreach ( $attributes as $tag => $attr ) {
+			$tag = sanitize_key( $tag );
+
+			if ( ! isset( $allowed_attributes[ $tag ][ $attr ] ) && in_array( $attr, self::ALLOWED_ALPINE_ATTRS, true ) ) {
+				$allowed_attributes[ $tag ][ $attr ] = true;
+			}
+		}
+
+		$this->allowed_attributes = $allowed_attributes;
+		return $this;
 	}
 
 	/**

--- a/components/Tooltip.php
+++ b/components/Tooltip.php
@@ -122,8 +122,9 @@ class Tooltip extends BaseComponent {
 	 *
 	 * @return $this
 	 */
-	public function content( string $content ): self {
-		$this->content = $content;
+	public function content( string $content, $extra_tags = array() ): self {
+
+		$this->content = wp_kses( $content, $this->get_allowed_html_tags( $extra_tags ) );
 		return $this;
 	}
 
@@ -278,7 +279,7 @@ class Tooltip extends BaseComponent {
 			esc_attr( $this->attributes['class'] ?? '' ),
 			$this->get_attributes_string(),
 			$trigger_html,
-			wp_kses( $this->content, $this->allowed_attributes() )
+			$this->content
 		);
 
 		return $this->component_string;

--- a/components/Tooltip.php
+++ b/components/Tooltip.php
@@ -116,31 +116,6 @@ class Tooltip extends BaseComponent {
 	);
 
 	/**
-	 * Allowed HTML tags and Alpine.js attributes for wp_kses sanitization.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @var array
-	 */
-	protected $allowed_attributes = array();
-
-	/**
-	 * Allowed Alpine.js HTML attributes.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @var array
-	 */
-	private const ALLOWED_ALPINE_ATTRS = array(
-		'x-data',
-		'x-text',
-		'x-show',
-		'x-cloak',
-		'x-ref',
-		'x-transition',
-	);
-
-	/**
 	 * Set the tooltip content.
 	 *
 	 * @param string $content HTML or text content.
@@ -263,46 +238,6 @@ class Tooltip extends BaseComponent {
 			'hide' => $hide,
 		);
 		return $this;
-	}
-
-	/**
-	 * Adds Alpine.js attributes to the wp_kses allow-list.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @param array $attributes attribute map.
-	 *
-	 * @return $this
-	 */
-	public function add_alpine_attributes( array $attributes ) {
-
-		$this->allowed_attributes = wp_kses_allowed_html( 'post' );
-
-		foreach ( $attributes as $tag => $attr ) {
-			$tag = sanitize_key( $tag );
-
-			if ( ! isset( $this->allowed_attributes[ $tag ][ $attr ] ) && in_array( $attr, self::ALLOWED_ALPINE_ATTRS, true ) ) {
-				$this->allowed_attributes[ $tag ][ $attr ] = true;
-			}
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Returns the allowed HTML configuration for wp_kses().
-	 *
-	 * @since 4.0.0
-	 *
-	 * @return array
-	 */
-	private function allowed_attributes() {
-
-		if ( empty( $this->allowed_attributes ) ) {
-			return wp_kses_allowed_html( 'post' );
-		}
-
-		return $this->allowed_attributes;
 	}
 
 	/**

--- a/components/Tooltip.php
+++ b/components/Tooltip.php
@@ -116,9 +116,11 @@ class Tooltip extends BaseComponent {
 	);
 
 	/**
-	 * Set the tooltip content.
+	 * Set and sanitize the tooltip content.
 	 *
-	 * @param string $content HTML or text content.
+	 * @param string                             $content HTML or text content.
+	 * @param array<string, array<string, bool>> $extra_tags Optional.
+	 *        Additional HTML tags and attributes in KSES-compatible format.
 	 *
 	 * @return $this
 	 */


### PR DESCRIPTION
**Scenario**:
The Tooltip component uses `wp_kses()` to sanitize content. When Alpine.js attributes are required for rendering dynamic data, wp_kses() strips those attributes.

**Solution**:
Added **`get_allowed_html_tags()`** to BaseComponent  class to support Alpine.js attributes within `wp_kses` sanitized content.