### PR TITLE
Add heading link styles and feedback link

### DIFF
--- a/assets/scss/admin-dashboard/_tutor-admin.scss
+++ b/assets/scss/admin-dashboard/_tutor-admin.scss
@@ -2044,6 +2044,19 @@ h2.tutor-page-heading {
       color: #ffffff;
       margin: 0px;
       padding: 0px;
+
+      a {
+        color: #ffffff;
+		text-decoration: underline;
+		text-underline-offset: 3px;
+
+        &:hover,
+        &:focus,
+        &:active,
+        &:visited {
+          color: #ffffff;
+        }
+      }
     }
 
     &-buttons {

--- a/classes/Admin.php
+++ b/classes/Admin.php
@@ -103,7 +103,21 @@ class Admin {
 			<div class="tutor-v4-beta-notice-right">
 				<div class="tutor-v4-beta-notice-right-content">
 					<h3><?php esc_html_e( 'Be the First to Try Tutor LMS 4.0 Beta!', 'tutor' ); ?></h3>
-					<p><?php esc_html_e( 'Explore the upcoming features of Tutor LMS 4.0, test the experience, and help us improve with your valuable feedback.', 'tutor' ); ?></p>
+					<p>
+						<?php
+						echo wp_kses_post(
+							sprintf(
+								/* translators: 1: opening anchor tag, 2: closing anchor tag */
+								__(
+									'Explore the upcoming features of Tutor LMS 4.0, test the experience, and help us improve with your valuable %1$sfeedback%2$s.',
+									'tutor'
+								),
+								'<a href="https://forms.gle/Dxc1CWT63UcEAJGR9" target="_blank">',
+								' <i class="tutor-icon-external-link" aria-hidden="true"></i></a>'
+							)
+						);
+						?>
+					</p>
 				</div>
 				<div class="tutor-v4-beta-notice-right-buttons">
 					<a href="https://tutorlms.com/blog/first-look-into-tutor-lms-4-0/?nocache=1" target="_blank" class="tutor-btn tutor-btn-tertiary tutor-gap-4px tutor-text-nowrap">

--- a/classes/Admin.php
+++ b/classes/Admin.php
@@ -105,22 +105,33 @@ class Admin {
 					<h3><?php esc_html_e( 'Be the First to Try Tutor LMS 4.0 Beta!', 'tutor' ); ?></h3>
 					<p>
 						<?php
-						echo wp_kses_post(
+						echo wp_kses(
 							sprintf(
 								/* translators: 1: opening anchor tag, 2: closing anchor tag */
 								__(
 									'Explore the upcoming features of Tutor LMS 4.0, test the experience, and help us improve with your valuable %1$sfeedback%2$s.',
 									'tutor'
 								),
-								'<a href="https://forms.gle/Dxc1CWT63UcEAJGR9" target="_blank">',
+								'<a href="https://forms.gle/Dxc1CWT63UcEAJGR9" target="_blank" rel="noopener noreferrer">',
 								' <i class="tutor-icon-external-link" aria-hidden="true"></i></a>'
+							),
+							array(
+								'a' => array(
+									'href'   => true,
+									'target' => true,
+									'rel'    => true,
+								),
+								'i' => array(
+									'class'       => true,
+									'aria-hidden' => true,
+								),
 							)
 						);
 						?>
 					</p>
 				</div>
 				<div class="tutor-v4-beta-notice-right-buttons">
-					<a href="https://tutorlms.com/blog/first-look-into-tutor-lms-4-0/?nocache=1" target="_blank" class="tutor-btn tutor-btn-tertiary tutor-gap-4px tutor-text-nowrap">
+					<a href="https://tutorlms.com/blog/first-look-into-tutor-lms-4-0/?nocache=1" target="_blank" rel="noopener noreferrer" class="tutor-btn tutor-btn-tertiary tutor-gap-4px tutor-text-nowrap">
 						<?php esc_html_e( 'Try now', 'tutor' ); ?>
 					</a>
 				</div>


### PR DESCRIPTION
Add anchor styling inside h2.tutor-page-heading to ensure white underlined links with hover/focus/active/visited color consistency. Update the admin beta notice paragraph to include a feedback link (Google Form) with an external-link icon, using wp_kses_post and sprintf for safe, translatable output.