### PR TITLE
🐛 Stop V4 quiz timer after submission

### DIFF
--- a/assets/core/ts/constant.ts
+++ b/assets/core/ts/constant.ts
@@ -16,4 +16,5 @@ export const TUTOR_CUSTOM_EVENTS = {
   LESSON_PLAYER_READY: 'tutorLessonPlayerReady',
   QUIZ_TIME_EXPIRED: 'tutor-quiz-time-expired',
   QUIZ_ABANDON_REQUESTED: 'tutor-quiz-abandon-requested',
+  QUIZ_ATTEMPT_COMPLETED: 'tutor-quiz-attempt-completed',
 };

--- a/assets/src/js/frontend/learning-area/quiz/submission.ts
+++ b/assets/src/js/frontend/learning-area/quiz/submission.ts
@@ -368,7 +368,21 @@ const quizSubmission = (config: QuizSubmissionConfig) => {
       modal?.showModal?.(modalId, payload ?? null);
     },
 
+    notifyAttemptCompleted() {
+      document.dispatchEvent(
+        new CustomEvent(TUTOR_CUSTOM_EVENTS.QUIZ_ATTEMPT_COMPLETED, {
+          detail: {
+            formId: this.formId,
+            attemptId: this.attemptId,
+            quizId: this.quizId,
+          },
+        }),
+      );
+    },
+
     handleSubmissionSuccess(isTimeout: boolean) {
+      this.notifyAttemptCompleted();
+
       if (isTimeout) {
         this.openResultModal(this.timeoutModalId, {
           attempted: this.getAttemptedCount(),
@@ -381,6 +395,7 @@ const quizSubmission = (config: QuizSubmissionConfig) => {
     },
 
     handleTimeoutSuccess() {
+      this.notifyAttemptCompleted();
       this.openResultModal(this.timeoutModalId, {
         attempted: this.getAttemptedCount(),
         total: this.totalQuestions,

--- a/assets/src/js/frontend/learning-area/quiz/timer.ts
+++ b/assets/src/js/frontend/learning-area/quiz/timer.ts
@@ -44,6 +44,15 @@ const quizTimer = (config: QuizTimerConfig) => {
         return;
       }
 
+      document.addEventListener(TUTOR_CUSTOM_EVENTS.QUIZ_ATTEMPT_COMPLETED, ((event: Event) => {
+        const detail = (event as CustomEvent)?.detail ?? {};
+        if (detail?.formId && detail.formId !== this.formId) {
+          return;
+        }
+
+        this.stop();
+      }) as EventListener);
+
       if (this.remaining <= 0) {
         this.handleExpire();
         return;


### PR DESCRIPTION
This PR fixes a quiz attempt regression in the V4 learning area where the countdown timer continued running after the attempt had already been submitted.

From a user perspective, the issue was confusing because the quiz would appear to be complete, the submitted or timeout result modal would open, and the timer UI would still continue counting down in the background. That created the impression that the attempt was still active even though the submission request had already succeeded.

The root cause was that the timer component and the submission component were operating independently. The timer only stopped when it reached zero or when its own local stop logic ran, but the submission flow never notified the timer that the attempt had entered a terminal state. As a result, a successful manual submit or a successful timeout-triggered submit left the countdown interval alive until the page reloaded.

The fix introduces a dedicated quiz-attempt-completed custom event in the shared frontend event constants. The V4 quiz submission component now dispatches that event after a successful submit and after a successful timeout completion path. The V4 timer component listens for that event for the matching form and stops its running interval immediately. This keeps the timer state aligned with the actual attempt lifecycle and prevents the countdown from continuing once the quiz is already complete.

Validation for this change was done by running the frontend lint checks on the touched files after the implementation:

- `pnpm exec eslint assets/core/ts/constant.ts assets/src/js/frontend/learning-area/quiz/timer.ts assets/src/js/frontend/learning-area/quiz/submission.ts`

This branch contains one commit:

- `fix(quiz): stop timer after submission`
