### PR TITLE
fix(quiz): Improve layout responsiveness for quiz attempt details

### DIFF
--- a/assets/src/js/v3/shared/utils/quiz.ts
+++ b/assets/src/js/v3/shared/utils/quiz.ts
@@ -102,6 +102,7 @@ export const validateQuizQuestion = (
       if (firstAnswer?.answer_two_gap_match) {
         try {
           const data = JSON.parse(firstAnswer.answer_two_gap_match) as {
+            value?: number;
             config?: { min?: number; max?: number };
           };
           const min = Number(data.config?.min ?? 0);
@@ -109,6 +110,19 @@ export const validateQuizQuestion = (
           if (!Number.isNaN(min) && !Number.isNaN(max) && max <= min) {
             return {
               message: __('The maximum value must be greater than the minimum value.', __TUTOR_TEXT_DOMAIN__),
+              type: 'question',
+            };
+          }
+
+          const correctValue = Number(data.value);
+          if (
+            !Number.isNaN(min) &&
+            !Number.isNaN(max) &&
+            !Number.isNaN(correctValue) &&
+            (correctValue < min || correctValue > max)
+          ) {
+            return {
+              message: __('The correct value must be between the minimum and maximum values.', __TUTOR_TEXT_DOMAIN__),
               type: 'question',
             };
           }

--- a/assets/src/scss/frontend/components/_quiz-attempt-details.scss
+++ b/assets/src/scss/frontend/components/_quiz-attempt-details.scss
@@ -133,11 +133,18 @@
     }
   }
 
+  // Allow the main column to shrink on narrow viewports (avoids wide children e.g. scale track forcing overflow).
+  .tutor-quiz-summary-content {
+    min-width: 0;
+    max-width: 100%;
+  }
+
   .tutor-quiz-questions {
     @include tutor-frontend-layout();
     @include tutor-flex(column);
     padding-inline: 0;
     width: 100%;
+    min-width: 0;
     gap: $tutor-spacing-5;
   }
 
@@ -255,6 +262,10 @@
   }
 
   .tutor-quiz-question {
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+
     &-header {
       &-actions {
         @include tutor-flex(row, center);


### PR DESCRIPTION
- Adjusted styles in `_quiz-attempt-details.scss` to allow the main column to shrink on narrow viewports, preventing overflow from wide children.
- Set `min-width` and `max-width` properties for `.tutor-quiz-summary-content` and `.tutor-quiz-questions` to enhance layout flexibility.