### PR TITLE
🐛 Fix V4 quiz and account review regressions

### DIFF
--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -1921,6 +1921,9 @@ class Quiz {
 	 */
 	public static function render_question( $question, $index = 0 ) {
 		$question_settings = maybe_unserialize( $question->question_settings );
+		$question_type     = $question->question_type;
+		$rand_choice       = ! empty( $question_settings['randomize_question'] )
+			&& '1' === $question_settings['randomize_question'];
 
 		// Normalize question type + settings.
 		switch ( $question->question_type ) {
@@ -1940,22 +1943,12 @@ class Quiz {
 		}
 
 		$template = str_replace( '_', '-', $question->question_type );
+		$answers  = self::prepare_question_answers( (int) $question->question_id, $question_type, $rand_choice );
 
-		$rand_choice = ! empty( $question_settings['randomize_question'] )
-		&& '1' === $question_settings['randomize_question'];
-
-		$question->index             = $index;
-		$question->question_settings = $question_settings;
-
-		$answers = QuizModel::get_answers_by_quiz_question(
-			$question->question_id,
-			$rand_choice
-		);
-
-		$question->question_answers = array_map(
-			static fn( $answer ) => (array) $answer,
-			$answers
-		);
+		$question->index                       = $index;
+		$question->question_settings           = $question_settings;
+		$question->question_answers            = $answers['question_answers'];
+		$question->question_randomized_answers = $answers['question_randomized_answers'];
 
 		tutor_load_template(
 			'learning-area.quiz.question',
@@ -1964,6 +1957,47 @@ class Quiz {
 				'question_settings' => $question_settings,
 				'question_type'     => $template,
 			)
+		);
+	}
+
+	/**
+	 * Get question answers prepared for render.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param int    $question_id  Question ID.
+	 * @param string $question_type Original question type.
+	 * @param bool   $rand_choice  Whether randomized choices are enabled.
+	 *
+	 * @return array{question_answers: array, question_randomized_answers: array}
+	 */
+	private static function prepare_question_answers( int $question_id, string $question_type, bool $rand_choice ): array {
+		$question_answers            = QuizModel::get_answers_by_quiz_question( $question_id );
+		$question_randomized_answers = array();
+
+		// Ordering questions always use a randomized answer list.
+		// Matching and image matching keep the drop-zone items ordered and only shuffle the draggable choices.
+
+		if ( 'ordering' === $question_type ) {
+			$question_answers = QuizModel::get_answers_by_quiz_question( $question_id, true );
+		} elseif ( 'matching' === $question_type || 'image_matching' === $question_type ) {
+			$question_randomized_answers = QuizModel::get_answers_by_quiz_question( $question_id, $rand_choice );
+		} elseif ( $rand_choice ) {
+			$question_answers = QuizModel::get_answers_by_quiz_question( $question_id, true );
+		}
+
+		$question_answers            = array_map(
+			static fn( $answer ) => (array) $answer,
+			$question_answers
+		);
+		$question_randomized_answers = array_map(
+			static fn( $answer ) => (array) $answer,
+			$question_randomized_answers
+		);
+
+		return array(
+			'question_answers'            => $question_answers,
+			'question_randomized_answers' => $question_randomized_answers,
 		);
 	}
 }

--- a/models/QuizModel.php
+++ b/models/QuizModel.php
@@ -94,7 +94,8 @@ class QuizModel {
 				);
 			}
 
-			$start_time = DateTimeHelper::get_gmt_to_user_timezone_date( $quiz_attempt->attempt_started_at ?? '', 'D j M Y, g:i A' );
+			$start_time = DateTimeHelper::create( $quiz_attempt->attempt_started_at ?? '' )
+				->format( get_option( 'date_format' ) . ', ' . get_option( 'time_format' ) );
 
 			$attempt_time = strtotime( $quiz_attempt->attempt_ended_at ) - strtotime( $quiz_attempt->attempt_started_at );
 			$attempt_time = tutor_utils()->playtime_string( $attempt_time );

--- a/templates/dashboard/account/reviews.php
+++ b/templates/dashboard/account/reviews.php
@@ -24,7 +24,9 @@ $item_per_page = tutor_utils()->get_option( 'pagination_per_page', 20 );
 $current_page  = max( 1, Input::get( 'current_page', 0, Input::TYPE_INT ) );
 $offset        = ( $current_page - 1 ) * $item_per_page;
 
-$all_reviews  = tutor_utils()->get_reviews_by_user( 0, $offset, $item_per_page, true, null, array( 'approved', 'hold' ) );
+$all_reviews  = User::is_student_view() ?
+	tutor_utils()->get_reviews_by_user( 0, $offset, $item_per_page, true, null, array( 'approved', 'hold' ) ) :
+	tutor_utils()->get_reviews_by_instructor( 0, $offset, $item_per_page );
 $review_count = $all_reviews->count;
 $reviews      = $all_reviews->results;
 $is_editable  = User::is_student_view();

--- a/templates/learning-area/quiz/question.php
+++ b/templates/learning-area/quiz/question.php
@@ -21,21 +21,23 @@ global $tutor_is_started_quiz;
 global $post;
 
 $default_question = array(
-	'index'                => 1,
-	'question_id'          => 0,
-	'question_title'       => '',
-	'question_description' => '',
-	'question_type'        => 'true_false',
-	'answer_required'      => true,
-	'question_mark'        => 10,
-	'answer_explanation'   => '',
-	'question_settings'    => array(
+	'index'                       => 1,
+	'question_id'                 => 0,
+	'question_title'              => '',
+	'question_description'        => '',
+	'question_type'               => 'true_false',
+	'answer_required'             => true,
+	'question_mark'               => 10,
+	'answer_explanation'          => '',
+	'question_settings'           => array(
 		'answer_required'    => '0',
 		'question_mark'      => '1',
 		'question_type'      => 'true_false',
 		'randomize_question' => '1',
 		'show_question_mark' => '1',
 	),
+	'question_answers'            => array(),
+	'question_randomized_answers' => array(),
 );
 
 $quiz_id            = $tutor_is_started_quiz->quiz_id ?? 0;

--- a/templates/learning-area/quiz/questions/matching.php
+++ b/templates/learning-area/quiz/questions/matching.php
@@ -19,6 +19,7 @@ use Tutor\Components\Constants\Variant;
 
 $answer_field_name = ( $question_field_name_base ?? '' ) . '[answers][]';
 $register_rules    = '';
+$draggable_answers = $question['question_randomized_answers'] ?? $question['question_answers'] ?? array();
 if ( $answer_is_required ) {
 	$register_rules = ", { validate: (value) => Array.isArray(value) && value.every((item) => item) || '" . esc_js( $required_message ) . "' }";
 }
@@ -93,7 +94,7 @@ $register_attr = "register('{$answer_field_name}'{$register_rules})";
 			<span class="tutor-text-small tutor-font-medium"><?php esc_html_e( 'Drag from here', 'tutor' ); ?></span>
 		</div>
 		<div class="tutor-quiz-question-options">
-			<?php foreach ( $question['question_answers'] as $answer ) : ?>
+			<?php foreach ( $draggable_answers as $answer ) : ?>
 				<div
 					class="tutor-quiz-question-option"
 					data-option="draggable"


### PR DESCRIPTION
This PR fixes a set of regressions around the V4 quiz flow and related account surfaces.

The main user-facing issues were in three areas. First, V4 quiz questions were not preserving the legacy answer-randomization behavior for all supported question types. That created inconsistent answer ordering between the legacy flow and the new learning area, especially for ordering, matching, and image matching questions. Second, student quiz attempt dates were being rendered with the wrong timezone offset because the stored attempt timestamp was being passed through a GMT-to-user conversion path that did not match the value being stored. Third, the account reviews screen was not loading the correct review dataset for instructors, so instructor-facing review pages could show the wrong results.

The root cause in the quiz flow was that the V4 renderer had a simplified answer preparation path that did not mirror the older per-question-type randomization rules. The fix restores those rules in the shared PHP rendering layer so ordering questions always use randomized answers, matching and image matching keep the fixed side ordered while randomizing the draggable choices, and other question types continue to respect the existing randomization flag. This keeps V4 behavior aligned with the legacy quiz experience.

The date issue came from formatting attempt timestamps with a GMT conversion helper even though the value being formatted in this path was not a GMT timestamp. The fix switches the formatting step to use the existing `DateTimeHelper` creation path and renders the output with the site's configured WordPress date and time formats. This avoids the extra offset while still keeping the output consistent with user settings.

The reviews issue came from the account reviews template always using the student review query path. That meant instructor account review screens were not pulling instructor review data through the correct model path. The fix now branches by current account view, using `get_reviews_by_user()` for student view and `get_reviews_by_instructor()` for instructor view. As a result, the account reviews page now loads the expected reviews for both roles.

Validation was done with targeted PHP syntax checks on the touched files and a review of the branch delta against `4.0.0-dev`. The branch includes the following commits:

- `fix(quiz): preserve question answer randomization in v4`
- `fix(quiz): use configured format for attempt dates`
- `fix(reviews): load instructor account reviews`
