### PR TITLE
Wrap option label and count in flex span

### DIFF
--- a/components/DropdownFilter.php
+++ b/components/DropdownFilter.php
@@ -525,31 +525,35 @@ class DropdownFilter extends BaseComponent {
 										x-show="search === '' || '<?php echo esc_js( $opt_label ); ?>'.toLowerCase().includes(search.toLowerCase())"
 									<?php endif; ?>
 								>
-									<span class="tutor-truncate">
-										<?php echo esc_html( $opt_label ); ?>
-									</span>
-									<?php if ( null !== $opt_count ) : ?>
-										<span>
-											(<?php echo esc_html( $opt_count ); ?>)
+									<span class="tutor-flex tutor-gap-2 tutor-items-center">
+										<span class="tutor-truncate">
+											<?php echo esc_html( $opt_label ); ?>
 										</span>
-									<?php endif; ?>
+										<?php if ( null !== $opt_count ) : ?>
+											<span>
+												(<?php echo esc_html( $opt_count ); ?>)
+											</span>
+										<?php endif; ?>
+									</span>
 								</button>
 							<?php else : ?>
 								<a 
 									href="<?php echo esc_url( $opt_url ); ?>" 
-									class="tutor-popover-menu-item tutor-gap-2 <?php echo $is_active ? 'tutor-active' : ''; ?>"
+									class="tutor-popover-menu-item <?php echo $is_active ? 'tutor-active' : ''; ?>"
 									<?php if ( $this->show_search ) : ?>
 										x-show="search === '' || '<?php echo esc_js( $opt_label ); ?>'.toLowerCase().includes(search.toLowerCase())"
 									<?php endif; ?>
 								>
-									<span class="tutor-truncate">
-										<?php echo esc_html( $opt_label ); ?>
-									</span>
-									<?php if ( null !== $opt_count ) : ?>
-										<span>
-											(<?php echo esc_html( $opt_count ); ?>)
+									<span class="tutor-flex tutor-gap-2 tutor-items-center">
+										<span class="tutor-truncate">
+											<?php echo esc_html( $opt_label ); ?>
 										</span>
-									<?php endif; ?>
+										<?php if ( null !== $opt_count ) : ?>
+											<span>
+												(<?php echo esc_html( $opt_count ); ?>)
+											</span>
+										<?php endif; ?>
+									</span>
 								</a>
 							<?php endif; ?>
 						<?php endforeach; ?>


### PR DESCRIPTION
Group the option label and optional count inside a flex container (tutor-flex tutor-gap-2 tutor-items-center) for both button and link variants to align the label and count horizontally and center them vertically. Also remove the top-level tutor-gap-2 from the anchor so spacing is controlled by the inner container; conditional rendering of the count is preserved.