### PR TITLE
Fix: Prevented pasting image on assignment submission textarea

### DIFF
--- a/assets/core/ts/components/wp-editor.ts
+++ b/assets/core/ts/components/wp-editor.ts
@@ -15,6 +15,7 @@ interface WPEditorConfig {
   name: string;
   editorId: string;
   placeholder?: string;
+  pasteImage: boolean;
 }
 
 interface AlpineComponent {
@@ -42,7 +43,7 @@ interface WPEditorComponent {
 }
 
 export const wpEditor = (config: WPEditorConfig): WPEditorComponent => {
-  const { name, editorId, placeholder = '' } = config;
+  const { name, editorId, placeholder = '', pasteImage } = config;
 
   return {
     name,
@@ -89,6 +90,21 @@ export const wpEditor = (config: WPEditorConfig): WPEditorComponent => {
 
           // Sync editor content with form value on change
           editor.on('change keyup', () => {
+            this.syncEditorToForm();
+          });
+
+          editor.on('paste', (e: ClipboardEvent) => {
+            if (!pasteImage) {
+              const items = e.clipboardData?.items;
+              if (!items) return;
+              for (let i = 0; i < items.length; i++) {
+                if (items[i].type.indexOf('image') !== -1) {
+                  e.preventDefault();
+                  return false;
+                }
+              }
+            }
+
             this.syncEditorToForm();
           });
 

--- a/assets/src/js/front/tutor-front.js
+++ b/assets/src/js/front/tutor-front.js
@@ -992,4 +992,32 @@ jQuery(document).ready(function($) {
         
         jQuery(this).parent().find('.tutor-validation-icon')[matched ? 'show' : 'hide']();
     });
+
+	const initTinyMceFilter = () => {
+        if (typeof tinymce === 'undefined') {
+            setTimeout(initTinyMceFilter, 100);
+            return;
+        }
+
+		tinymce.editors.forEach((e) =>{
+			e.on('paste', function(e){
+				const items = (e.clipboardData || e.originalEvent.clipboardData).items;
+
+				if (!items) return; 
+
+				for( let i =0; i<items.length; i++) {
+					if ( items[i].type.indexOf('image') !== -1 ) {
+						e.preventDefault();
+						return false;
+					}
+				}
+			})
+		})
+
+    };
+
+	const assignment_submit_button = document.getElementById('tutor_assignment_submit_btn');
+	if ( assignment_submit_button ) {
+    	initTinyMceFilter();
+	}
 });

--- a/components/WPEditor.php
+++ b/components/WPEditor.php
@@ -144,6 +144,15 @@ class WPEditor extends BaseComponent {
 	protected $editor_config = array();
 
 	/**
+	 * Whether editor supports pasting image.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @var boolean
+	 */
+	protected $paste_image = true;
+
+	/**
 	 * Set editor name.
 	 *
 	 * @since 4.0.0
@@ -154,6 +163,20 @@ class WPEditor extends BaseComponent {
 	 */
 	public function name( $name ) {
 		$this->name = sanitize_key( $name );
+		return $this;
+	}
+
+	/**
+	 * Set whether to paste images.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param boolean $should_paste whether to paste images.
+	 *
+	 * @return $this
+	 */
+	public function pasteImage( $should_paste = true ) {
+		$this->paste_image = $should_paste;
 		return $this;
 	}
 
@@ -387,7 +410,8 @@ class WPEditor extends BaseComponent {
 			x-data="tutorWPEditor({ 
 				name: '<?php echo esc_js( $this->name ); ?>',
 				editorId: '<?php echo esc_js( $editor_id ); ?>',
-				placeholder: '<?php echo esc_js( $this->placeholder ); ?>'
+				placeholder: '<?php echo esc_js( $this->placeholder ); ?>',
+				pasteImage: <?php echo $this->paste_image ? 'true' : 'false'; ?>
 			})"
 			x-init="init()"
 		>

--- a/components/WPEditor.php
+++ b/components/WPEditor.php
@@ -175,7 +175,7 @@ class WPEditor extends BaseComponent {
 	 *
 	 * @return $this
 	 */
-	public function pasteImage( $should_paste = true ) {
+	public function paste_image( $should_paste = true ) {
 		$this->paste_image = $should_paste;
 		return $this;
 	}


### PR DESCRIPTION
This pr fixes the issue where students where allowed to paste images on textarea for assignment submit.  This was fixed in both legacy and modern. To fix this in legacy in `tutor_front.js` i check if `tinymce` is available, if it is loop through each editor and handle the `onpaste` event and check if user pasted an image. For modern, the `WPEditor` component was updated to have a new property called `pasteImage` which on paste event if it is true the allow pasting image, otherwise it prevents it.