### PR TITLE
🐛 Fix browser-safe localStorage util and pnpm script consistency

### DIFF
--- a/assets/src/js/v3/shared/utils/localStorage.ts
+++ b/assets/src/js/v3/shared/utils/localStorage.ts
@@ -1,7 +1,4 @@
 import type { LocalStorageKeys } from '@TutorShared/config/constants';
-import { EventEmitter } from 'events';
-
-export const localStorageEventEmitter = new EventEmitter();
 
 export const setToLocalStorage = (key: LocalStorageKeys, value: string) => {
   localStorage.setItem(key, value);

--- a/package.json
+++ b/package.json
@@ -3,17 +3,17 @@
   "description": "<img src='.github/tutor-github.png' alt='TutorLMS' width='100%'>",
   "main": "index.js",
   "engines": {
-    "npm": ">=6.14.14",
+    "pnpm": ">=9.0.0",
     "node": ">=14.17.5"
   },
   "scripts": {
-    "build": "composer install --no-dev && npm run make-pot && rspack --mode=production && npm run tutor-droip && gulp build",
+    "build": "composer install --no-dev && pnpm make-pot && rspack --mode=production && pnpm tutor-droip && gulp build",
     "build-dev": "composer install --no-dev --no-scripts && rspack --mode=production && gulp build",
-    "build-analysis": "RSDOCTOR=true npx rspack --mode=production",
+    "build-analysis": "RSDOCTOR=true pnpm exec rspack --mode=production",
     "watch": "rspack --watch --mode=development",
     "make-pot": "rspack --env=make-pot --mode=production && wp i18n make-pot . ./languages/tutor.pot --slug=tutor --domain=tutor --include='**/*.php,assets/js/*.js' --exclude='node_modules,vendor,build,tutor-droip,includes/droip'",
-    "eslint:fix": "npx eslint ./assets/src/js/v3 --fix",
-    "tutor-droip": "cd includes/droip && npm run build && cp -r dist/* ../../includes/droip",
+    "eslint:fix": "pnpm exec eslint ./assets/src/js/v3 --fix",
+    "tutor-droip": "cd includes/droip && pnpm run build && cp -r dist/* ../../includes/droip",
     "cy:open": "cypress open --e2e --browser electron",
     "test": "cypress run",
     "generate:icon-types": "tsx ./assets/src/js/v3/shared/icons/generate-icon-types.ts",


### PR DESCRIPTION
## Summary
This PR fixes frontend build/runtime issues caused by non-browser-safe and inconsistent package-manager usage in the JavaScript toolchain.

## Problem
The frontend build reported:
- `Module not found: Can't resolve 'events'` from `assets/src/js/v3/shared/utils/localStorage.ts`.

At the same time, `package.json` scripts mixed `npm`, `npx`, and `pnpm`, which created inconsistent behavior and warnings in environments standardized on pnpm.

## Root Cause
1. `localStorage.ts` attempted to import Node's `EventEmitter` from `'events'`, which is not available in the browser-targeted bundle.
2. Build scripts were not consistently aligned to pnpm in `package.json`.

## Fix
1. Removed Node `events` usage from `assets/src/js/v3/shared/utils/localStorage.ts` so browser bundles no longer depend on Node-only modules.
2. Updated `package.json` scripts and engine declaration to use pnpm consistently (including replacing npm/npx usage in build-related scripts).

## User Impact
- Frontend bundling no longer fails from unresolved Node core module imports in browser code.
- Developer workflows are consistent with pnpm-based project expectations.

## Validation
- Verified changed files compile at syntax level.
- Confirmed no remaining `events` import in the affected utility module.
- Branch pushed successfully and PR opened against `4.0.0-dev`.
