### PR TITLE
Remove Spotlight Mode option and usage

### DIFF
--- a/classes/Options_V2.php
+++ b/classes/Options_V2.php
@@ -852,14 +852,6 @@ class Options_V2 {
 								'desc'    => __( 'Enabling this feature will show a course content summary on the Course Details page.', 'tutor' ),
 							),
 							array(
-								'key'         => 'enable_spotlight_mode',
-								'type'        => 'toggle_switch',
-								'label'       => __( 'Spotlight Mode', 'tutor' ),
-								'default'     => 'off',
-								'label_title' => '',
-								'desc'        => __( 'This will hide the header and the footer and enable spotlight (full screen) mode when students view lessons.', 'tutor' ),
-							),
-							array(
 								'key'         => 'auto_course_complete_on_all_lesson_completion',
 								'type'        => 'toggle_switch',
 								'label'       => __( 'Auto Complete Course on All Lesson Completion', 'tutor' ),

--- a/includes/tutor-general-functions.php
+++ b/includes/tutor-general-functions.php
@@ -495,9 +495,7 @@ if ( ! function_exists( 'get_tutor_header' ) ) {
 	 * @return void
 	 */
 	function get_tutor_header( $full_screen = false ) {
-		$enable_spotlight_mode = tutor_utils()->get_option( 'enable_spotlight_mode' );
-
-		if ( $enable_spotlight_mode || $full_screen ) {
+		if ( $full_screen ) {
 			?>
 			<!doctype html>
 			<html <?php language_attributes(); ?>>
@@ -529,8 +527,7 @@ if ( ! function_exists( 'get_tutor_footer' ) ) {
 	 * @return void
 	 */
 	function get_tutor_footer( $full_screen = false ) {
-		$enable_spotlight_mode = tutor_utils()->get_option( 'enable_spotlight_mode' );
-		if ( $enable_spotlight_mode || $full_screen ) {
+		if ( $full_screen ) {
 			?>
 				</div>
 			<?php wp_footer(); ?>

--- a/templates/single-content-loader.php
+++ b/templates/single-content-loader.php
@@ -24,8 +24,7 @@ $previous_id = $contents->previous_id;
 $next_id     = $contents->next_id;
 $user_id     = get_current_user_id();
 
-$is_course_completed   = tutor_utils()->is_completed_course( $course_id, $user_id );
-$enable_spotlight_mode = tutor_utils()->get_option( 'enable_spotlight_mode' );
+$is_course_completed = tutor_utils()->is_completed_course( $course_id, $user_id );
 //phpcs:ignore WordPress.PHP.DontExtract.extract_extract
 extract( $data ); // $data variable consist $context, $html_content.
 
@@ -63,7 +62,7 @@ if ( tutor()->lesson_post_type === $post->post_type ) {
 ?>
 
 <?php do_action( 'tutor_' . $context . '/single/before/wrap' ); ?>
-<div class="tutor-course-single-content-wrapper<?php echo $enable_spotlight_mode ? ' tutor-spotlight-mode' : ''; ?>">
+<div class="tutor-course-single-content-wrapper">
 	<div class="tutor-course-single-sidebar-wrapper tutor-<?php echo esc_attr( $context ); ?>-sidebar">
 		<?php tutor_course_single_sidebar(); ?>
 	</div>

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -13,13 +13,12 @@ use Tutor\Models\CourseModel;
 global $previous_id;
 
 // Get the ID of this content and the corresponding course.
-$course_content_id     = get_the_ID();
-$course_id             = tutor_utils()->get_course_id_by_subcontent( $course_content_id );
-$content_id            = tutor_utils()->get_post_id( $course_content_id );
-$contents              = tutor_utils()->get_course_prev_next_contents_by_id( $content_id );
-$previous_id           = $contents->previous_id;
-$course                = CourseModel::get_course_by_quiz( get_the_ID() );
-$enable_spotlight_mode = tutor_utils()->get_option( 'enable_spotlight_mode' );
+$course_content_id = get_the_ID();
+$course_id         = tutor_utils()->get_course_id_by_subcontent( $course_content_id );
+$content_id        = tutor_utils()->get_post_id( $course_content_id );
+$contents          = tutor_utils()->get_course_prev_next_contents_by_id( $content_id );
+$previous_id       = $contents->previous_id;
+$course            = CourseModel::get_course_by_quiz( get_the_ID() );
 ob_start();
 ?>
 <input type="hidden" name="tutor_quiz_id" id="tutor_quiz_id" value="<?php the_ID(); ?>">


### PR DESCRIPTION
Deletes the Spotlight Mode setting and removes its runtime checks and CSS class toggles. Header/footer now rely only on the $full_screen flag, and templates no longer read or apply the enable_spotlight_mode option. Also cleans up related unused variables/spacing in single-content-loader.php and single-quiz.php.