### PR TITLE
Fix: Skip Next and Continue Lesson button

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -5364,8 +5364,8 @@ class Utils {
 	public function get_random_questions_by_quiz( $quiz_id = 0 ) {
 		global $wpdb;
 
-		$quiz_id         = $this->get_post_id( $quiz_id );
-		$attempt         = $this->is_started_quiz( $quiz_id );
+		$quiz_id = $this->get_post_id( $quiz_id );
+		$attempt = $this->is_started_quiz( $quiz_id );
 		if ( ! $attempt ) {
 			return false;
 		}
@@ -7307,9 +7307,26 @@ class Utils {
 	public function get_course_prev_next_contents_by_id( $content_id = 0 ) {
 
 		$course_id       = $this->get_course_id_by_content( $content_id );
-		$course_contents = $this->get_course_contents_by_id( $course_id );
-		$previous_id     = 0;
-		$next_id         = 0;
+		$course_contents = array();
+		$topics          = $this->get_topics( $course_id, array( 'fields' => 'ids' ) );
+		$topic_ids       = $topics->posts ?? array();
+
+		/*
+		 * Get course content based on topic ordering
+		 * instead of ordering all the content through query.
+		 */
+		if ( $this->count( $topic_ids ) ) {
+			foreach ( $topic_ids as $topic_id ) {
+				$course_content = $this->get_course_contents_by_topic( $topic_id, -1 );
+				if ( ! $this->count( $course_content->posts ) ) {
+					continue;
+				}
+				array_push( $course_contents, ...$course_content->posts );
+			}
+		}
+
+		$previous_id = 0;
+		$next_id     = 0;
 
 		if ( $this->count( $course_contents ) ) {
 			$ids = wp_list_pluck( $course_contents, 'ID' );


### PR DESCRIPTION
The method `$this->get_course_contents_by_id( $course_id );` was getting all the content based on topic id and grouping it based on the menu_order, thus if two topic have menu order 1,2,3,4,5, the order the content were coming in was like 1,1,2,2,3,3,4,4...etc. Therefore when click `Skip Assignment` or `Continue lesson` it was going to the next topic assignment or quiz. To fix this instead of getting all the content and grouping, i had looped over the individual topics course content since it is sorted and added those course content in the sorted order defined in the topic