### PR TITLE
fix: PHP 8.4 nullable Throwable compatibility and WooCommerce hook args mismatch

### DIFF
--- a/classes/WooCommerce.php
+++ b/classes/WooCommerce.php
@@ -62,7 +62,7 @@ class WooCommerce extends Tutor_Base {
 		/**
 		 * After place new order
 		 */
-		add_action( 'woocommerce_new_order', array( $this, 'course_placing_order_from_admin' ), 10, 3 );
+		add_action( 'woocommerce_new_order', array( $this, 'course_placing_order_from_admin' ), 10, 1 );
 		add_action( 'woocommerce_new_order_item', array( $this, 'course_placing_order_from_customer' ), 10, 3 );
 
 		/**

--- a/ecommerce/PaymentGateways/Paypal/src/Exceptions/FilesystemException.php
+++ b/ecommerce/PaymentGateways/Paypal/src/Exceptions/FilesystemException.php
@@ -7,7 +7,7 @@ use Throwable;
 
 class FilesystemException extends RuntimeException implements Throwable
 {
-	public function __construct($message = "", $code = 0, Throwable $previous = null)
+	public function __construct($message = "", $code = 0, ?Throwable $previous = null)
 	{
 		parent::__construct(
 			$message,


### PR DESCRIPTION
1. Fix nullable Throwable parameter for PHP 8.4 compatibility
2. Fix callback argument mismatch in WooCommerce new order hook