### PR TITLE
Fix: Back url with wpml and completed status card query update

### DIFF
--- a/templates/account.php
+++ b/templates/account.php
@@ -31,7 +31,7 @@ $account_pages = Dashboard::get_account_pages();
 $page_data     = $account_pages[ $subpage ] ?? array();
 $page_template = $page_data['template'] ?? '';
 
-$back_url  = UrlHelper::back( tutor_utils()->tutor_dashboard_url() );
+$back_url  = apply_filters( 'tutor_dashboard_back_url', UrlHelper::back( tutor_utils()->tutor_dashboard_url() ) );
 $close_url = tutor_utils()->tutor_dashboard_url();
 ?>
 <div class="tutor-account-page-wrapper">

--- a/templates/dashboard/account/settings/header.php
+++ b/templates/dashboard/account/settings/header.php
@@ -17,7 +17,7 @@ use Tutor\Components\Button;
 use Tutor\Components\Constants\Size;
 use Tutor\Components\Constants\Variant;
 
-$back_url = UrlHelper::back( tutor_utils()->tutor_dashboard_url() );
+$back_url = apply_filters( 'tutor_dashboard_back_url', UrlHelper::back( tutor_utils()->tutor_dashboard_url() ) );
 
 ?>
 <div class="tutor-profile-header">

--- a/templates/dashboard/student-dashboard.php
+++ b/templates/dashboard/student-dashboard.php
@@ -51,11 +51,11 @@ if ( tutor_utils()->get_option( 'enable_profile_completion' ) ) {
 <div class="tutor-student-dashboard" x-data>
 	<?php
 	$enrolled_course   = CourseModel::get_enrolled_courses_by_user( $user_id, array( 'private', 'publish' ) );
-	$completed_courses = tutor_utils()->get_completed_courses_ids_by_user();
+	$completed_courses = CourseModel::get_completed_courses_by_user( $user_id );
 	$active_courses    = CourseModel::get_active_courses_by_user( $user_id );
 
 	$enrolled_course_count  = $enrolled_course ? $enrolled_course->post_count : 0;
-	$completed_course_count = count( $completed_courses );
+	$completed_course_count = is_object( $completed_courses ) && $completed_courses->have_posts() ? $completed_courses->post_count : 0;
 	$active_course_count    = is_object( $active_courses ) && $active_courses->have_posts() ? $active_courses->post_count : 0;
 
 	$enrolled_course_link  = tutor_utils()->tutor_dashboard_url( 'courses' );


### PR DESCRIPTION
- Added filter hook `tutor_dashboard_back_url` for filtering back url when using WPML
- On dashboard page the course completed status query was updated so that when language is switched it only shows completed course of that language