### PR TITLE
Fix(🛠) : Incorrect order badge count on order submenu

### DIFF
--- a/ecommerce/AdminMenu.php
+++ b/ecommerce/AdminMenu.php
@@ -43,6 +43,7 @@ class AdminMenu {
 				array(
 					'payment_status' => OrderModel::PAYMENT_UNPAID,
 					'order_type'     => OrderModel::TYPE_SINGLE_ORDER,
+					'order_status'   => OrderModel::ORDER_INCOMPLETE,
 				)
 			);
 			set_transient( OrderModel::TRANSIENT_ORDER_BADGE_COUNT, $order_badge_count, HOUR_IN_SECONDS );


### PR DESCRIPTION
Fixed badge count issue to exclude trashed and cancelled orders on order submenu.