### PR TITLE
Fix: WP_Editor attributes and assignment error state

### DIFF
--- a/assets/core/scss/components/_input.scss
+++ b/assets/core/scss/components/_input.scss
@@ -185,5 +185,14 @@
         border-color: $tutor-border-error;
       }
     }
+
+    .tutor-wp-editor-container {
+      border: 1px solid $tutor-border-error;
+      box-shadow: $tutor-shadow-xs;
+      &:focus {
+        @include tutor-focus-ring('error');
+        border-color: $tutor-border-error;
+      }
+    }
   }
 }

--- a/assets/src/scss/frontend/learning-area/components/_assignment.scss
+++ b/assets/src/scss/frontend/learning-area/components/_assignment.scss
@@ -111,6 +111,12 @@
     @include tutor-flex(column, stretch, flex-start);
     gap: $tutor-spacing-3;
 
+    .tutor-wp-editor-error{
+      .tutor-wp-editor-container {
+        border: 1px solid $tutor-border-error;
+      }
+    }
+
     @include tutor-breakpoint-down(sm) {
       @include tutor-reset;
       gap: $tutor-spacing-1;

--- a/assets/src/scss/frontend/learning-area/components/_assignment.scss
+++ b/assets/src/scss/frontend/learning-area/components/_assignment.scss
@@ -111,12 +111,6 @@
     @include tutor-flex(column, stretch, flex-start);
     gap: $tutor-spacing-3;
 
-    .tutor-wp-editor-error{
-      .tutor-wp-editor-container {
-        border: 1px solid $tutor-border-error;
-      }
-    }
-
     @include tutor-breakpoint-down(sm) {
       @include tutor-reset;
       gap: $tutor-spacing-1;

--- a/components/WPEditor.php
+++ b/components/WPEditor.php
@@ -332,14 +332,13 @@ class WPEditor extends BaseComponent {
 
 		$wrapper_attrs['class'] = $wrapper_class;
 
-		$wrapper_attr_str = '';
-		foreach ( $wrapper_attrs as $key => $value ) {
-			$wrapper_attr_str .= sprintf( '%s="%s" ', esc_attr( $key ), esc_attr( $value ) );
-		}
-
 		?>
 		<div 
-			<?php echo esc_attr( $wrapper_attr_str ); ?>
+			<?php
+			foreach ( $wrapper_attrs as $key => $value ) {
+				printf( '%s="%s"', esc_attr( $key ), esc_attr( $value ) );
+			}
+			?>
 			x-data="tutorWPEditor({ 
 				name: '<?php echo esc_js( $this->name ); ?>',
 				editorId: '<?php echo esc_js( $editor_id ); ?>',


### PR DESCRIPTION
### Overview
- On WP_Editor php component, the wrapper attributes were not rendering properly, it was being rendered as `class="first_class" other_classqutoes;"` , since extra quote was getting added on sprintf statement
- To fix this i have used printf() to directly print it instead of echoing it, now the attributes are rendered as `class="first second"` like this
- I have also added border for assignment error when user does not provide an answer.