### PR TITLE
v4-fixes

### DIFF
--- a/assets/src/scss/frontend/components/_quiz-attempts.scss
+++ b/assets/src/scss/frontend/components/_quiz-attempts.scss
@@ -11,10 +11,19 @@
 }
 
 .tutor-quiz-attempts {
-  @include tutor-breakpoint-down(sm) {
-    background-color: $tutor-surface-l1;
-    border: 1px solid $tutor-border-idle;
-    border-radius: $tutor-radius-2xl;
+  .tutor-quiz-students-attempts-filter-item:nth-child(1) {
+    .tutor-btn-link {
+      span:nth-child(1) {
+        color: $tutor-text-secondary;
+      }
+      span:nth-child(2) {
+        color: $tutor-text-primary;
+      }
+
+      svg {
+        color: $tutor-icon-secondary;
+      }
+    }
   }
 
   &-filter {
@@ -22,7 +31,7 @@
     padding: $tutor-spacing-5 $tutor-spacing-6;
     border-bottom: 1px solid $tutor-border-idle;
     display: grid;
-    grid-template-areas: 'nav search calender sort';
+    grid-template-areas: 'nav clear_filter search calender sort';
     @include tutor-breakpoint-down(sm) {
       padding: 0;
     }
@@ -32,12 +41,15 @@
         grid-area: nav;
       }
       &:nth-child(2) {
-        grid-area: search;
+        grid-area: clear_filter;
       }
       &:nth-child(3) {
-        grid-area: calender;
+        grid-area: search;
       }
       &:nth-child(4) {
+        grid-area: calender;
+      }
+      &:nth-child(5) {
         grid-area: sort;
       }
     }
@@ -57,28 +69,28 @@
     }
 
     @include tutor-breakpoint-up(sm) {
-      grid-template-columns: 1fr auto auto auto;
+      grid-template-columns: 1fr auto;
       gap: $tutor-spacing-3;
     }
 
     @include tutor-breakpoint-down(sm) {
       grid-template-areas:
-        'search sort'
-        'nav calender';
+        'search search search sort'
+        'nav clear_filter calender calender';
       grid-template-columns: 1fr auto;
       &-item {
-        &:nth-child(2) {
+        &:nth-child(3) {
           border-bottom: 1px solid $tutor-border-idle;
           padding: $tutor-spacing-5 $tutor-spacing-4 $tutor-spacing-5 $tutor-spacing-5;
         }
-        &:nth-child(4) {
+        &:nth-child(5) {
           border-bottom: 1px solid $tutor-border-idle;
           padding: $tutor-spacing-5 $tutor-spacing-5 $tutor-spacing-5 $tutor-spacing-4;
         }
         &:nth-child(1) {
           padding: $tutor-spacing-5 $tutor-spacing-4 $tutor-spacing-5 $tutor-spacing-5;
         }
-        &:nth-child(3) {
+        &:nth-child(4) {
           padding: $tutor-spacing-5 $tutor-spacing-5 $tutor-spacing-5 $tutor-spacing-4;
         }
       }
@@ -373,6 +385,12 @@
     @include tutor-breakpoint-down(sm) {
       padding: $tutor-spacing-5;
     }
+  }
+
+  @include tutor-breakpoint-down(sm) {
+    background-color: $tutor-surface-l1;
+    border: 1px solid $tutor-border-idle;
+    border-radius: $tutor-radius-2xl;
   }
 }
 

--- a/assets/src/scss/frontend/components/_quiz-attempts.scss
+++ b/assets/src/scss/frontend/components/_quiz-attempts.scss
@@ -11,20 +11,6 @@
 }
 
 .tutor-quiz-attempts {
-  .tutor-quiz-students-attempts-filter-item:nth-child(1) {
-    .tutor-btn-link {
-      span:nth-child(1) {
-        color: $tutor-text-secondary;
-      }
-      span:nth-child(2) {
-        color: $tutor-text-primary;
-      }
-
-      svg {
-        color: $tutor-icon-secondary;
-      }
-    }
-  }
 
   &-filter {
     @include tutor-flex(row, center, space-between);

--- a/components/StarRatingInput.php
+++ b/components/StarRatingInput.php
@@ -164,7 +164,7 @@ class StarRatingInput extends BaseComponent {
 				<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
 					<button 
 						type="button"
-						class="tutor-btn tutor-btn-link tutor-p-none tutor-min-h-0"
+						class="tutor-btn tutor-p-none tutor-min-h-0 tutor-bg-transparent"
 						@click="setRating(<?php echo esc_attr( $i ); ?>, (rating) => setValue('<?php echo esc_attr( $this->field_name ); ?>', rating))"
 						@mouseenter="hoverRating = <?php echo esc_attr( $i ); ?>"
 					>

--- a/templates/dashboard/my-quiz-attempts.php
+++ b/templates/dashboard/my-quiz-attempts.php
@@ -11,7 +11,9 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Tutor\Components\Button;
 use Tutor\Components\ConfirmationModal;
+use Tutor\Components\Constants\Variant;
 use Tutor\Components\DropdownFilter;
 use Tutor\Components\EmptyState;
 use Tutor\Components\Pagination;
@@ -57,8 +59,21 @@ $nav_links = $quiz_attempt_obj->get_quiz_attempts_nav_data( $quiz_attempts, $qui
 						->render();
 				?>
 				</div>
-				<div class="tutor-quiz-students-attempts-filter-item">
-					<?php Sorting::make()->order( $order_filter )->render(); ?>
+				<div class="tutor-quiz-students-attempts-filter-item tutor-flex tutor-items-center tutor-gap-4">
+					<?php
+
+					if ( Input::has_any( array( 'result', 'order' ), Input::GET_REQUEST ) ) {
+						Button::make()
+						->tag( 'a' )
+						->attr( 'href', tutor_utils()->tutor_dashboard_url( 'courses/my-quiz-attempts' ) )
+						->attr( 'class', 'tutor-text-brand' )
+						->label( __( 'Clear all', 'tutor' ) )
+						->variant( Variant::LINK )
+						->render();
+					}
+					Sorting::make()->order( $order_filter )->render();
+
+					?>
 				</div>
 			</div>
 			<div class="tutor-quiz-attempts-header">

--- a/templates/dashboard/quiz-attempts.php
+++ b/templates/dashboard/quiz-attempts.php
@@ -11,6 +11,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Tutor\Components\Button;
 use Tutor\Components\ConfirmationModal;
 use Tutor\Components\Constants\Positions;
 use Tutor\Components\Constants\Size;
@@ -21,6 +22,7 @@ use Tutor\Components\EmptyState;
 use Tutor\Components\Pagination;
 use Tutor\Components\SearchFilter;
 use Tutor\Components\Sorting;
+use Tutor\Helpers\UrlHelper;
 use TUTOR\Icon;
 use TUTOR\Input;
 use Tutor\Models\QuizModel;
@@ -47,10 +49,14 @@ $search_filter = Input::get( 'search', '' );
 
 $quiz_attempts           = QuizModel::get_quiz_attempts( 0, 0, $search_filter, '', $date_filter, $order_filter, null, false, true );
 $quiz_attempts_formatted = QuizModel::format_quiz_attempts( $quiz_attempts, $result_filter );
-$quiz_attempts_list      = array_slice( $quiz_attempts_formatted, $offset, $item_per_page, true );
 $quiz_attempts_count     = (int) count( $quiz_attempts_formatted );
 
-$nav_links = $quiz_attempt_obj->get_quiz_attempts_nav_data( $quiz_attempts, $quiz_attempts_count, get_pagenum_link(), $result_filter );
+if ( Input::has( 'date', Input::GET_REQUEST ) && $quiz_attempts_count <= $offset ) {
+	$offset = 0;
+}
+
+$quiz_attempts_list = array_slice( $quiz_attempts_formatted, $offset, $item_per_page, true );
+$nav_links          = $quiz_attempt_obj->get_quiz_attempts_nav_data( $quiz_attempts, $quiz_attempts_count, get_pagenum_link(), $result_filter );
 
 ?>
 
@@ -59,7 +65,6 @@ $nav_links = $quiz_attempt_obj->get_quiz_attempts_nav_data( $quiz_attempts, $qui
 	<?php esc_html_e( 'Quiz Attempts', 'tutor' ); ?>
 	</h4>
 	<div class="tutor-dashboard-page-card">
-		<?php if ( $quiz_attempts_count ) : ?>
 		<div class="tutor-quiz-attempts">
 			<div class="tutor-quiz-attempts-filter">
 				<div class="tutor-quiz-attempts-filter-item">
@@ -69,6 +74,20 @@ $nav_links = $quiz_attempt_obj->get_quiz_attempts_nav_data( $quiz_attempts, $qui
 							->query_param( 'result' )
 							->variant( Variant::PRIMARY_SOFT )
 							->render();
+					?>
+				</div>
+								<div class="tutor-quiz-attempts-filter-item">
+					<?php
+					$query_items = array( 'search', 'date', 'result', 'order' );
+					if ( Input::has_any( $query_items, Input::GET_REQUEST ) ) {
+						Button::make()
+							->tag( 'a' )
+							->attr( 'href', tutor_utils()->tutor_dashboard_url( 'quiz-attempts' ) )
+							->attr( 'class', 'tutor-text-brand' )
+							->label( __( 'Clear all', 'tutor' ) )
+							->variant( Variant::LINK )
+							->render();
+					}
 					?>
 				</div>
 				<div class="tutor-quiz-attempts-filter-item">
@@ -85,7 +104,7 @@ $nav_links = $quiz_attempt_obj->get_quiz_attempts_nav_data( $quiz_attempts, $qui
 					<?php
 						DateFilter::make()
 							->type( DateFilter::TYPE_SINGLE )
-							->placement( Positions::BOTTOM_START )
+							->placement( Positions::BOTTOM_END )
 							->trigger_size( Size::X_SMALL )
 							->icon_size( 15 )
 							->render();
@@ -101,6 +120,7 @@ $nav_links = $quiz_attempt_obj->get_quiz_attempts_nav_data( $quiz_attempts, $qui
 				<div class="tutor-quiz-attempts-header-item"><?php esc_html_e( 'Time', 'tutor' ); ?></div>
 				<div class="tutor-quiz-attempts-header-item"><?php esc_html_e( 'Result', 'tutor' ); ?></div>
 			</div>
+		<?php if ( $quiz_attempts_count ) : ?>
 			<div class="tutor-quiz-attempts-list">
 				<?php
 				foreach ( $quiz_attempts_list as $quiz_index => $quiz_attempt ) {
@@ -133,7 +153,6 @@ $nav_links = $quiz_attempt_obj->get_quiz_attempts_nav_data( $quiz_attempts, $qui
 	</div>
 	<div class="tutor-pt-6">
 		<?php
-		if ( $quiz_attempts_count > $item_per_page ) {
 			Pagination::make()
 			->current( $current_page )
 			->total( $quiz_attempts_count )
@@ -141,7 +160,6 @@ $nav_links = $quiz_attempt_obj->get_quiz_attempts_nav_data( $quiz_attempts, $qui
 			->prev( tutor_utils()->get_svg_icon( Icon::CHEVRON_LEFT_2 ) )
 			->next( tutor_utils()->get_svg_icon( Icon::CHEVRON_RIGHT_2 ) )
 			->render();
-		}
 		?>
 	</div>
 	<?php


### PR DESCRIPTION
### Instructor Quiz Attempt List Page

- Fixed the issue where after filtering if there is no result the filter also does not show, only the empty state shows
- Added Clear All button to clear the filters
- Style Fixes
- Fixed the issue where after a pagination link is clicked and after that when the date filter is set it does not show any data, this is due to the `current_page` filter is still added on the url. To fix this i check if the date filter is added in the url and if the current count of attempts exceed the max then i set the offset to 0 so that it doesn't give me offset value when querying

### Student Quiz Attempt List Page

- Added Clear All button to clear the filters
- Updated style of dropdown filter `btn-link` class