### PR TITLE
Add options param to get_assignment_deadline

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -7903,10 +7903,11 @@ class Utils {
 	 *
 	 * @return string|false
 	 */
-	public function get_assignment_deadline_date_in_gmt( $assignment_id, $fallback = null, $student_id = 0, $course_id = 0 ) {
-		$value               = $this->get_assignment_option( $assignment_id, 'time_duration.value' );
-		$time                = $this->get_assignment_option( $assignment_id, 'time_duration.time' );
-		$deadline_from_start = (bool) $this->get_assignment_option( $assignment_id, 'deadline_from_start' );
+	public function get_assignment_deadline_date_in_gmt( $assignment_id, $fallback = null, $student_id = 0, $course_id = 0, $options = null ) {
+		$options             = $options ?? $this->get_assignment_option( $assignment_id );
+		$value               = $this->avalue_dot( 'time_duration.value', $options );
+		$time                = $this->avalue_dot( 'time_duration.time', $options );
+		$deadline_from_start = (bool) $this->avalue_dot( 'deadline_from_start', $options );
 
 		if ( ! $value ) {
 			return $fallback;


### PR DESCRIPTION
Allow callers to pass a pre-fetched $options array to get_assignment_deadline_date_in_gmt to avoid repeated lookups. The function signature adds an optional $options parameter (default null) and uses avalue_dot to read 'time_duration.value', 'time_duration.time', and 'deadline_from_start' from the options; if $options is null it falls back to the existing get_assignment_option behavior. Function behavior and fallback logic remain unchanged.