### PR TITLE
✨ Add max file selection support to uploader

### DIFF
--- a/assets/core/ts/components/file-uploader.ts
+++ b/assets/core/ts/components/file-uploader.ts
@@ -10,6 +10,7 @@ type FileUploaderVariant = 'file-uploader' | 'image-uploader';
 
 export interface FileUploaderProps {
   multiple?: boolean;
+  maxFiles?: number;
   accept?: string;
   maxSize?: number; // in bytes
   onFileSelect?: (files: (File | WPMedia | string)[]) => void;
@@ -28,6 +29,7 @@ export interface FileUploaderProps {
 
 const defaultProps = {
   multiple: false,
+  maxFiles: undefined,
   accept: '.pdf,.doc,.docx,.jpg,.jpeg,.png',
   maxSize: Number(tutorConfig.max_upload_size),
   variant: 'file-uploader',
@@ -81,6 +83,7 @@ export const fileUploader = (props: FileUploaderProps = defaultProps) => ({
   isDragOver: false,
   isDisabled: props.disabled,
   multiple: !!props.multiple,
+  maxFiles: props.maxFiles,
   accept: props.accept,
   maxSize: props.maxSize || 52428800,
   variant: props.variant,
@@ -170,6 +173,7 @@ export const fileUploader = (props: FileUploaderProps = defaultProps) => ({
         multiple: this.multiple,
         library: this.wpMediaLibraryType ? { type: this.wpMediaLibraryType } : undefined,
         maxFileSize: this.maxSize,
+        maxFiles: this.maxFiles,
       },
       (files: WPMedia[]) => {
         this.processFiles(files);
@@ -228,7 +232,20 @@ export const fileUploader = (props: FileUploaderProps = defaultProps) => ({
       }
 
       if (this.multiple) {
-        this.selectedFiles = this.mergeFileLists(this.selectedFiles, validFiles);
+        const mergedFiles = this.mergeFileLists(this.selectedFiles, validFiles);
+
+        if (this.maxFiles && mergedFiles.length > this.maxFiles) {
+          this.showError(
+            sprintf(
+              // translators: %d is the maximum number of files allowed
+              __('Cannot select more than %d files', 'tutor'),
+              this.maxFiles,
+            ),
+          );
+          return;
+        }
+
+        this.selectedFiles = mergedFiles;
       } else {
         this.selectedFiles = [validFiles[0]];
       }

--- a/components/FileUploader.php
+++ b/components/FileUploader.php
@@ -29,6 +29,7 @@ use Tutor\Components\AttachmentCard;
  *     ->uploader_subtitle( __( 'Support PDF, DOCX (Max 20MB)', 'tutor' ) )
  *     ->accept( '.pdf,.docx' )
  *     ->multiple( true )
+ *     ->max_files( 3 )
  *     ->max_size( 20 * 1024 * 1024 )
  *     ->render();
  *
@@ -99,6 +100,15 @@ class FileUploader extends BaseComponent {
 	 * @var int
 	 */
 	protected $max_size = null;
+
+	/**
+	 * File uploader max files.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @var int|null
+	 */
+	protected $max_files = null;
 
 	/**
 	 * File uploader icon.
@@ -267,6 +277,21 @@ class FileUploader extends BaseComponent {
 			$max_size = wp_max_upload_size();
 		}
 		$this->max_size = $max_size;
+
+		return $this;
+	}
+
+	/**
+	 * Set uploader max files.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param int|null $max_files Maximum number of selectable files.
+	 *
+	 * @return $this
+	 */
+	public function max_files( $max_files = null ) {
+		$this->max_files = null !== $max_files ? (int) $max_files : null;
 
 		return $this;
 	}
@@ -507,6 +532,7 @@ class FileUploader extends BaseComponent {
 		$multiple            = $this->multiple;
 		$accept              = $this->accept;
 		$max_size            = $this->max_size ?? wp_max_upload_size();
+		$max_files           = $this->max_files;
 		$icon                = $this->uploader_icon;
 		$title               = ! empty( $this->uploader_title ) ? $this->uploader_title : __( 'Drop files here or click to upload', 'tutor' );
 		$subtitle            = ! empty( $this->uploader_subtitle ) ? $this->uploader_subtitle : '';
@@ -528,6 +554,7 @@ class FileUploader extends BaseComponent {
 			class="tutor-file-uploader-wrapper"
 			x-data="tutorFileUploader({
 				multiple: <?php echo $multiple ? 'true' : 'false'; ?>,
+				maxFiles: <?php echo null !== $max_files ? (int) $max_files : 'undefined'; ?>,
 				accept: '<?php echo esc_attr( $accept ); ?>',
 				maxSize: <?php echo (int) $max_size; ?>,
 				onFileSelect: <?php echo esc_js( $on_file_select ); ?>,

--- a/templates/demo-components/components/file-uploader.php
+++ b/templates/demo-components/components/file-uploader.php
@@ -22,6 +22,7 @@ use TUTOR\Icon;
 		</p>
 		<div x-data="tutorFileUploader({
 			multiple: true,
+			maxFiles: 3,
 			accept: '.pdf,.doc,.docx,.jpg,.jpeg,.png',
 			maxSize: 52428800,
 			onFileSelect: (files) => console.log('Files selected:', files),
@@ -51,7 +52,7 @@ use TUTOR\Icon;
 				</div>
 				<div class="tutor-file-uploader-content">
 					<p class="tutor-file-uploader-title">Drop files here or click to upload</p>
-					<p class="tutor-file-uploader-subtitle">PDF, DOC, DOCX, JPG, PNG Formats (Max 50MB)</p>
+					<p class="tutor-file-uploader-subtitle">PDF, DOC, DOCX, JPG, PNG Formats (Max 50MB, up to 3 files)</p>
 				</div>
 				<button type="button" class="tutor-btn tutor-btn-primary-soft" :disabled="isDisabled">
 					Select Files
@@ -66,6 +67,7 @@ use TUTOR\Icon;
 		<div class="tutor-bg-gray-50 tutor-p-4 tutor-rounded-lg">
 			<pre class="tutor-text-sm tutor-text-gray-700"><code>&lt;div x-data="tutorFileUploader({
 	multiple: true,
+	maxFiles: 3,
 	accept: '.pdf,.doc,.docx,.jpg,.jpeg,.png',
 	maxSize: 52428800, // 50MB in bytes
 	onFileSelect: (files) => console.log('Files selected:', files),


### PR DESCRIPTION
## Summary
This PR adds maximum file-count support to the shared file uploader so upload limits can be enforced consistently across native file input, drag and drop, and the WordPress media library flow.

## Problem
The uploader already validated file size and file type, but it had no component-level limit for how many files a user could add in one field. That meant forms using the uploader could allow more files than intended, especially when users mixed repeated selections, drag and drop, and WordPress media selections. The PHP component API also had no way to declare a file-count limit, so consumers could not configure this behavior from server-rendered component usage.

## Root Cause
The TypeScript uploader component only tracked `multiple` as a boolean and merged new selections without checking the final count. Separately, the PHP `FileUploader` builder did not expose any `max_files` option, so the limit could not be passed into the Alpine component config or demonstrated in the component demo.

## Fix
The uploader now accepts a `maxFiles` prop in the TypeScript component and passes it through to the WordPress media service. For native input and drag/drop flows, the component validates the deduplicated merged file list before mutating state and shows the existing limit error message when the final selection exceeds the configured maximum. On the PHP side, the `FileUploader` component now exposes a `max_files()` setter and forwards that value into the frontend config. The demo component has also been updated to show a concrete `maxFiles: 3` example so the new API is visible and testable.

## Validation
- `npx eslint assets/core/ts/components/file-uploader.ts`
- `php -l components/FileUploader.php`
- `php -l templates/demo-components/components/file-uploader.php`
