### PR TITLE
Fix(🛠) : Subscription orders are visible in order history when Subscription Add-on is disabled

### DIFF
--- a/models/OrderModel.php
+++ b/models/OrderModel.php
@@ -990,7 +990,7 @@ class OrderModel {
 	 * Get order of a user
 	 *
 	 * @since 3.0.0
-	 * @since 4.0.0 params $order_status and $order added.
+	 * @since 4.0.0 params $order_status, $order and $args added.
 	 *
 	 * @param string $time_period $time_period Sorting time period,
 	 * supported time periods are: today, monthly & yearly.
@@ -1001,15 +1001,17 @@ class OrderModel {
 	 * @param int    $limit  Limit to fetch record.
 	 * @param int    $offset  Offset to fetch record.
 	 * @param string $order  Order to fetch record.
+	 * @param array  $args Optional additional WHERE conditions.
 	 *
 	 * @throws \Exception Throw exception if database error occur.
 	 *
 	 * @return array
 	 */
-	public function get_user_orders( $time_period = null, $start_date = null, $end_date = null, $order_status = '', int $user_id = 0, $limit = 10, int $offset = 0, $order = 'DESC' ) {
-		$user_id      = tutor_utils()->get_user_id( $user_id );
-		$order        = QueryHelper::get_valid_sort_order( $order );
-		$order_status = esc_sql( $order_status );
+	public function get_user_orders( $time_period = null, $start_date = null, $end_date = null, $order_status = '', int $user_id = 0, $limit = 10, int $offset = 0, $order = 'DESC', $args ) {
+		$user_id           = tutor_utils()->get_user_id( $user_id );
+		$order             = QueryHelper::get_valid_sort_order( $order );
+		$order_status      = esc_sql( $order_status );
+		$order_type_clause = '';
 
 		$response = array(
 			'results'     => array(),
@@ -1034,6 +1036,10 @@ class OrderModel {
 			}
 		}
 
+		if ( ! empty( $args['order_type'] ) ) {
+			$order_type_clause = ' AND ' . QueryHelper::prepare_where_clause( array( 'o.order_type' => esc_sql( $args['order_type'] ) ) );
+		}
+
 		//phpcs:disable
 		$query = $wpdb->prepare(
 			"SELECT
@@ -1041,6 +1047,7 @@ class OrderModel {
 				o.* 
 				FROM $this->table_name AS o
 				WHERE o.user_id = %d
+				{$order_type_clause}
 				{$time_period_clause}
 				{$date_range_clause}
 				{$order_status_clause}

--- a/templates/dashboard/account/billing/order-history.php
+++ b/templates/dashboard/account/billing/order-history.php
@@ -22,7 +22,12 @@ $end_date        = Input::get( 'end_date' );
 $selected_filter = Input::get( 'data', 'all' );
 
 if ( tutor_utils()->is_monetize_by_tutor() ) {
-	$response    = ( new OrderModel() )->get_user_orders( $time_period, $start_date, $end_date, $selected_filter, $user_id, $item_per_page, $offset, $order_filter );
+
+	$args = array();
+	if ( ! tutor_utils()->is_addon_enabled( 'subscription' ) ) {
+		$args['order_type'] = OrderModel::TYPE_SINGLE_ORDER;
+	}
+	$response    = ( new OrderModel() )->get_user_orders( $time_period, $start_date, $end_date, $selected_filter, $user_id, $item_per_page, $offset, $order_filter, $args );
 	$orders      = $response['results'];
 	$total_items = $response['total_count'];
 } else {
@@ -41,13 +46,7 @@ else :
 	?>
 <div class="tutor-flex tutor-flex-column tutor-gap-4 tutor-order-history">
 	<?php foreach ( $orders as $order ) : //phpcs:ignore ?>
-		<?php
-		if ( OrderModel::TYPE_SINGLE_ORDER !== $order->order_type && ! tutor_utils()->is_addon_enabled( 'subscription' ) ) {
-			continue;
-		}
-
-		include tutor_get_template( 'dashboard.account.billing.order-history-card' );
-		?>
+		<?php include tutor_get_template( 'dashboard.account.billing.order-history-card' ); ?>
 	<?php endforeach; ?>
 </div>
 

--- a/templates/dashboard/account/billing/order-history.php
+++ b/templates/dashboard/account/billing/order-history.php
@@ -41,7 +41,13 @@ else :
 	?>
 <div class="tutor-flex tutor-flex-column tutor-gap-4 tutor-order-history">
 	<?php foreach ( $orders as $order ) : //phpcs:ignore ?>
-		<?php include tutor_get_template( 'dashboard.account.billing.order-history-card' ); ?>	
+		<?php
+		if ( OrderModel::TYPE_SINGLE_ORDER !== $order->order_type && ! tutor_utils()->is_addon_enabled( 'subscription' ) ) {
+			continue;
+		}
+
+		include tutor_get_template( 'dashboard.account.billing.order-history-card' );
+		?>
 	<?php endforeach; ?>
 </div>
 


### PR DESCRIPTION
Subscription-type orders are still appearing in the order history even when the subscription add-on is disabled.