### PR TITLE
Use WPEditor and allow HTML in bio

### DIFF
--- a/classes/User.php
+++ b/classes/User.php
@@ -607,7 +607,7 @@ class User {
 		$public_display = array_unique( $public_display );
 		$max_filesize   = floatval( ini_get( 'upload_max_filesize' ) ) * ( 1024 * 1024 );
 
-		$profile_bio = wp_strip_all_tags( get_user_meta( $user->ID, self::PROFILE_BIO_META, true ) );
+		$profile_bio = wp_kses_post( get_user_meta( $user->ID, self::PROFILE_BIO_META, true ) );
 		$job_title   = get_user_meta( $user->ID, self::PROFILE_JOB_TITLE_META, true );
 		$phone       = get_user_meta( $user->ID, self::PHONE_NUMBER_META, true );
 

--- a/components/WPEditor.php
+++ b/components/WPEditor.php
@@ -41,11 +41,20 @@ defined( 'ABSPATH' ) || exit;
  * WPEditor::make()
  *     ->name( 'bio' )
  *     ->content( $user_bio )
- *     ->editor_config( array(
- *         'media_buttons' => true,
- *         'teeny' => false,
- *         'editor_height' => 300,
- *     ) )
+ *     ->editor_config(
+ *         array(
+ *             'teeny'         => false,
+ *             'media_buttons' => false,
+ *             'quicktags'     => false,
+ *             'editor_height' => 150,
+ *             'tinymce'       => array(
+ *                 'toolbar1' => 'bold,italic,underline,link,unlink,removeformat,image,bullist,codesample',
+ *                 'toolbar2' => '',
+ *                 'toolbar3' => '',
+ *                 'plugins'  => 'link,image,lists,codesample',
+ *             ),
+ *         )
+ *     );
  *     ->render();
  * ```
  *

--- a/templates/dashboard/account/settings/account.php
+++ b/templates/dashboard/account/settings/account.php
@@ -17,6 +17,7 @@ use Tutor\Components\InputField;
 use Tutor\Components\Constants\Size;
 use Tutor\Components\Constants\Variant;
 use Tutor\Components\Constants\InputType;
+use Tutor\Components\WPEditor;
 
 $user          = wp_get_current_user();
 $settings_data = User::get_profile_settings_data( $user->ID );
@@ -241,14 +242,13 @@ $default_values = (array) apply_filters( 'tutor_profile_default_values', $defaul
 						->attr( 'x-bind', "register('display_name')" )
 						->render();
 
-					InputField::make()
-						->type( InputType::TEXTAREA )
+					WPEditor::make()
 						->label( __( 'Bio', 'tutor' ) )
 						->name( 'tutor_profile_bio' )
-						->clearable()
-						->id( 'tutor_profile_bio' )
 						->placeholder( __( 'Enter your bio', 'tutor' ) )
+						->content( $default_values['tutor_profile_bio'] )
 						->attr( 'x-bind', "register('tutor_profile_bio')" )
+						->editor_config( tutor_utils()->get_profile_bio_editor_config( 'tutor_profile_bio' ) )
 						->render();
 				?>
 			</div>


### PR DESCRIPTION
Replace the plain textarea with the WPEditor component for the user profile bio, wiring its content and editor_config (via tutor_utils()->get_profile_bio_editor_config). Tighten the editor UI (smaller height, disable media/quicktags, restrict TinyMCE toolbar/plugins). Persist bio using wp_kses_post instead of wp_strip_all_tags so safe HTML is preserved in user bios. Also add the WPEditor import to the account settings template.