### PR TITLE
Fix: enhance quiz attempt details answer explanation ordering for new quiz type

### DIFF
--- a/templates/shared/components/quiz/attempt-details/question.php
+++ b/templates/shared/components/quiz/attempt-details/question.php
@@ -87,11 +87,10 @@ if ( 'review-answer-dnd' === $question_template ) {
 		)
 	);
 
+	do_action( 'tutor_quiz_attempt_details_after_question_template', $question, $question_template, $attempt_answer, $index );
+
 	if ( is_object( $attempt_answer ) ) {
 		do_action( 'tutor_quiz_attempt_details_loop_after_row', $attempt_answer, $answer_status, array() );
 	}
-
-	// Add-ons may output Pro-only attempt-details partials (scale, draw-image, pin-image) before the wrapper closes.
-	do_action( 'tutor_quiz_attempt_details_before_question_wrapper_close', $question, $question_template, $attempt_answer, $index );
 	?>
 </div>


### PR DESCRIPTION
- Added a new action hook `tutor_quiz_attempt_details_after_question_template` to allow for additional functionality after rendering the question template.
- Removed the previous action hook `tutor_quiz_attempt_details_before_question_wrapper_close` to streamline the code and improve maintainability.