### PR TITLE
🩹 Fix checkbox state and button styling

### DIFF
--- a/assets/core/scss/mixins/_layout.scss
+++ b/assets/core/scss/mixins/_layout.scss
@@ -37,6 +37,19 @@
   padding: 0 $tutor-spacing-6;
 }
 
+@mixin tutor-frontend-layout {
+  max-width: 760px;
+  margin: 0 auto;
+
+  @include tutor-breakpoint-up(2xl) {
+    max-width: 860px;
+  }
+
+  @include tutor-breakpoint-up(3xl) {
+    max-width: 944px;
+  }
+}
+
 @mixin tutor-visually-hidden {
   position: absolute !important;
   width: 1px !important;

--- a/assets/core/scss/tokens/_breakpoints.scss
+++ b/assets/core/scss/tokens/_breakpoints.scss
@@ -7,9 +7,11 @@ $tutor-breakpoint-md: 768px;
 $tutor-breakpoint-lg: 992px;
 $tutor-breakpoint-xl: 1200px;
 $tutor-breakpoint-2xl: 1400px;
+$tutor-breakpoint-3xl: 1920px;
 
 // Breakpoint map for mixins
 $tutor-breakpoints: (
+  3xl: $tutor-breakpoint-3xl,
   2xl: $tutor-breakpoint-2xl,
   xl: $tutor-breakpoint-xl,
   lg: $tutor-breakpoint-lg,

--- a/assets/core/ts/components/form.ts
+++ b/assets/core/ts/components/form.ts
@@ -418,16 +418,39 @@ export const form = (config: FormControlConfig & { id?: string } = {}) => {
       const type = element?.type ?? 'text';
       const isCheckbox = type === 'checkbox';
       const isFile = type === 'file';
+      const existingField = this.fields[name];
+      const isSameElement = existingField?.ref === element;
 
-      // Check if a checkbox with this name is already registered (indicates multiple checkboxes)
-      const isCheckboxArray = isCheckbox && this.fields[name]?.type === 'checkbox';
+      // Treat as checkbox group only when a different checkbox with the same name already exists; avoids upgrading a single checkbox to an array during re-registration (e.g., after DOM reorder).
+      const isCheckboxArray = isCheckbox && existingField?.type === 'checkbox' && !isSameElement;
 
       let defaultValue: unknown;
 
       if (isCheckboxArray) {
-        // Ensure array type for checkbox groups
+        // Ensure array type for checkbox groups and include any existing checked value
         const currentValue = this.values[name];
-        defaultValue = Array.isArray(currentValue) ? currentValue : [];
+        const aggregatedValues: string[] = Array.isArray(currentValue) ? [...currentValue] : [];
+
+        const existingCheckbox = existingField?.ref;
+        const existingChecked =
+          existingCheckbox?.checked ??
+          (typeof existingField?.defaultValue === 'boolean' ? existingField.defaultValue : false);
+
+        if (existingChecked) {
+          const existingValue = existingCheckbox?.value ?? 'on';
+          if (!aggregatedValues.includes(existingValue)) {
+            aggregatedValues.push(existingValue);
+          }
+        }
+
+        if (element?.checked) {
+          const currentValueToAdd = element.value ?? 'on';
+          if (!aggregatedValues.includes(currentValueToAdd)) {
+            aggregatedValues.push(currentValueToAdd);
+          }
+        }
+
+        defaultValue = aggregatedValues;
       } else if (isCheckbox) {
         defaultValue = this.values[name] ?? element?.checked ?? false;
       } else {

--- a/assets/src/js/frontend/dashboard/pages/instructor/home-charts.ts
+++ b/assets/src/js/frontend/dashboard/pages/instructor/home-charts.ts
@@ -108,9 +108,13 @@ const CHART_CONFIG = {
 } as const;
 
 const hexToRgba = (hex: string, alpha: number): string => {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
+  // Expand 3-digit hex (#RGB → #RRGGBB)
+  const normalized = hex.length === 4 ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}` : hex;
+
+  const r = parseInt(normalized.slice(1, 3), 16) || 0;
+  const g = parseInt(normalized.slice(3, 5), 16) || 0;
+  const b = parseInt(normalized.slice(5, 7), 16) || 0;
+
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
 

--- a/assets/src/js/frontend/dashboard/pages/instructor/sort-sections.ts
+++ b/assets/src/js/frontend/dashboard/pages/instructor/sort-sections.ts
@@ -1,209 +1,210 @@
 import { DragDropManager, KeyboardSensor, PointerSensor } from '@dnd-kit/dom';
 import { RestrictToElement } from '@dnd-kit/dom/modifiers';
 import { Sortable } from '@dnd-kit/dom/sortable';
-import { wpAjaxInstance } from '@TutorShared/utils/api';
 import type { AjaxResponse } from '@FrontendTypes/index';
+import { wpAjaxInstance } from '@TutorShared/utils/api';
+import { __ } from '@wordpress/i18n';
 
-export const sortSections = (sectionsIds: string[]) => ({
-  _sortables: [] as Sortable[],
-  _sortableSections: [] as HTMLElement[],
-  initialized: false,
-  sectionsIds: sectionsIds,
-  $el: null as HTMLElement | null,
+export const sortSections = (sectionsIds: string[]) => {
+  const toast = window.TutorCore.toast;
 
-  init() {
-    if (!this.initialized) {
-      this.setupDrag();
-      this.initialized = true;
-    }
-  },
+  return {
+    _sortables: [] as Sortable[],
+    _sortableSections: [] as HTMLElement[],
+    initialized: false,
+    sectionsIds: sectionsIds,
+    $el: null as HTMLElement | null,
 
-  setupDrag() {
-    const container = this.$el;
-    if (!container) {
-      return;
-    }
+    init() {
+      if (!this.initialized) {
+        this.setupDrag();
+        this.initialized = true;
+      }
+    },
 
-    const manager = new DragDropManager({
-      sensors: [PointerSensor, KeyboardSensor],
-    });
+    setupDrag() {
+      const container = this.$el;
+      if (!container) {
+        return;
+      }
 
-    const items = Array.from(container.querySelectorAll<HTMLElement>('.tutor-popover-menu-item'));
+      const manager = new DragDropManager({
+        sensors: [PointerSensor, KeyboardSensor],
+      });
 
-    this._sortables = [];
-    this._sortableSections = [];
+      const items = Array.from(container.querySelectorAll<HTMLElement>('.tutor-popover-menu-item'));
 
-    for (const [idx, element] of items.entries()) {
-      const handle = element.querySelector('[data-grab]') as HTMLElement | null;
-      const id = element.dataset.id ?? String(idx);
+      this._sortables = [];
+      this._sortableSections = [];
 
-      const sortable = new Sortable(
-        {
-          id,
-          index: idx,
-          element: element,
-          handle: handle ?? undefined,
-          modifiers: [
-            RestrictToElement.configure({
-              element: this.$el,
-            }),
-          ],
+      for (const [idx, element] of items.entries()) {
+        const handle = element.querySelector('[data-grab]') as HTMLElement | null;
+        const id = element.dataset.id ?? String(idx);
+
+        const sortable = new Sortable(
+          {
+            id,
+            index: idx,
+            element: element,
+            handle: handle ?? undefined,
+            modifiers: [
+              RestrictToElement.configure({
+                element: this.$el,
+              }),
+            ],
+          },
+          manager,
+        );
+
+        this._sortables.push(sortable);
+      }
+
+      manager.monitor.addEventListener('dragstart', (event) => {
+        const operation = event.operation;
+        if (!operation.source) {
+          return;
+        }
+
+        const sourceElement = operation.source.element;
+        if (!sourceElement) {
+          return;
+        }
+      });
+
+      manager.monitor.addEventListener('dragend', async (event) => {
+        const operation = event.operation;
+        if (!operation.source) {
+          return;
+        }
+
+        const sourceElement = operation.source.element;
+        if (!sourceElement) {
+          return;
+        }
+
+        const order = this.getOrder();
+        try {
+          const response = await wpAjaxInstance.post<undefined, AjaxResponse>(
+            'tutor_save_instructor_home_sections_order',
+            { order },
+          );
+
+          if (!response.success) {
+            toast.error((response?.data as string) || __('Failed to save instructor home section order.', 'tutor'));
+            return;
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : __('Unknown error occurred.', 'tutor');
+          toast.error(message);
+          return;
+        }
+
+        if ('startViewTransition' in document) {
+          setTimeout(() => {
+            document.startViewTransition(() => this.updateDom());
+          }, 260);
+        } else {
+          this.updateDom();
+        }
+      });
+    },
+
+    async handleCheckboxClick() {
+      const items = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).reduce(
+        (acc, checkbox) => {
+          acc[checkbox.name] = checkbox.checked;
+          return acc;
         },
-        manager,
+        {} as Record<string, boolean>,
       );
 
-      this._sortables.push(sortable);
-    }
-
-    manager.monitor.addEventListener('dragstart', (event) => {
-      const operation = event.operation;
-      if (!operation.source) {
-        return;
-      }
-
-      const sourceElement = operation.source.element;
-      if (!sourceElement) {
-        return;
-      }
-    });
-
-    manager.monitor.addEventListener('dragend', async (event) => {
-      const operation = event.operation;
-      if (!operation.source) {
-        return;
-      }
-
-      const sourceElement = operation.source.element;
-      if (!sourceElement) {
-        return;
-      }
-
-      const order = this.getOrder();
       try {
-        const response = await wpAjaxInstance.post<AjaxResponse, AjaxResponse>(
-          'tutor_save_instructor_home_sections_order',
-          { order },
+        const response = await wpAjaxInstance.post<undefined, AjaxResponse>(
+          'tutor_save_instructor_home_sections_visibility',
+          { items },
         );
 
         if (!response.success) {
-          window.TutorCore.toast.error(
-            response?.data || wp.i18n.__('Failed to save instructor home section order.', 'tutor'),
-          );
+          toast.error((response?.data as string) || __('Failed to save instructor home section visibility.', 'tutor'));
           return;
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : wp.i18n.__('Unknown error occurred.', 'tutor');
-        window.TutorCore.toast.error(message);
+        const message = error instanceof Error ? error.message : __('Unknown error occurred.', 'tutor');
+        toast.error(message);
+        return;
+      }
+    },
+
+    updateDom() {
+      const newOrder = this.getOrder();
+      const sectionMap = this.getSortableSections();
+
+      const firstSectionId = Object.keys(sectionMap)[0];
+      const parentContainer = firstSectionId ? sectionMap[firstSectionId]?.parentElement : null;
+
+      if (!parentContainer) {
         return;
       }
 
-      if ('startViewTransition' in document) {
-        setTimeout(() => {
-          document.startViewTransition(() => this.updateDom());
-        }, 260);
-      } else {
-        this.updateDom();
-      }
-    });
-  },
-
-  async handleCheckboxClick() {
-    const items = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).reduce(
-      (acc, checkbox) => {
-        acc[checkbox.name] = checkbox.checked;
-        return acc;
-      },
-      {} as Record<string, boolean>,
-    );
-
-    try {
-      const response = await wpAjaxInstance.post<AjaxResponse, AjaxResponse>(
-        'tutor_save_instructor_home_sections_visibility',
-        { items },
+      const existingOrder = Array.from(
+        new Set(
+          Array.from(parentContainer.querySelectorAll<HTMLElement>('[data-section-id]'))
+            .map((el) => el.dataset.sectionId)
+            .filter((id): id is string => id !== undefined),
+        ),
       );
 
-      if (!response.success) {
-        window.TutorCore.toast.error(
-          response?.data || wp.i18n.__('Failed to save instructor home section visibility.', 'tutor'),
-        );
+      if (newOrder.length === existingOrder.length && newOrder.every((id, index) => id === existingOrder[index])) {
         return;
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : wp.i18n.__('Unknown error occurred.', 'tutor');
-      window.TutorCore.toast.error(message);
-      return;
-    }
-  },
 
-  updateDom() {
-    const newOrder = this.getOrder();
-    const sectionMap = this.getSortableSections();
+      const fragment = document.createDocumentFragment();
 
-    const firstSectionId = Object.keys(sectionMap)[0];
-    const parentContainer = firstSectionId ? sectionMap[firstSectionId]?.parentElement : null;
-
-    if (!parentContainer) {
-      return;
-    }
-
-    const existingOrder = Array.from(
-      new Set(
-        Array.from(parentContainer.querySelectorAll<HTMLElement>('[data-section-id]'))
-          .map((el) => el.dataset.sectionId)
-          .filter((id): id is string => id !== undefined),
-      ),
-    );
-
-    if (newOrder.length === existingOrder.length && newOrder.every((id, index) => id === existingOrder[index])) {
-      return;
-    }
-
-    const fragment = document.createDocumentFragment();
-
-    for (const id of newOrder) {
-      const section = sectionMap[id];
-      if (section) {
-        section.remove();
-        fragment.appendChild(section);
-      }
-    }
-
-    parentContainer.appendChild(fragment);
-  },
-
-  getOrder() {
-    const container = this.$el;
-    if (!container) {
-      return [];
-    }
-    const ids = Array.from(container.querySelectorAll<HTMLElement>('.tutor-popover-menu-item'))
-      .map((el) => el.dataset.id)
-      .filter((id): id is string => id !== undefined);
-
-    return Array.from(new Set(ids));
-  },
-
-  getSortableSections() {
-    const sections = document.querySelectorAll<HTMLElement>('[data-section-id]');
-
-    return Array.from(sections).reduce(
-      (acc, section) => {
-        const sectionId = section.dataset.sectionId;
-        if (sectionId) {
-          acc[sectionId] = section;
+      for (const id of newOrder) {
+        const section = sectionMap[id];
+        if (section) {
+          section.remove();
+          fragment.appendChild(section);
         }
-        return acc;
-      },
-      {} as Record<string, HTMLElement>,
-    );
-  },
+      }
 
-  destroy() {
-    for (const sortable of this._sortables) {
-      sortable.destroy();
-    }
-    this._sortables = [];
+      parentContainer.appendChild(fragment);
+    },
 
-    this.initialized = false;
-  },
-});
+    getOrder() {
+      const container = this.$el;
+      if (!container) {
+        return [];
+      }
+      const ids = Array.from(container.querySelectorAll<HTMLElement>('.tutor-popover-menu-item'))
+        .map((el) => el.dataset.id)
+        .filter((id): id is string => id !== undefined);
+
+      return Array.from(new Set(ids));
+    },
+
+    getSortableSections() {
+      const sections = document.querySelectorAll<HTMLElement>('[data-section-id]');
+
+      return Array.from(sections).reduce(
+        (acc, section) => {
+          const sectionId = section.dataset.sectionId;
+          if (sectionId) {
+            acc[sectionId] = section;
+          }
+          return acc;
+        },
+        {} as Record<string, HTMLElement>,
+      );
+    },
+
+    destroy() {
+      for (const sortable of this._sortables) {
+        sortable.destroy();
+      }
+      this._sortables = [];
+
+      this.initialized = false;
+    },
+  };
+};

--- a/assets/src/scss/frontend/components/_quiz-question.scss
+++ b/assets/src/scss/frontend/components/_quiz-question.scss
@@ -2,13 +2,13 @@
 @use '@Core/scss/tokens' as *;
 
 .tutor-quiz-questions {
+  @include tutor-frontend-layout();
   @include tutor-flex(column);
-  @include tutor-container(792px);
   padding-inline: 0;
   width: 100%;
   gap: $tutor-spacing-5;
 
-  @include tutor-breakpoint-down(sm) {
+  @include tutor-breakpoint-down(md) {
     padding-inline: $tutor-spacing-6;
   }
 }

--- a/assets/src/scss/frontend/dashboard/instructor/dashboard.scss
+++ b/assets/src/scss/frontend/dashboard/instructor/dashboard.scss
@@ -257,7 +257,7 @@
       @include tutor-button-variant(link);
       min-height: unset;
       padding: 0;
-      margin-top: $tutor-spacing-6;
+      margin-top: $tutor-spacing-5;
       color: $tutor-text-brand;
       width: fit-content;
     }

--- a/assets/src/scss/frontend/dashboard/layout/_header.scss
+++ b/assets/src/scss/frontend/dashboard/layout/_header.scss
@@ -17,10 +17,13 @@
   }
 
   &-inner {
+    @include tutor-frontend-layout();
     @include tutor-flex(row, center, space-between);
     height: 100%;
-    max-width: 726px;
-    margin: 0 auto;
+
+    @include tutor-breakpoint-up(2xl) {
+      padding-inline: $tutor-spacing-6;
+    }
   }
 
   &-left {

--- a/assets/src/scss/frontend/dashboard/layout/_layout.scss
+++ b/assets/src/scss/frontend/dashboard/layout/_layout.scss
@@ -20,8 +20,7 @@
   }
 
   .tutor-dashboard-page {
-    max-width: 760px;
-    margin: 0 auto;
+    @include tutor-frontend-layout();
     padding-inline: $tutor-spacing-6;
     padding-bottom: $tutor-spacing-7;
 

--- a/assets/src/scss/frontend/learning-area/components/quiz/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/components/quiz/_quiz.scss
@@ -151,12 +151,12 @@ $tutor-quiz-content-bottom-offset: calc(
 
   &-progress {
     @include tutor-flex(column);
-    @include tutor-container(792px);
+    @include tutor-frontend-layout();
     padding-inline: 0;
     padding-block: $tutor-spacing-5;
     gap: $tutor-spacing-5;
 
-    @include tutor-breakpoint-down(sm) {
+    @include tutor-breakpoint-down(md) {
       padding: $tutor-spacing-6;
     }
 
@@ -315,11 +315,12 @@ $tutor-quiz-content-bottom-offset: calc(
   }
 
   &-question-meta {
+    @include tutor-frontend-layout();
     @include tutor-flex(row, center, space-between);
-    @include tutor-container(792px);
+    width: 100%;
     padding-inline: 0;
 
-    @include tutor-breakpoint-down(sm) {
+    @include tutor-breakpoint-down(md) {
       padding-inline: $tutor-spacing-6;
     }
   }

--- a/assets/src/scss/frontend/learning-area/layout/_layout.scss
+++ b/assets/src/scss/frontend/learning-area/layout/_layout.scss
@@ -32,10 +32,9 @@
   }
 
   .tutor-learning-area-container {
-    max-width: 780px;
-    margin: 0 auto;
+    @include tutor-frontend-layout();
 
-    @include tutor-breakpoint-up(sm) {
+    @include tutor-breakpoint-down(md) {
       padding-inline: $tutor-spacing-6;
     }
 

--- a/templates/dashboard/instructor/home.php
+++ b/templates/dashboard/instructor/home.php
@@ -364,6 +364,7 @@ $recent_reviews = Instructor::format_instructor_recent_reviews( $reviews->result
 				data-section-id="current_stats" 
 				class="tutor-flex tutor-flex-wrap tutor-gap-5 tutor-z-positive"					
 				x-show="watch('current_stats')"
+				x-cloak
 			>
 				<?php foreach ( $stat_cards as $card ) : ?>
 					<div class="tutor-flex-1">
@@ -402,6 +403,7 @@ $recent_reviews = Instructor::format_instructor_recent_reviews( $reviews->result
 				data-section-id="course_completion_and_leader" 
 				class="tutor-flex tutor-gap-6"
 				x-show="watch('course_completion_and_leader')"
+				x-cloak
 			>
 				<!-- Course Completion Chart -->
 				<?php
@@ -421,6 +423,7 @@ $recent_reviews = Instructor::format_instructor_recent_reviews( $reviews->result
 				data-section-id="top_performing_courses"
 				class="tutor-dashboard-home-card"
 				x-show="watch('top_performing_courses')"
+				x-cloak
 			> 
 				<div class="tutor-flex tutor-row tutor-justify-between tutor-align-center tutor-gap-9">
 					<div class="tutor-small">
@@ -465,6 +468,7 @@ $recent_reviews = Instructor::format_instructor_recent_reviews( $reviews->result
 				data-section-id="upcoming_tasks_and_activity"
 				class="tutor-flex tutor-gap-6"
 				x-show="watch('upcoming_tasks_and_activity')"
+				x-cloak
 			>
 				<!-- Upcoming Tasks -->
 				<div class="tutor-dashboard-home-card tutor-flex-1">
@@ -492,6 +496,7 @@ $recent_reviews = Instructor::format_instructor_recent_reviews( $reviews->result
 				data-section-id="recent_reviews" 
 				class="tutor-dashboard-home-card"
 				x-show="watch('recent_reviews')"
+				x-cloak
 			>
 				<div class="tutor-small">
 					<?php esc_html_e( 'Recent Student Reviews', 'tutor' ); ?>

--- a/templates/dashboard/instructor/home/overview-chart.php
+++ b/templates/dashboard/instructor/home/overview-chart.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
 	data-section-id="overview_chart"
 	class="tutor-dashboard-home-chart"
 	x-show="watch('overview_chart')"
+	x-cloak
 >
 	<div class="tutor-dashboard-home-chart-header">
 		<div class="tutor-small">

--- a/templates/shared/components/quiz/attempt-details/summary.php
+++ b/templates/shared/components/quiz/attempt-details/summary.php
@@ -222,7 +222,7 @@ if ( QuizModel::RESULT_PASS === $attempt_result ) {
 			</div>
 		</div>
 
-		<?php if ( $can_retry ) : ?>
+		<?php if ( ! $is_instructor_review && $can_retry ) : ?>
 			<div class="tutor-quiz-result-retake">
 				<?php
 				Button::make()


### PR DESCRIPTION
## Summary
- keep instructor home visibility checkboxes as booleans after drag-sort re-registration instead of coercing to arrays
- add success button tokens/variant with hover and focus colors in light and dark themes
- reuse button variants in quiz attempt review chips for consistent success/destructive styling

## Testing
- not run (not requested)
