### PR TITLE
Fix: Manual payment methods not showing when added media files

### DIFF
--- a/ecommerce/Settings.php
+++ b/ecommerce/Settings.php
@@ -359,6 +359,16 @@ class Settings {
 	 */
 	public static function get_payment_settings() {
 		$settings = tutor_utils()->get_option( OptionKeys::PAYMENT_SETTINGS );
+
+		// Check for image tags in the settings and escape them before decoding JSON.
+		$settings = preg_replace_callback(
+			'/<img[^>]+>/',
+			function ( $matches ) {
+				return addslashes( $matches[0] );
+			},
+			$settings
+		);
+
 		$settings = json_decode( $settings, true );
 
 		return $settings;


### PR DESCRIPTION
### Overview
This PR fixes the issue where when a image is added to manual payment, due to the image tag the json value obtained before decoding becomes invalid, thus it shows no payment gateway in the tutor checkout page, to fix this i have use `preg_replace_callback` and obtained the image tags and added slashes to those string using `addslashes` method, this fixes the issue where the media was not showing in the checkout page as well.