### PR TITLE
refactor(templates): replace inline alert HTML with Alert component

### DIFF
--- a/templates/dashboard/instructor/logged-in.php
+++ b/templates/dashboard/instructor/logged-in.php
@@ -9,7 +9,7 @@
  * @since 1.4.3
  */
 
-use Tutor\Components\SvgIcon;
+use Tutor\Components\Alert;
 use TUTOR\Icon;
 
 $user_id           = get_current_user_id();
@@ -17,12 +17,11 @@ $is_instructor     = tutor_utils()->is_instructor( $user_id );
 $instructor_status = get_user_meta( $user_id, '_tutor_instructor_status', true );
 
 if ( 'try_again' === $instructor_status ) {
-	?>
-	<div class="tutor-flex tutor-flex-column tutor-items-center tutor-justify-center tutor-p-6" style="border: 1px solid var(--tutor-text-critical); max-width: 500px; margin: 10px auto;">
-		<span class="tutor-icon-circle-info tutor-color-warning"></span>
-		<span><?php esc_html_e( 'You have been rejected from being an instructor.', 'tutor' ); ?></span>
-	</div>
-	<?php
+	Alert::make()
+		->text( 'You have been rejected from being an instructor.' )
+		->variant( Alert::WARNING )
+		->icon( Icon::WARNING )
+		->render();
 	tutor_load_template( 'dashboard.instructor.apply_for_instructor' );
 	return;
 }
@@ -32,22 +31,21 @@ if ( $is_instructor ) {
 	<div class="tutor-container">
 		<div class="tutor-instructor-application-process tutor-pt-48 tutor-pb-48">
 			<div class="tutor-app-process-alert tutor-mb-10">
-				<div class="tutor-p-3 tutor-radius-sm" style="border:1px solid var(--tutor-text-brand);">
-					<div class="tutor-alert-text tutor-flex tutor-gap-2 tutor-items-center">
-					<?php SvgIcon::make()->name( Icon::INFO )->size( 20 )->render(); ?>
-					<span>
-					<?php
-					if ( 'pending' === $instructor_status ) {
-						esc_html_e( 'Your application will be reviewed and the results will be sent to you by email.', 'tutor' );
-					} elseif ( 'approved' === $instructor_status ) {
-						esc_html_e( 'Your application has been accepted. Further necessary details have been sent to your registered email account.', 'tutor' );
-					} elseif ( 'blocked' === $instructor_status ) {
-						esc_html_e( 'You have been blocked from being an instructor.', 'tutor' );
-					}
-					?>
-					</span>
-					</div>
-				</div>
+				<?php
+				$instructor_status_text = '';
+				if ( 'pending' === $instructor_status ) {
+					$instructor_status_text = 'Your application will be reviewed and the results will be sent to you by email.';
+				} elseif ( 'approved' === $instructor_status ) {
+					$instructor_status_text = 'Your application has been accepted. Further necessary details have been sent to your registered email account.';
+				} elseif ( 'blocked' === $instructor_status ) {
+					$instructor_status_text = 'You have been blocked from being an instructor.';
+				}
+				Alert::make()
+					->text( $instructor_status_text )
+					->variant( Alert::INFO )
+					->icon( Icon::INFO )
+					->render();
+				?>
 			</div>
 			<div class="tutor-app-process-image tutor-m-auto tutor-d-flex tutor-justify-center tutor-align-center">
 				<span class="tutor-app-process-img">

--- a/templates/dashboard/instructor/registration.php
+++ b/templates/dashboard/instructor/registration.php
@@ -9,13 +9,13 @@
  * @since 1.4.3
  */
 
+use Tutor\Components\Alert;
 use Tutor\Components\SvgIcon;
 use TUTOR\Icon;
 
 ?>
 
 <?php if ( ! get_option( 'users_can_register', false ) ) : ?>
-
 	<?php
 		$args = array(
 			'image_path'  => tutor()->url . 'assets/images/construction.png',
@@ -29,7 +29,6 @@ use TUTOR\Icon;
 		);
 		tutor_load_template( 'feature_disabled', $args );
 		?>
-
 <?php else : ?>
 
 	<div id="tutor-registration-wrap" class="tutor-card" style="max-width: 520px; margin: 40px auto;">
@@ -45,15 +44,17 @@ use TUTOR\Icon;
 
 			<?php
 			$errors = apply_filters( 'tutor_instructor_register_validation_errors', array() ); //phpcs:ignore
-			if ( is_array( $errors ) && count( $errors ) ) {
-				echo '<div class="tutor-alert tutor-warning tutor-mb-5" style="border: 1px solid var(--tutor-text-critical)"><ul class="tutor-required-fields tutor-p-none">';
-				foreach ( $errors as $error_key => $error_value ) {
-					echo wp_kses( "<li>{$error_value}</li>", array( 'li' => array() ) );
-				}
-				echo '</ul></div>';
-			}
+			if ( is_array( $errors ) && count( $errors ) ) :
+				foreach ( $errors as $error_key => $error_value ) :
+					Alert::make()
+						->text( $error_value )
+						->variant( Alert::ERROR )
+						->icon( Icon::WARNING )
+						->attr( 'class', 'tutor-mb-8' )
+						->render();
+					endforeach;
+				endif;
 			?>
-			
 			<div class="tutor-input-field tutor-mb-8">
 				<label class="tutor-block tutor-mb-3"><?php esc_html_e( 'First Name', 'tutor' ); ?></label>
 				<input class="tutor-form-control tutor-input" type="text" name="first_name" value="<?php echo esc_attr( tutor_utils()->input_old( 'first_name' ) ); ?>" placeholder="<?php esc_html_e( 'First Name', 'tutor' ); ?>" required autocomplete="given-name">
@@ -84,12 +85,12 @@ use TUTOR\Icon;
 							x-show="value.length > 0"
 							@click="show = !show"
 						>
-							<template x-if="!show">
-								<?php SvgIcon::make()->name( Icon::EYE )->size( 20 )->render(); ?>
-							</template>
-							<template x-if="show">
-								<?php SvgIcon::make()->name( Icon::EYE_OFF )->size( 20 )->render(); ?>
-							</template>
+						<template x-if="!show">
+							<?php SvgIcon::make()->name( Icon::EYE )->size( 20 )->render(); ?>
+						</template>
+						<template x-if="show">
+							<?php SvgIcon::make()->name( Icon::EYE_OFF )->size( 20 )->render(); ?>
+						</template>
 						</span>
 						<input 
 							class="tutor-form-control tutor-input" 
@@ -133,19 +134,15 @@ use TUTOR\Icon;
 
 			<?php do_action( 'tutor_instructor_reg_form_end' ); ?>
 
-			<?php
-				$tutor_toc_page_link = tutor_utils()->get_toc_page_link();
-			?>
+			<?php $tutor_toc_page_link = tutor_utils()->get_toc_page_link(); ?>
 
 			<?php if ( null !== $tutor_toc_page_link ) : ?>
-				<div class="tutor-small tutor-mb-6">
-					<?php esc_html_e( 'By signing up, I agree with the website\'s', 'tutor' ); ?> <a target="_blank" href="<?php echo esc_url( $tutor_toc_page_link ); ?>" title="<?php esc_attr_e( 'Terms and Conditions', 'tutor' ); ?>"><?php esc_html_e( 'Terms and Conditions', 'tutor' ); ?></a>
-				</div>
+			<div class="tutor-small tutor-mb-6">
+				<?php esc_html_e( 'By signing up, I agree with the website\'s', 'tutor' ); ?> <a target="_blank" href="<?php echo esc_url( $tutor_toc_page_link ); ?>" title="<?php esc_attr_e( 'Terms and Conditions', 'tutor' ); ?>"><?php esc_html_e( 'Terms and Conditions', 'tutor' ); ?></a>
+			</div>
 			<?php endif; ?>
 
-			<div>
-				<button type="submit" name="tutor_register_instructor_btn" value="register" class="tutor-btn tutor-btn-primary tutor-btn-block"><?php esc_html_e( 'Register as instructor', 'tutor' ); ?></button>
-			</div>
+			<button type="submit" name="tutor_register_instructor_btn" value="register" class="tutor-btn tutor-btn-primary tutor-btn-block"><?php esc_html_e( 'Register as instructor', 'tutor' ); ?></button>
 			<?php do_action( 'tutor_after_register_button' ); ?>
 
 		</form>

--- a/templates/dashboard/registration.php
+++ b/templates/dashboard/registration.php
@@ -11,11 +11,15 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Tutor\Components\Alert;
 use Tutor\Components\SvgIcon;
 use TUTOR\Icon;
 ?>
 
-<?php if ( ! get_option( 'users_can_register', false ) ) : ?> 
+<?php
+if ( ! get_option( 'users_can_register', false ) ) :
+	?>
+
 	<?php
 		$args = array(
 			'image_path'  => tutor()->url . 'assets/images/construction.png',
@@ -45,21 +49,16 @@ use TUTOR\Icon;
 			<?php
 			$validation_errors = apply_filters( 'tutor_student_register_validation_errors', array() );
 			if ( is_array( $validation_errors ) && count( $validation_errors ) ) :
-				?>
-				<div class="tutor-alert tutor-warning tutor-mb-6" style="border: 1px solid var(--tutor-text-critical);">
-					<ul class="tutor-required-fields tutor-p-none">
-						<?php foreach ( $validation_errors as $validation_error ) : ?>
-							<li>
-								<?php echo esc_html( $validation_error ); ?>
-							</li>
-							<li>
-								<?php echo esc_html( $validation_error ); ?>
-							</li>
-						<?php endforeach; ?>
-					</ul>
-				</div>
-			<?php endif; ?>
-
+				foreach ( $validation_errors as $validation_error ) :
+					Alert::make()
+						->text( $validation_error )
+						->variant( Alert::ERROR )
+						->icon( Icon::WARNING )
+						->attr( 'class', 'tutor-mb-8' )
+						->render();
+				endforeach;
+			endif;
+			?>
 			<div class="tutor-form-group">
 				<label class="tutor-block tutor-mb-3"><?php esc_html_e( 'First Name', 'tutor' ); ?></label>
 				<div class="tutor-input-field tutor-mb-8">
@@ -147,12 +146,12 @@ use TUTOR\Icon;
 				</div>
 			</div>    
 
-			<?php do_action( 'tutor_student_reg_form_end' ); ?>
+				<?php do_action( 'tutor_student_reg_form_end' ); ?>
 
-			<?php
+				<?php
 				$tutor_toc_page_link = tutor_utils()->get_toc_page_link();
-			?>
-			<?php if ( null !== $tutor_toc_page_link ) : ?>
+				?>
+				<?php if ( null !== $tutor_toc_page_link ) : ?>
 				<div class="tutor-small tutor-mb-6">
 					<?php esc_html_e( 'By signing up, I agree with the website\'s', 'tutor' ); ?> 
 					<a target="_blank" href="<?php echo esc_url( $tutor_toc_page_link ); ?>" title="<?php esc_html_e( 'Terms and Conditions', 'tutor' ); ?>"><?php esc_html_e( 'Terms and Conditions', 'tutor' ); ?></a>
@@ -170,11 +169,11 @@ use TUTOR\Icon;
 					</a>
 				</div>
 			</div>
-			<?php do_action( 'tutor_after_register_button' ); ?>
+				<?php do_action( 'tutor_after_register_button' ); ?>
 			
 		</form>
-		<?php do_action( 'tutor_after_registration_form_wrap' ); ?>
+				<?php do_action( 'tutor_after_registration_form_wrap' ); ?>
 		
 	</div>
-	<?php do_action( 'tutor_after_student_reg_form' ); ?>
+				<?php do_action( 'tutor_after_student_reg_form' ); ?>
 <?php endif; ?>

--- a/templates/login-form.php
+++ b/templates/login-form.php
@@ -9,6 +9,7 @@
  */
 
 use TUTOR\Ajax;
+use Tutor\Components\Alert;
 use Tutor\Components\SvgIcon;
 use TUTOR\Icon;
 
@@ -21,31 +22,12 @@ $lost_pass = apply_filters( 'tutor_lostpassword_url', wp_lostpassword_url() );
  */
 $login_errors = get_transient( Ajax::LOGIN_ERRORS_TRANSIENT_KEY ) ? get_transient( Ajax::LOGIN_ERRORS_TRANSIENT_KEY ) : array();
 foreach ( $login_errors as $login_error ) {
-	?>
-	<div class="tutor-alert tutor-warning tutor-mb-10" style="display:block; grid-gap: 0px 10px; border: 1px solid var(--tutor-text-critical)">
-		<?php
-		echo wp_kses(
-			$login_error,
-			array(
-				'strong' => true,
-				'a'      => array(
-					'href'  => true,
-					'class' => true,
-					'id'    => true,
-				),
-				'p'      => array(
-					'class' => true,
-					'id'    => true,
-				),
-				'div'    => array(
-					'class' => true,
-					'id'    => true,
-				),
-			)
-		);
-		?>
-	</div>
-	<?php
+	Alert::make()
+		->text( $login_error )
+		->variant( Alert::ERROR )
+		->icon( Icon::WARNING )
+		->attr( 'class', 'tutor-mb-8' )
+		->render();
 }
 
 do_action( 'tutor_before_login_form' );


### PR DESCRIPTION
Refactor login, registration, and instructor dashboard templates to use the centralized Alert component instead of inline HTML markup. This improves consistency, maintainability, and reduces code duplication across multiple template files.