### PR TITLE
🐛 Align WP editor styling

### DIFF
--- a/assets/core/scss/components/_input.scss
+++ b/assets/core/scss/components/_input.scss
@@ -210,7 +210,7 @@
     }
 
     .tutor-wp-editor-container {
-      border: 1px solid $tutor-border-error;
+      outline: 1px solid $tutor-border-error;
       border-radius: $tutor-input-radius;
       box-shadow: $tutor-shadow-xs;
 

--- a/assets/core/scss/components/_input.scss
+++ b/assets/core/scss/components/_input.scss
@@ -51,6 +51,28 @@
     @include tutor-textarea;
   }
 
+  .tutor-wp-editor-container {
+    .wp-editor-container,
+    .mce-tinymce {
+      border-radius: $tutor-input-radius;
+    }
+
+    .mce-toolbar-grp,
+    .quicktags-toolbar {
+      border-top-left-radius: $tutor-input-radius;
+      border-top-right-radius: $tutor-input-radius;
+    }
+
+    .mce-toolbar:last-of-type {
+      border-top: none;
+    }
+
+    .mce-statusbar {
+      border-bottom-left-radius: $tutor-input-radius;
+      border-bottom-right-radius: $tutor-input-radius;
+    }
+  }
+
   .tutor-checkbox {
     @include tutor-checkbox;
 
@@ -189,6 +211,7 @@
 
     .tutor-wp-editor-container {
       border: 1px solid $tutor-border-error;
+      border-radius: $tutor-input-radius;
       box-shadow: $tutor-shadow-xs;
 
       &:focus {

--- a/assets/src/scss/frontend/kids/_learning-area.scss
+++ b/assets/src/scss/frontend/kids/_learning-area.scss
@@ -5,12 +5,12 @@
 [data-tutor-ui='kids'] {
   .tutor-resources-wrapper,
   .tutor-learning-area-qna,
-  .tutor-lesson-content-tab,
+  .tutor-lesson-content .tutor-lesson-content-tab,
   .tutor-assignment-info,
   .tutor-assignment-description,
   .tutor-assignment-attachments,
   .tutor-assignment-form {
-    @include tutor-kids-shadow(false, $tutor-border-idle, $tutor-radius-5xl, sm);
+    @include tutor-kids-shadow(false, $tutor-border-idle, $tutor-radius-5xl, sm)
   }
 
   .tutor-assignment-feedback {

--- a/assets/src/scss/frontend/kids/_learning-area.scss
+++ b/assets/src/scss/frontend/kids/_learning-area.scss
@@ -10,7 +10,7 @@
   .tutor-assignment-description,
   .tutor-assignment-attachments,
   .tutor-assignment-form {
-    @include tutor-kids-shadow(false, $tutor-border-idle, $tutor-radius-5xl, sm)
+    @include tutor-kids-shadow(false, $tutor-border-idle, $tutor-radius-5xl, sm);
   }
 
   .tutor-assignment-feedback {

--- a/components/WPEditor.php
+++ b/components/WPEditor.php
@@ -13,6 +13,8 @@
 
 namespace Tutor\Components;
 
+use Tutor\Helpers\UrlHelper;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -274,7 +276,7 @@ class WPEditor extends BaseComponent {
 			'textarea_name' => $this->name,
 			'tinymce'       => array(
 				'skin'        => 'light',
-				'skin_url'    => tutor()->url . 'assets/lib/tinymce/light',
+				'skin_url'    => UrlHelper::asset( 'lib/tinymce/light' ),
 				'content_css' => $this->get_content_css(),
 			),
 		);
@@ -296,7 +298,7 @@ class WPEditor extends BaseComponent {
 			array(
 				includes_url( 'css/dashicons.min.css' ),
 				includes_url( 'js/tinymce/skins/wordpress/wp-content.css' ),
-				tutor()->url . 'assets/lib/tinymce/light/content.min.css',
+				UrlHelper::asset( 'lib/tinymce/light/content.min.css' ),
 			)
 		);
 	}

--- a/components/WPEditor.php
+++ b/components/WPEditor.php
@@ -272,6 +272,32 @@ class WPEditor extends BaseComponent {
 			'quicktags'     => true,
 			'editor_height' => 150,
 			'textarea_name' => $this->name,
+			'tinymce'       => array(
+				'skin'        => 'light',
+				'skin_url'    => tutor()->url . 'assets/lib/tinymce/light',
+				'content_css' => $this->get_content_css(),
+			),
+		);
+	}
+
+	/**
+	 * Get TinyMCE content styles used inside the editor iframe.
+	 *
+	 * Mirrors the stylesheet list used by the React WPEditor component so both
+	 * entry points render editor content consistently.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @return string
+	 */
+	protected function get_content_css() {
+		return implode(
+			',',
+			array(
+				includes_url( 'css/dashicons.min.css' ),
+				includes_url( 'js/tinymce/skins/wordpress/wp-content.css' ),
+				tutor()->url . 'assets/lib/tinymce/light/content.min.css',
+			)
 		);
 	}
 
@@ -313,8 +339,16 @@ class WPEditor extends BaseComponent {
 
 		ob_start();
 
-		$editor_id     = ! empty( $this->id ) ? $this->id : $this->name;
-		$config        = array_merge( $this->get_default_config(), $this->editor_config );
+		$editor_id      = ! empty( $this->id ) ? $this->id : $this->name;
+		$default_config = $this->get_default_config();
+		$config         = array_merge( $default_config, $this->editor_config );
+
+		if ( isset( $default_config['tinymce'] ) || isset( $this->editor_config['tinymce'] ) ) {
+			$config['tinymce'] = array_merge(
+				$default_config['tinymce'] ?? array(),
+				$this->editor_config['tinymce'] ?? array()
+			);
+		}
 		$wrapper_class = 'tutor-wp-editor-wrapper tutor-input-field';
 
 		if ( isset( $this->attributes['class'] ) ) {

--- a/templates/dashboard/components/header.php
+++ b/templates/dashboard/components/header.php
@@ -78,6 +78,7 @@ $edit_profile_url = Dashboard::get_account_page_url( 'settings' ) . '?tab=accoun
 					x-show="open"
 					x-cloak
 					@click.outside="handleClickOutside()"
+					x-transition.origin.top.right
 					class="tutor-popover tutor-dashboard-header-user-popover"
 				>
 					<div class="tutor-dashboard-header-user-popover-profile">


### PR DESCRIPTION
## Summary
This change aligns the PHP-rendered WordPress editor with the styling and TinyMCE asset configuration already used by the React `WPEditor` implementation. It also applies the shared input border radius to the editor chrome through shared SCSS so the editor matches other Tutor form fields.

## Problem
The PHP `WPEditor` path and the React `WPEditor` path were not rendering from the same baseline. In practice that meant the PHP-rendered editor could miss the same TinyMCE content stylesheet configuration used in React, and its editor chrome did not inherit the same radius treatment as the textarea and other input components. Users would see inconsistent editor presentation depending on which implementation rendered the field.

## Root Cause
The React editor explicitly configured TinyMCE with Tutor-specific `content_css` and skin settings, while the PHP component depended mostly on `wp_editor()` defaults. On top of that, the shared input SCSS had no matching rules for the TinyMCE wrapper inside `.tutor-wp-editor-container`, so the PHP editor chrome kept WordPress defaults instead of following Tutor's input tokens.

## Fix
The PHP component now provides the TinyMCE content CSS used by the React editor and preserves nested `tinymce` defaults when custom editor config is passed, so instance-level overrides do not accidentally wipe out the shared defaults. The shared input SCSS now styles `.tutor-wp-editor-container` so the TinyMCE wrapper, toolbar, and status bar use the same input radius token as the textarea path.

## Validation
I verified the PHP component with `php -l components/WPEditor.php`. The SCSS change was kept in the shared input component layer and should be picked up by the normal asset build for the branch.
