### PR TITLE
🐛 Support unlimited quiz question pools

### DIFF
--- a/assets/src/js/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
@@ -106,7 +106,8 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
   const hasQuestionLimit = form.watch('quiz_option.limit_questions_to_answer');
   const hasTimeLimit = form.watch('quiz_option.enable_time_limit');
   const questionsOrder = form.watch('quiz_option.questions_order');
-  const availableQuestionInPool = Math.min(Number(form.watch('quiz_option.max_questions_for_answer')), questionsCount);
+  const availableQuestionInPool =
+    Math.min(Number(form.watch('quiz_option.max_questions_for_answer')), questionsCount) || questionsCount;
   const usedQuestionCountPercentage = (availableQuestionInPool / questionsCount) * 100;
   const orderedQuestions = (() => {
     if (questionsOrder === 'sorting') {
@@ -284,7 +285,15 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
                 <Show when={hasQuestionLimit}>
                   <Controller
                     name="quiz_option.max_questions_for_answer"
-                    rules={requiredRule()}
+                    rules={{
+                      ...requiredRule(),
+                      validate: (value) => {
+                        if (value <= 0) {
+                          return __('Question limit must be greater than 0', 'tutor');
+                        }
+                        return true;
+                      },
+                    }}
                     control={form.control}
                     render={(controllerProps) => (
                       <FormInput
@@ -294,9 +303,7 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
                         isInlineLabel
                         selectOnFocus
                         style={styles.maxWidth('99px')}
-                        formFieldWrapperCss={css`
-                          width: auto;
-                        `}
+                        formFieldWrapperCss={styles.width('auto')}
                         inputContainerCss={styles.justifyContent('flex-end')}
                       />
                     )}
@@ -411,9 +418,7 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
                         contentPosition="right"
                         wrapperCss={styles.maxWidth('80px')}
                         contentCss={styles.minWidth('fit-content')}
-                        formFieldWrapperCss={css`
-                          width: auto;
-                        `}
+                        formFieldWrapperCss={styles.width('auto')}
                         showVerticalBar={false}
                         presetOptions={[
                           {

--- a/assets/src/js/v3/entries/course-builder/components/modals/QuizModal.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/modals/QuizModal.tsx
@@ -88,6 +88,7 @@ const QuizModal = ({
         },
         hide_quiz_time_display: false,
         limit_attempts_allowed: false,
+        limit_questions_to_answer: false,
         attempts_allowed: 10,
         passing_grade: 80,
         max_questions_for_answer: contentType === 'tutor_h5p_quiz' ? 0 : 10,

--- a/assets/src/js/v3/entries/course-builder/services/quiz.ts
+++ b/assets/src/js/v3/entries/course-builder/services/quiz.ts
@@ -240,7 +240,9 @@ export const convertQuizFormDataToPayload = (
           isAddonEnabled(Addons.H5P_INTEGRATION) &&
           formData.questions.every((question) => question.question_type === 'h5p')
             ? formData.questions.length
-            : formData.quiz_option.max_questions_for_answer,
+            : formData.quiz_option.limit_questions_to_answer
+              ? formData.quiz_option.max_questions_for_answer
+              : 0,
         open_ended_answer_characters_limit: formData.quiz_option.open_ended_answer_characters_limit,
         pass_is_required: formData.quiz_option.pass_is_required ? '1' : '0',
         passing_grade: formData.quiz_option.passing_grade,

--- a/assets/src/scss/frontend/components/_quiz-attempt-details.scss
+++ b/assets/src/scss/frontend/components/_quiz-attempt-details.scss
@@ -241,6 +241,11 @@
       background: $tutor-surface-warning-hover;
     }
   }
+  .tutor-quiz-question-option {
+    &[data-readonly='true'] {
+      cursor: default;
+    }
+  }
 
   [data-question='fill_in_the_blank'] {
     .tutor-quiz-question-option {

--- a/assets/src/scss/frontend/components/_quiz-question.scss
+++ b/assets/src/scss/frontend/components/_quiz-question.scss
@@ -256,9 +256,9 @@
       border: none;
       line-height: 2.5;
 
-      &:hover:not(:has(:checked)):not([data-option='correct']):not([data-option='incorrect']):not(
-          [data-option='draggable']
-        ) {
+      &:hover:not(:has(:checked)):not(:has(:disabled)):not([data-readonly='true']):not([data-option='correct']):not(
+          [data-option='incorrect']
+        ):not([data-option='draggable']) {
         background-color: transparent;
         cursor: default;
       }

--- a/assets/src/scss/frontend/learning-area/components/quiz/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/components/quiz/_quiz.scss
@@ -976,9 +976,9 @@ $tutor-quiz-content-bottom-offset: calc(
 
     &-inner {
       @include tutor-flex(row, center, flex-start);
+      @include tutor-frontend-layout();
       gap: $tutor-spacing-4;
       width: 100%;
-      max-width: 792px;
       margin-inline: auto;
     }
 

--- a/assets/src/scss/frontend/learning-area/components/quiz/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/components/quiz/_quiz.scss
@@ -641,9 +641,9 @@ $tutor-quiz-content-bottom-offset: calc(
     &-option {
       cursor: pointer;
 
-      &:hover:not(:has(:checked)):not([data-option='correct']):not([data-option='incorrect']):not(
-          [data-option='draggable']
-        ) {
+      &:hover:not(:has(:checked)):not(:has(:disabled)):not([data-readonly='true']):not([data-option='correct']):not(
+          [data-option='incorrect']
+        ):not([data-option='draggable']) {
         border-color: $tutor-border-hover;
         background-color: $tutor-surface-l1-hover;
       }

--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -1700,7 +1700,7 @@ class Quiz {
 						' . SvgIcon::make()->name( Icon::PRIME_CHECK_CIRCLE )->size( 20 )->get() . __( 'Total Marks', 'tutor' ) . '
 					</div>',
 				),
-				array( 'content' => $total_questions ),
+				array( 'content' => $total_marks ),
 			),
 		);
 

--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -5378,7 +5378,7 @@ class Utils {
 			)
 		);
 
-		return min( $max_questions_count, $total_question );
+		return min( $max_questions_count, $total_question ) <= 0 ? $total_question : min( $max_questions_count, $total_question );
 	}
 
 	/**
@@ -5445,6 +5445,10 @@ class Utils {
 		);
 
 		$max_mentioned = (int) $this->get_quiz_option( $quiz_id, 'max_questions_for_answer', 10 );
+
+		if ( $max_mentioned <= 0 ) {
+			return $max_questions;
+		}
 
 		if ( $max_mentioned < $max_questions ) {
 			return $max_mentioned;

--- a/templates/dashboard/quiz-attempts/quiz-reviews.php
+++ b/templates/dashboard/quiz-attempts/quiz-reviews.php
@@ -30,7 +30,7 @@ if ( ! $attempt_data || ! $can_review ) {
 
 $form_id             = 'quiz-attempt-review-form';
 $form_default_values = array(
-	'feedback' => is_array( $attempt_info ) ? (string) ( $attempt_info['instructor_feedback'] ?? '' ) : '',
+	'feedback' => is_array( $attempt_info ) ? (string) ( wp_json_encode( $attempt_info['feedback'] ?? '', JSON_HEX_APOS ) ) : '',
 );
 
 $attempt_answers_map = array();

--- a/templates/shared/components/quiz/attempt-details/questions/fill-in-the-blank.php
+++ b/templates/shared/components/quiz/attempt-details/questions/fill-in-the-blank.php
@@ -103,13 +103,13 @@ $correct_lines      = array();
 <?php endforeach; ?>
 
 <div class="tutor-quiz-question-options">
-	<div class="tutor-quiz-question-option">
+	<div class="tutor-quiz-question-option" data-readonly="true">
 		<div class="tutor-quiz-review-col-title"><?php esc_html_e( 'Given Answer', 'tutor' ); ?></div>
 		<?php foreach ( $given_markup_lines as $line ) : ?>
 			<p><?php echo wp_kses_post( $line ); ?></p>
 		<?php endforeach; ?>
 	</div>
-	<div class="tutor-quiz-question-option">
+	<div class="tutor-quiz-question-option" data-readonly="true">
 		<div class="tutor-quiz-review-col-title"><?php esc_html_e( 'Correct Answer', 'tutor' ); ?></div>
 		<?php foreach ( $correct_lines as $line ) : ?>
 			<p><?php echo wp_kses_post( $line ); ?></p>

--- a/templates/shared/components/quiz/attempt-details/questions/multiple-choice.php
+++ b/templates/shared/components/quiz/attempt-details/questions/multiple-choice.php
@@ -44,7 +44,7 @@ $given_ids = array_map( 'intval', array_filter( $given_ids ) );
 			$option_attr = 'correct';
 		}
 		?>
-		<div class="tutor-quiz-question-option" data-option="<?php echo esc_attr( $option_attr ); ?>">
+		<div class="tutor-quiz-question-option" data-option="<?php echo esc_attr( $option_attr ); ?>" data-readonly="true">
 			<?php if ( ! empty( $answer->image_id ) ) : ?>
 				<img src="<?php echo esc_url( wp_get_attachment_image_url( $answer->image_id, 'full' ) ); ?>" alt="<?php echo esc_attr( $answer->answer_title ?? '' ); ?>">
 				<div data-title><?php echo esc_html( $answer->answer_title ?? '' ); ?></div>

--- a/templates/shared/components/quiz/attempt-details/questions/true-false.php
+++ b/templates/shared/components/quiz/attempt-details/questions/true-false.php
@@ -43,7 +43,7 @@ $given_ids = array_map( 'intval', array_filter( $given_ids ) );
 			$option_attr = 'correct';
 		}
 		?>
-		<div class="tutor-quiz-question-option" data-option="<?php echo esc_attr( $option_attr ); ?>">
+		<div class="tutor-quiz-question-option" data-option="<?php echo esc_attr( $option_attr ); ?>" data-readonly="true">
 			<?php SvgIcon::make()->name( ! empty( $answer->is_correct ) ? Icon::CHECK_2 : Icon::CROSS )->size( 20 )->render(); ?>
 			<?php echo esc_html( $answer->answer_title ?? '' ); ?>
 		</div>


### PR DESCRIPTION
## Summary
This change adds explicit support for storing `0` as the unlimited value for quiz question pools while preserving a safe positive default in the course builder when an instructor enables question limiting. It also fixes the attempt-details review UI so read-only quiz options no longer present hover or pointer affordances, and corrects how instructor feedback is hydrated in the dashboard quiz review form.

Without these updates, instructors could end up with inconsistent quiz-question-limit behavior depending on whether the limit was enabled, learners reviewing attempt details could still see answer options behave like interactive controls even though those views are read-only, and the quiz review form could preload feedback using the wrong attempt-info key and encoding path.

## Root Cause
The frontend and backend were using `max_questions_for_answer` inconsistently. The builder needed a distinction between "limit disabled" and "limit enabled with a positive count," but the old form defaults and validation did not enforce that. Once `0` was introduced as the unlimited value, the backend attempt setup path still treated that `0` as a literal cap instead of expanding it to the full question count.

Separately, the shared quiz option styles still applied hover and pointer behavior based on generic option markup. That worked for active quiz attempts, but the attempt-details templates reuse the same visual option containers for read-only answer review, including true/false variants that do not include disabled form controls inside the option wrapper.

The dashboard review form also populated its default feedback field from `instructor_feedback`, while the rest of the review flow stores and reads the value from `feedback`. That mismatch meant existing feedback could be hydrated incorrectly when opening the review screen.

## Fix
The course builder now keeps a positive default for `max_questions_for_answer` on regular quizzes so enabling the limit starts from a valid value. The settings form also validates that the limit must be greater than zero whenever the limit is enabled.

On save, the payload now writes `0` only when question limiting is disabled, which makes the unlimited state explicit. On the backend, quiz question-count helpers and attempt setup now interpret `0` as unlimited and resolve it to the full available question count before storing attempt metadata or rendering learner-facing totals.

For the attempt-details UI, read-only option wrappers are now marked explicitly in the review templates, and the shared quiz option styles skip hover and pointer states for both disabled-input options and explicitly read-only ones. That keeps the review screen visually static while preserving the interactive behavior in active quiz-taking flows.

For instructor reviews, the dashboard form now hydrates its `feedback` field from the `feedback` entry in attempt info and encodes it consistently for the frontend form defaults.

## Validation
The commits passed the repository's commit hooks. The earlier quiz-limit commit ran `pnpm exec eslint --fix` and `pnpm exec prettier --write` through `lint-staged`, and the follow-up commits completed successfully with no matching staged tasks for `lint-staged`. I did not run additional manual or automated test suites beyond those checks.
