### PR TITLE
🐛 Integrate Date/DateTime calendar sync with TutorCore.form

### DIFF
--- a/assets/core/ts/components/calendar.ts
+++ b/assets/core/ts/components/calendar.ts
@@ -1,4 +1,5 @@
 import { type AlpineComponentMeta } from '@Core/ts/types';
+import { TUTOR_CUSTOM_EVENTS } from '@Core/ts/constant';
 import { tutorConfig } from '@TutorShared/config/config';
 import { DateFormats } from '@TutorShared/config/constants';
 import { __ } from '@wordpress/i18n';
@@ -48,6 +49,96 @@ export function calendar({ options, hidePopover }: { options: OptionsCalendar; h
     $nextTick: null as unknown as (callback: () => void) => void,
     calendar: null as Calendar | null,
 
+    parseInputValue(inputValue: string): { selectedDates: string[]; selectedTime: string } {
+      const normalizedValue = inputValue.trim();
+
+      if (!normalizedValue) {
+        return { selectedDates: [], selectedTime: '' };
+      }
+
+      const [datePart, ...timeParts] = normalizedValue.split(' ');
+      const selectedDates = datePart ? [datePart] : [];
+      const selectedTime = timeParts.join(' ').trim();
+
+      return { selectedDates, selectedTime };
+    },
+
+    syncCalendarWithInputValue(inputValue?: string): void {
+      if (!this.calendar || !this.calendar.context.inputElement) {
+        return;
+      }
+
+      const value = inputValue ?? this.calendar.context.inputElement.value;
+      const { selectedDates, selectedTime } = this.parseInputValue(value);
+
+      this.calendar.set({
+        selectedDates,
+        selectedTime: selectedTime || undefined,
+      });
+    },
+
+    setupFormIntegration(): void {
+      if (!options.inputMode || !(this.$el instanceof HTMLInputElement)) {
+        return;
+      }
+
+      const inputElement = this.$el;
+      const fieldName = inputElement.name;
+      if (!fieldName) {
+        return;
+      }
+
+      const formElement = inputElement.closest(
+        'form[x-data*="tutorForm"], form[x-data*="form("]',
+      ) as HTMLElement | null;
+      if (!formElement) {
+        return;
+      }
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const alpineData = window.Alpine?.$data(formElement) as any;
+        if (!alpineData || typeof alpineData.setValue !== 'function') {
+          return;
+        }
+
+        const inputValue = inputElement.value?.trim() ?? '';
+        const formValue = alpineData.values?.[fieldName];
+        const normalizedFormValue = formValue == null ? '' : String(formValue).trim();
+
+        // Keep initial input value as the form baseline default when form has no value yet.
+        if (!normalizedFormValue && inputValue) {
+          alpineData.setValue(fieldName, inputValue, {
+            shouldValidate: false,
+            shouldTouch: false,
+            shouldDirty: false,
+          });
+
+          if (alpineData.fields?.[fieldName]) {
+            alpineData.fields[fieldName].defaultValue = inputValue;
+          }
+        } else if (normalizedFormValue && normalizedFormValue !== inputValue) {
+          inputElement.value = normalizedFormValue;
+          this.syncCalendarWithInputValue(normalizedFormValue);
+        }
+
+        // Watch external form updates (setValue/reset/setValues) and keep calendar state in sync.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const component = this as unknown as { $watch?: (path: string, cb: (value: any) => void) => void };
+        component.$watch?.(`values.${fieldName}`, (newValue) => {
+          const normalizedValue = newValue == null ? '' : String(newValue).trim();
+          if (inputElement.value !== normalizedValue) {
+            inputElement.value = normalizedValue;
+          }
+
+          this.syncCalendarWithInputValue(normalizedValue);
+        });
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to integrate calendar with form:', error);
+      }
+    },
+
     init(): void {
       if (!this.$el) return;
 
@@ -60,11 +151,9 @@ export function calendar({ options, hidePopover }: { options: OptionsCalendar; h
 
         // For input mode
         if (options.inputMode && (el as HTMLInputElement).value) {
-          const parts = (el as HTMLInputElement).value.split(' ');
-          selectedDates.push(parts[0]);
-          if (parts.length > 1) {
-            selectedTime = parts.slice(1).join(' ');
-          }
+          const parsedValue = this.parseInputValue((el as HTMLInputElement).value);
+          selectedDates.push(...parsedValue.selectedDates);
+          selectedTime = parsedValue.selectedTime;
         } else {
           // For filter mode
           const startDate = url.searchParams.get('start_date');
@@ -165,8 +254,19 @@ export function calendar({ options, hidePopover }: { options: OptionsCalendar; h
         });
 
         this.calendar.init();
+        if (options.inputMode) {
+          this.syncCalendarWithInputValue((el as HTMLInputElement).value);
+          this.setupFormIntegration();
+        }
         this.updateActivePreset();
 
+        el.addEventListener('focus', () => this.syncCalendarWithInputValue());
+        el.addEventListener('click', () => this.syncCalendarWithInputValue());
+        el.addEventListener('click', (e) => this.handleNavigationClick(e));
+        el.addEventListener(TUTOR_CUSTOM_EVENTS.CALENDAR_SYNC, (event: Event) => {
+          const customEvent = event as CustomEvent<{ value?: string }>;
+          this.syncCalendarWithInputValue(customEvent.detail?.value);
+        });
         el.addEventListener('click', (e) => this.handlePresetClick(e));
         el.addEventListener('click', (e) => this.handleActionClick(e));
         window.addEventListener('popstate', this.updateActivePreset);
@@ -191,6 +291,13 @@ export function calendar({ options, hidePopover }: { options: OptionsCalendar; h
       } else if (action === 'clear') {
         this.clear();
       }
+    },
+
+    handleNavigationClick(e: Event) {
+      const target = (e.target as HTMLElement).closest('[data-vc="controls"]');
+      if (!target) return;
+
+      e.stopPropagation();
     },
 
     handlePresetClick(e: Event) {
@@ -219,15 +326,15 @@ export function calendar({ options, hidePopover }: { options: OptionsCalendar; h
     },
 
     handleInputSelection(self: Calendar) {
-      let inputValue = '';
-
-      if (self.context.selectedDates[0]) {
-        inputValue = `${self.context.selectedDates[0]} ${self.context.selectedTime ?? ''}`;
-      }
+      const selectedDate = self.context.selectedDates[0] ?? '';
+      const selectedTime = self.context.selectedTime ?? '';
+      const inputValue = `${selectedDate}${selectedTime ? ` ${selectedTime}` : ''}`.trim();
 
       if (self.context.inputElement) {
         self.context.inputElement.value = inputValue;
+        self.context.inputElement.dispatchEvent(new Event('input', { bubbles: true }));
         self.context.inputElement.dispatchEvent(new Event('change', { bubbles: true }));
+        self.context.inputElement.dispatchEvent(new Event('blur', { bubbles: true }));
         self.hide();
       }
     },

--- a/assets/core/ts/components/calendar.ts
+++ b/assets/core/ts/components/calendar.ts
@@ -1,5 +1,4 @@
 import { type AlpineComponentMeta } from '@Core/ts/types';
-import { TUTOR_CUSTOM_EVENTS } from '@Core/ts/constant';
 import { tutorConfig } from '@TutorShared/config/config';
 import { DateFormats } from '@TutorShared/config/constants';
 import { __ } from '@wordpress/i18n';
@@ -263,10 +262,6 @@ export function calendar({ options, hidePopover }: { options: OptionsCalendar; h
         el.addEventListener('focus', () => this.syncCalendarWithInputValue());
         el.addEventListener('click', () => this.syncCalendarWithInputValue());
         el.addEventListener('click', (e) => this.handleNavigationClick(e));
-        el.addEventListener(TUTOR_CUSTOM_EVENTS.CALENDAR_SYNC, (event: Event) => {
-          const customEvent = event as CustomEvent<{ value?: string }>;
-          this.syncCalendarWithInputValue(customEvent.detail?.value);
-        });
         el.addEventListener('click', (e) => this.handlePresetClick(e));
         el.addEventListener('click', (e) => this.handleActionClick(e));
         window.addEventListener('popstate', this.updateActivePreset);

--- a/assets/core/ts/components/calendar.ts
+++ b/assets/core/ts/components/calendar.ts
@@ -1,6 +1,3 @@
-import { type AlpineComponentMeta } from '@Core/ts/types';
-import { tutorConfig } from '@TutorShared/config/config';
-import { DateFormats } from '@TutorShared/config/constants';
 import { __ } from '@wordpress/i18n';
 import {
   endOfMonth,
@@ -13,9 +10,12 @@ import {
   subMonths,
   subYears,
 } from 'date-fns';
-import { type Calendar, Calendar as VanillaCalendar } from 'vanilla-calendar-pro';
-import type OptionsCalendar from 'vanilla-calendar-pro/options';
-// @ts-ignore
+
+import { type AlpineComponentMeta } from '@Core/ts/types';
+import { tutorConfig } from '@TutorShared/config/config';
+import { DateFormats } from '@TutorShared/config/constants';
+import { type Calendar, type Options, Calendar as VanillaCalendar } from 'vanilla-calendar-pro';
+
 import 'vanilla-calendar-pro/styles/index.css';
 
 const PRESETS = {
@@ -42,7 +42,7 @@ const PRESET_LABELS: Record<Preset, string> = {
   [PRESETS.LAST_YEAR]: __('Last year', 'tutor'),
 };
 
-export function calendar({ options, hidePopover }: { options: OptionsCalendar; hidePopover?: () => void }) {
+export function calendar({ options, hidePopover }: { options: Options; hidePopover?: () => void }) {
   return {
     $el: undefined as HTMLElement | HTMLInputElement | undefined,
     $nextTick: null as unknown as (callback: () => void) => void,
@@ -87,9 +87,7 @@ export function calendar({ options, hidePopover }: { options: OptionsCalendar; h
         return;
       }
 
-      const formElement = inputElement.closest(
-        'form[x-data*="tutorForm"], form[x-data*="form("]',
-      ) as HTMLElement | null;
+      const formElement = inputElement.closest('form[x-data*="tutorForm"]') as HTMLElement | null;
       if (!formElement) {
         return;
       }

--- a/assets/core/ts/constant.ts
+++ b/assets/core/ts/constant.ts
@@ -8,7 +8,6 @@ export const TUTOR_CUSTOM_EVENTS = {
   FORM_REGISTER: 'tutor-form-register',
   FORM_UNREGISTER: 'tutor-form-unregister',
   FORM_STATE_CHANGE: 'tutor-form-state-change',
-  CALENDAR_SYNC: 'tutor-calendar:sync',
   TUTOR_PLAYER_READY: 'tutor-player-ready',
   COMMENT_REPLIED: 'tutor:comment:replied',
   LESSON_PLAYER_READY: 'tutorLessonPlayerReady',

--- a/assets/core/ts/constant.ts
+++ b/assets/core/ts/constant.ts
@@ -8,6 +8,7 @@ export const TUTOR_CUSTOM_EVENTS = {
   FORM_REGISTER: 'tutor-form-register',
   FORM_UNREGISTER: 'tutor-form-unregister',
   FORM_STATE_CHANGE: 'tutor-form-state-change',
+  CALENDAR_SYNC: 'tutor-calendar:sync',
   TUTOR_PLAYER_READY: 'tutor-player-ready',
   COMMENT_REPLIED: 'tutor:comment:replied',
   LESSON_PLAYER_READY: 'tutorLessonPlayerReady',

--- a/templates/demo-components/components/form.php
+++ b/templates/demo-components/components/form.php
@@ -9,6 +9,8 @@
  */
 
 use Tutor\Icon;
+use Tutor\Components\InputField;
+use Tutor\Components\Constants\InputType;
 
 ?>
 <section class="tutor-bg-white tutor-py-6 tutor-px-8 tutor-rounded-lg tutor-shadow-sm">
@@ -846,10 +848,10 @@ use Tutor\Icon;
 							<div class="tutor-error-text" x-cloak x-show="errors.lastName" x-text="errors?.lastName?.message" role="alert" aria-live="polite"></div>
 						</div>
 
-						<!-- Email -->
-						<div class="tutor-input-field tutor-mb-4" :class="{
-							'tutor-input-field-error': errors.profileEmail,
-						}">
+							<!-- Email -->
+							<div class="tutor-input-field tutor-mb-4" :class="{
+								'tutor-input-field-error': errors.profileEmail,
+							}">
 							<label for="profileEmail" class="tutor-label tutor-label-required">Email</label>
 							<div class="tutor-input-wrapper">
 								<input 
@@ -873,11 +875,39 @@ use Tutor\Icon;
 									<?php echo esc_html( tutor_utils()->render_svg_icon( Icon::CROSS, 16, 16 ) ); ?>
 								</button>
 							</div>
-							<div class="tutor-error-text" x-cloak x-show="errors.profileEmail" x-text="errors?.profileEmail?.message" role="alert" aria-live="polite"></div>
-						</div>
+								<div class="tutor-error-text" x-cloak x-show="errors.profileEmail" x-text="errors?.profileEmail?.message" role="alert" aria-live="polite"></div>
+							</div>
 
-						<div class="tutor-flex tutor-gap-3">
-							<button 
+							<?php
+							InputField::make()
+								->type( InputType::DATE )
+								->name( 'profilePublishDate' )
+								->id( 'profilePublishDate' )
+								->label( 'Publish Date' )
+								->placeholder( 'Select publish date' )
+								->required()
+								->clearable()
+								->help_text( 'Used for TutorCore.form set/reset Date demo.' )
+								->attr( 'class', 'tutor-mb-4' )
+								->attr( 'x-bind', "register('profilePublishDate', { required: 'Publish date is required' })" )
+								->render();
+
+							InputField::make()
+								->type( InputType::DATE_TIME )
+								->name( 'profilePublishDateTime' )
+								->id( 'profilePublishDateTime' )
+								->label( 'Publish DateTime' )
+								->placeholder( 'Select publish date and time' )
+								->required()
+								->clearable()
+								->help_text( 'Used for TutorCore.form set/reset DateTime demo.' )
+								->attr( 'class', 'tutor-mb-4' )
+								->attr( 'x-bind', "register('profilePublishDateTime', { required: 'Publish date time is required' })" )
+								->render();
+							?>
+
+							<div class="tutor-flex tutor-gap-3">
+								<button 
 								type="submit" 
 								class="tutor-btn tutor-btn-primary"
 								:disabled="isSubmitting"
@@ -910,7 +940,9 @@ use Tutor\Icon;
 								onclick="TutorCore.form.setValues('profile-form', {
 									firstName: 'Jane',
 									lastName: 'Smith',
-									profileEmail: 'jane.smith@example.com'
+									profileEmail: 'jane.smith@example.com',
+									profilePublishDate: '2026-02-25',
+									profilePublishDateTime: '2026-02-25 10:30 AM'
 								}, { shouldValidate: true })"
 								class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
 							>
@@ -928,15 +960,35 @@ use Tutor\Icon;
 							</button>
 						</div>
 
-						<!-- Set Single Value -->
-						<div>
-							<button 
-								onclick="TutorCore.form.setValue('profile-form', 'firstName', 'John', { shouldValidate: true })"
-								class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
-							>
-								✏️ Set First Name
-							</button>
-						</div>
+							<!-- Set Single Value -->
+							<div>
+								<button 
+									onclick="TutorCore.form.setValue('profile-form', 'firstName', 'John', { shouldValidate: true })"
+									class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
+								>
+									✏️ Set First Name
+								</button>
+							</div>
+
+							<!-- Set Date -->
+							<div>
+								<button 
+									onclick="TutorCore.form.setValue('profile-form', 'profilePublishDate', '2026-03-20', { shouldValidate: true, shouldTouch: true })"
+									class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
+								>
+									📅 Set Publish Date
+								</button>
+							</div>
+
+							<!-- Set DateTime -->
+							<div>
+								<button 
+									onclick="TutorCore.form.setValue('profile-form', 'profilePublishDateTime', '2026-03-20 02:45 PM', { shouldValidate: true, shouldTouch: true })"
+									class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
+								>
+									🕒 Set Publish DateTime
+								</button>
+							</div>
 
 						<!-- Validate Form -->
 						<div>
@@ -968,15 +1020,25 @@ use Tutor\Icon;
 							</button>
 						</div>
 
-						<!-- Focus Field -->
-						<div>
-							<button 
-								onclick="TutorCore.form.setFocus('profile-form', 'firstName', { shouldSelect: true })"
-								class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
+							<!-- Focus Field -->
+							<div>
+								<button 
+									onclick="TutorCore.form.setFocus('profile-form', 'firstName', { shouldSelect: true })"
+									class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
 							>
-								🎯 Focus First Name
-							</button>
-						</div>
+									🎯 Focus First Name
+								</button>
+							</div>
+
+							<!-- Focus Date -->
+							<div>
+								<button 
+									onclick="TutorCore.form.setFocus('profile-form', 'profilePublishDate')"
+									class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
+								>
+									🎯 Focus Publish Date
+								</button>
+							</div>
 
 						<!-- Reset Form -->
 						<div>

--- a/templates/demo-components/components/form.php
+++ b/templates/demo-components/components/form.php
@@ -1020,25 +1020,25 @@ use Tutor\Components\Constants\InputType;
 							</button>
 						</div>
 
-							<!-- Focus Field -->
-							<div>
-								<button 
-									onclick="TutorCore.form.setFocus('profile-form', 'firstName', { shouldSelect: true })"
-									class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
+						<!-- Focus Field -->
+						<div>
+							<button 
+								onclick="TutorCore.form.setFocus('profile-form', 'firstName', { shouldSelect: true })"
+								class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
 							>
-									🎯 Focus First Name
-								</button>
-							</div>
+								🎯 Focus First Name
+							</button>
+						</div>
 
-							<!-- Focus Date -->
-							<div>
-								<button 
-									onclick="TutorCore.form.setFocus('profile-form', 'profilePublishDate')"
-									class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
-								>
-									🎯 Focus Publish Date
-								</button>
-							</div>
+						<!-- Focus Date -->
+						<div>
+							<button 
+								onclick="TutorCore.form.setFocus('profile-form', 'profilePublishDate')"
+								class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
+							>
+								🎯 Focus Publish Date
+							</button>
+						</div>
 
 						<!-- Reset Form -->
 						<div>

--- a/templates/demo-components/components/form.php
+++ b/templates/demo-components/components/form.php
@@ -849,9 +849,9 @@ use Tutor\Components\Constants\InputType;
 						</div>
 
 							<!-- Email -->
-							<div class="tutor-input-field tutor-mb-4" :class="{
-								'tutor-input-field-error': errors.profileEmail,
-							}">
+						<div class="tutor-input-field tutor-mb-4" :class="{
+							'tutor-input-field-error': errors.profileEmail,
+						}">
 							<label for="profileEmail" class="tutor-label tutor-label-required">Email</label>
 							<div class="tutor-input-wrapper">
 								<input 
@@ -875,10 +875,10 @@ use Tutor\Components\Constants\InputType;
 									<?php echo esc_html( tutor_utils()->render_svg_icon( Icon::CROSS, 16, 16 ) ); ?>
 								</button>
 							</div>
-								<div class="tutor-error-text" x-cloak x-show="errors.profileEmail" x-text="errors?.profileEmail?.message" role="alert" aria-live="polite"></div>
-							</div>
+							<div class="tutor-error-text" x-cloak x-show="errors.profileEmail" x-text="errors?.profileEmail?.message" role="alert" aria-live="polite"></div>
+						</div>
 
-							<?php
+						<?php
 							InputField::make()
 								->type( InputType::DATE )
 								->name( 'profilePublishDate' )
@@ -904,10 +904,10 @@ use Tutor\Components\Constants\InputType;
 								->attr( 'class', 'tutor-mb-4' )
 								->attr( 'x-bind', "register('profilePublishDateTime', { required: 'Publish date time is required' })" )
 								->render();
-							?>
+						?>
 
-							<div class="tutor-flex tutor-gap-3">
-								<button 
+						<div class="tutor-flex tutor-gap-3">
+							<button 
 								type="submit" 
 								class="tutor-btn tutor-btn-primary"
 								:disabled="isSubmitting"
@@ -941,8 +941,8 @@ use Tutor\Components\Constants\InputType;
 									firstName: 'Jane',
 									lastName: 'Smith',
 									profileEmail: 'jane.smith@example.com',
-									profilePublishDate: '2026-02-25',
-									profilePublishDateTime: '2026-02-25 10:30 AM'
+									profilePublishDate: '2026-03-25',
+									profilePublishDateTime: '2026-03-25 10:30 AM'
 								}, { shouldValidate: true })"
 								class="tutor-btn tutor-btn-outline tutor-btn-small tutor-w-full"
 							>


### PR DESCRIPTION
## Summary
This change improves Date and DateTime input behavior in Playground and Form Service API examples by fully syncing the calendar UI with Tutor form state. It ensures external form actions (set/reset/focus flows through `TutorCore.form`) are reflected in the calendar popover and selected month/time state.

## Issue and User Impact
Date and DateTime fields rendered via calendar input mode could drift from form state when values were updated outside direct calendar clicks. In practice, this caused inconsistent behavior where users could reset or set values from form APIs but the calendar popover might open on a different month or show stale selection, creating confusion and reducing trust in form controls.

## Root Cause
Calendar state and input/form state were not fully synchronized for all update paths. The input value could change through form service calls while the internal calendar selection context remained unchanged. Navigation interactions also bubbled click events to outer handlers.

## Fix
- Added robust input parsing and synchronization helpers in `calendar.ts`:
  - Parse current input string into selected date/time parts.
  - Re-apply parsed selection to the calendar instance whenever input/form value changes.
- Added form integration behavior inside calendar input mode (similar to select component integration):
  - Detect parent `tutorForm` Alpine form instance.
  - Initialize/sync field value and baseline behavior for API-driven changes.
  - Watch form value updates and keep input + calendar state aligned.
- Improved input event dispatch after calendar selection:
  - Dispatch `input`, `change`, and `blur` to keep form touched/dirty/validation behavior consistent.
- Prevented propagation for previous/next calendar navigation controls so parent popover/global handlers are not accidentally triggered.
- Added shared event constant `CALENDAR_SYNC` in `assets/core/ts/constant.ts` and used it in calendar listener code.
- Added/updated Form Service API demo in Playground (`form.php`) to include Date and DateTime field controls via `TutorCore.form` methods.

## Validation
- `npx eslint assets/core/ts/components/calendar.ts assets/core/ts/constant.ts`
- `php -l templates/demo-components/components/form.php`
- Manual flow covered through Form Service API demo controls for:
  - `setValue`
  - `setValues`
  - `reset`
  - focus behavior
