### PR TITLE
Fix: quiz image handling in QuestionPreviewModal

### DIFF
--- a/assets/src/js/v3/entries/course-builder/components/modals/QuestionPreviewModal.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/modals/QuestionPreviewModal.tsx
@@ -444,6 +444,7 @@ const getPreviewFrameStyles = () => `
     height: auto;
     max-width: 100%;
     max-height: min(52vh, 460px);
+    object-fit: contain;
   }
 
   /*

--- a/assets/src/scss/frontend/learning-area/components/quiz/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/components/quiz/_quiz.scss
@@ -972,6 +972,26 @@ $tutor-quiz-content-bottom-offset: calc(
     }
   }
 
+  [data-question='draw_image'],
+  [data-question='pin_image'] {
+    .tutor-quiz-question-options {
+      @include tutor-flex(column, center, center);
+      width: 100%;
+    }
+
+    img {
+      display: block;
+      width: auto;
+      height: auto;
+      max-width: 100%;
+      object-fit: contain;
+    }
+
+    canvas {
+      max-width: 100%;
+    }
+  }
+
   &-footer {
     padding-block: $tutor-spacing-8;
     margin-top: auto;


### PR DESCRIPTION
- Added `object-fit: contain` style to the preview frame for better image display.
- Updated quiz question styles to ensure images and canvas elements are responsive and maintain aspect ratio.