### PR TITLE
Add ignore_kids option to SVG icons

### DIFF
--- a/assets/core/ts/components/icon.ts
+++ b/assets/core/ts/components/icon.ts
@@ -8,6 +8,7 @@ export interface IconProps {
   width?: number;
   height?: number;
   from: 'php' | 'ts';
+  ignoreKids?: boolean;
 }
 
 const createSvg = ({
@@ -25,17 +26,17 @@ const createSvg = ({
 }) =>
   `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="${viewBox || '0 0 ' + width + ' ' + height}" fill="${fill}">${content}</svg>`;
 
-async function fetchSVG(name: string, width: number, height: number, from: 'php' | 'ts' = 'ts') {
-  if (iconCache.has(name)) {
-    return iconCache.get(name)!;
-  }
-
+async function fetchSVG(name: string, width: number, height: number, from: 'php' | 'ts' = 'ts', ignoreKids = false) {
   const fileName = from === 'php' ? name : name.trim().replace(/[A-Z]/g, (m) => '-' + m.toLowerCase());
-  const hasKidsVariant = tutorConfig.is_kids_mode && tutorConfig.kids_icons_registry?.includes(fileName);
+  const hasKidsVariant = !ignoreKids && tutorConfig.is_kids_mode && tutorConfig.kids_icons_registry?.includes(fileName);
 
   const basePath = hasKidsVariant ? 'assets/icons/kids/' : 'assets/icons/';
   const url = `${tutorConfig.tutor_url}${basePath}${fileName}.svg`;
   const defaultViewBox = `0 0 ${width} ${height}`;
+
+  if (iconCache.has(url)) {
+    return iconCache.get(url)!;
+  }
 
   try {
     const response = await fetch(url);
@@ -53,7 +54,7 @@ async function fetchSVG(name: string, width: number, height: number, from: 'php'
 
     const svgMarkup = createSvg({ width, height, viewBox, fill, content });
 
-    iconCache.set(fileName, svgMarkup);
+    iconCache.set(url, svgMarkup);
     return svgMarkup;
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -67,6 +68,7 @@ export const icon = (props: IconProps) => ({
   width: props.width || 16,
   height: props.height || 16,
   from: props.from || 'php',
+  ignoreKids: props.ignoreKids || false,
 
   async init() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -78,7 +80,7 @@ export const icon = (props: IconProps) => ({
       return;
     }
 
-    const svg = await fetchSVG(this.name, this.width, this.height);
+    const svg = await fetchSVG(this.name, this.width, this.height, this.from, this.ignoreKids);
 
     $el.innerHTML = svg;
   },
@@ -90,7 +92,7 @@ export const icon = (props: IconProps) => ({
 
     $el.innerHTML = createSvg({ width: this.width, height: this.height });
 
-    const svg = await fetchSVG(this.name, this.width, this.height);
+    const svg = await fetchSVG(this.name, this.width, this.height, this.from, this.ignoreKids);
     $el.innerHTML = svg;
   },
 });

--- a/assets/src/js/v3/shared/atoms/SVGIcon.tsx
+++ b/assets/src/js/v3/shared/atoms/SVGIcon.tsx
@@ -9,6 +9,7 @@ interface SVGIconProps {
   height?: number;
   style?: SerializedStyles;
   isColorIcon?: boolean;
+  ignoreKids?: boolean;
 }
 
 interface Icon {
@@ -27,20 +28,29 @@ interface IconCacheEntry {
 
 const iconCache: Record<string, IconCacheEntry> = {};
 
-const SVGIcon = ({ name, width = 16, height = 16, style, isColorIcon = false, ...rest }: SVGIconProps) => {
-  const [icon, setIcon] = useState<Icon | null>(iconCache[name]?.icon || null);
-  const [isLoading, setIsLoading] = useState(!iconCache[name]?.icon);
+const SVGIcon = ({
+  name,
+  width = 16,
+  height = 16,
+  style,
+  isColorIcon = false,
+  ignoreKids = false,
+  ...rest
+}: SVGIconProps) => {
+  const cacheKey = ignoreKids ? `${name}-ignoreKids` : name;
+  const [icon, setIcon] = useState<Icon | null>(iconCache[cacheKey]?.icon || null);
+  const [isLoading, setIsLoading] = useState(!iconCache[cacheKey]?.icon);
 
   useEffect(() => {
-    if (iconCache[name]?.icon) {
-      setIcon(iconCache[name]!.icon!);
+    if (iconCache[cacheKey]?.icon) {
+      setIcon(iconCache[cacheKey]!.icon!);
       setIsLoading(false);
       return;
     }
 
     setIsLoading(true);
 
-    fetchIcon(name, width, height)
+    fetchIcon(name, cacheKey, width, height, ignoreKids)
       .then((loadedIcon) => {
         setIcon(loadedIcon);
       })
@@ -50,7 +60,7 @@ const SVGIcon = ({ name, width = 16, height = 16, style, isColorIcon = false, ..
       .finally(() => {
         setIsLoading(false);
       });
-  }, [name, width, height]);
+  }, [name, width, height, ignoreKids, cacheKey]);
 
   const additionalAttributes = {
     ...(isColorIcon && { 'data-colorize': true }),
@@ -82,19 +92,19 @@ const SVGIcon = ({ name, width = 16, height = 16, style, isColorIcon = false, ..
   );
 };
 
-function fetchIcon(name: string, width: number, height: number): Promise<Icon> {
-  if (iconCache[name]?.icon) {
+function fetchIcon(name: string, cacheKey: string, width: number, height: number, ignoreKids: boolean): Promise<Icon> {
+  if (iconCache[cacheKey]?.icon) {
     // Icon already loaded
-    return Promise.resolve(iconCache[name]!.icon!);
+    return Promise.resolve(iconCache[cacheKey]!.icon!);
   }
 
-  if (iconCache[name]?.promise) {
+  if (iconCache[cacheKey]?.promise) {
     // Fetch already in progress, return existing promise
-    return iconCache[name]!.promise!;
+    return iconCache[cacheKey]!.promise!;
   }
 
   const fileName = name.trim().replace(/[A-Z0-9]/g, (m) => '-' + m.toLowerCase());
-  const hasKidsVariant = tutorConfig.is_kids_mode && tutorConfig.kids_icons_registry?.includes(fileName);
+  const hasKidsVariant = !ignoreKids && tutorConfig.is_kids_mode && tutorConfig.kids_icons_registry?.includes(fileName);
 
   const basePath = hasKidsVariant ? 'assets/icons/kids/' : 'assets/icons/';
   const url = `${tutorConfig.tutor_url}${basePath}${fileName}.svg`;
@@ -115,15 +125,15 @@ function fetchIcon(name: string, width: number, height: number): Promise<Icon> {
       const innerHTML = svgEl?.innerHTML || '';
 
       const loadedIcon = { viewBox, fill, icon: innerHTML };
-      iconCache[name] = { icon: loadedIcon };
+      iconCache[cacheKey] = { icon: loadedIcon };
       return loadedIcon;
     })
     .catch((err) => {
-      iconCache[name] = { error: err };
+      iconCache[cacheKey] = { error: err };
       throw err;
     });
 
-  iconCache[name] = { loading: true, promise };
+  iconCache[cacheKey] = { loading: true, promise };
   return promise;
 }
 
@@ -135,6 +145,7 @@ export default memo(SVGIcon, (prev, next) => {
     prev.height === next.height &&
     prev.width === next.height &&
     prev.isColorIcon === next.isColorIcon &&
+    prev.ignoreKids === next.ignoreKids &&
     prev.style?.name === next.style?.name
   );
 });

--- a/components/SvgIcon.php
+++ b/components/SvgIcon.php
@@ -83,6 +83,15 @@ class SvgIcon extends BaseComponent {
 	protected $color = '';
 
 	/**
+	 * Ignore kids mode variant.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @var bool
+	 */
+	protected $ignore_kids = false;
+
+	/**
 	 * Set icon name.
 	 *
 	 * @since 4.0.0
@@ -156,6 +165,20 @@ class SvgIcon extends BaseComponent {
 	}
 
 	/**
+	 * Set to ignore kids variant.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param bool $ignore_kids Ignore kids mode variant.
+	 *
+	 * @return $this
+	 */
+	public function ignore_kids( bool $ignore_kids = true ): self {
+		$this->ignore_kids = $ignore_kids;
+		return $this;
+	}
+
+	/**
 	 * Set custom HTML attribute.
 	 *
 	 * @since 4.0.0
@@ -185,7 +208,7 @@ class SvgIcon extends BaseComponent {
 		$icon_path = tutor()->path . 'assets/icons/' . $this->name . '.svg';
 
 		// If learning mode is kids, check kids folder first.
-		if ( tutor_utils()->is_kids_mode() ) {
+		if ( tutor_utils()->is_kids_mode() && ! $this->ignore_kids ) {
 			$kids_path = tutor()->path . 'assets/icons/kids/' . $this->name . '.svg';
 			if ( file_exists( $kids_path ) ) {
 				$icon_path = $kids_path;


### PR DESCRIPTION
Introduce an ignore_kids / ignoreKids flag across PHP and TypeScript components to allow loading the base icon even when tutor kids mode is enabled. Propagates the new option through the icon helper, the TS component, and the React SVGIcon (with prop and cacheKey) so callers can opt out of the kids-variant. Also fixes icon caching by using a URL/cacheKey (and including the ignore flag) to avoid collisions, and updates fetch logic to respect the ignore flag when selecting the kids icons path.