### PR TITLE
UI styles, DateFilter option, Table & templates fixes

### DIFF
--- a/assets/core/scss/components/_table.scss
+++ b/assets/core/scss/components/_table.scss
@@ -16,10 +16,6 @@
   table {
     min-width: 600px;
     width: 100%;
-    border: none;
-    td, th {
-      border: none;
-    }
   }
 }
 
@@ -28,6 +24,7 @@ table.tutor-table,
   @include tutor-typography('small', 'regular', 'secondary');
   width: 100%;
   margin: 0px;
+  border: none;
   border-collapse: collapse;
   border-spacing: 0;
   background-color: $tutor-surface-l1;
@@ -39,6 +36,8 @@ table.tutor-table,
       @include tutor-typography(tiny, regular, secondary);
       text-align: left;
       padding: $tutor-spacing-5;
+      border: none;
+      white-space: nowrap;
       border-bottom: 1px solid $tutor-border-idle;
     }
   }
@@ -56,7 +55,7 @@ table.tutor-table,
       }
 
       &:nth-child(odd) {
-        >td {
+        > td {
           background-color: transparent;
         }
       }
@@ -66,12 +65,12 @@ table.tutor-table,
       background-color: transparent;
       padding: $tutor-spacing-5;
       vertical-align: middle;
+      border: none;
     }
   }
 }
 
 .tutor-table-column-borders {
-
   th,
   td {
     border-width: 0px 1px 0px 0px;

--- a/assets/core/scss/utilities/_layout.scss
+++ b/assets/core/scss/utilities/_layout.scss
@@ -85,6 +85,9 @@ $grid-split-utils: (
 // Display
 @each $name, $value in $display-utils {
   .tutor-#{$name} {
+    display: $value;
+  }
+  .tutor-force-#{$name} {
     display: $value !important;
   }
 }
@@ -366,6 +369,9 @@ $overflow-types: auto, hidden, visible, scroll;
     // Display utilities
     @each $name, $value in $display-utils {
       .tutor-#{$breakpoint}-#{$name} {
+        display: $value;
+      }
+      .tutor-force-#{$breakpoint}-#{$name} {
         display: $value !important;
       }
     }

--- a/assets/icons/ascending.svg
+++ b/assets/icons/ascending.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.408" d="M6.286 12.786 10 16.5l3.714-3.714m0-5.572L10 3.5 6.286 7.214"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.3" d="m4 11 4 4 4-4m0-6L8 1 4 5"/></svg>

--- a/assets/icons/descending.svg
+++ b/assets/icons/descending.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.408" d="M13.714 16.5 10 12.786 6.286 16.5m0-13L10 7.214 13.714 3.5"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.3" d="M11.2 13.6 8 10.4l-3.2 3.2m0-11.2L8 5.6l3.2-3.2"/></svg>

--- a/assets/src/js/v3/entries/course-builder/components/curriculum/QuestionList.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/curriculum/QuestionList.tsx
@@ -33,7 +33,7 @@ import { useQuizModalContext } from '@CourseBuilderContexts/QuizModalContext';
 import { type QuizForm } from '@CourseBuilderServices/quiz';
 import { tutorConfig } from '@TutorShared/config/config';
 import { Addons, CURRENT_VIEWPORT } from '@TutorShared/config/constants';
-import { borderRadius, Breakpoint, colorTokens, shadow, spacing } from '@TutorShared/config/styles';
+import { borderRadius, Breakpoint, colorTokens, spacing } from '@TutorShared/config/styles';
 import { typography } from '@TutorShared/config/typography';
 import For from '@TutorShared/controls/For';
 import Show from '@TutorShared/controls/Show';
@@ -475,12 +475,14 @@ const QuestionList = ({ isEditing }: { isEditing: boolean }) => {
           <Show when={contentType !== 'tutor_h5p_quiz'}>
             <GenerateQuizWithAi />
           </Show>
-          <button
-            data-cy="add-question"
-            data-add-question-button
-            ref={addButtonRef}
+          <Button
             type="button"
+            size="small"
+            data-cy="add-question"
+            ref={addButtonRef}
             aria-label={__('Add question', 'tutor')}
+            isIconOnly
+            icon={<SVGIcon name="plus" width={20} height={20} />}
             onClick={() => {
               if (contentType === 'tutor_h5p_quiz') {
                 showModal({
@@ -498,9 +500,7 @@ const QuestionList = ({ isEditing }: { isEditing: boolean }) => {
                 setIsOpen(true);
               }
             }}
-          >
-            <SVGIcon name="plusSquareBrand" width={32} height={32} />
-          </button>
+          />
         </div>
       </div>
 
@@ -746,46 +746,8 @@ const styles = {
     align-items: center;
     gap: ${spacing[4]};
 
-    [data-add-question-button],
-    [data-generate-quiz-button] {
-      ${styleUtils.resetButton};
-      width: 32px;
-      height: 32px;
-      border-radius: ${borderRadius[6]};
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-
-      &:focus,
-      &:active,
-      &:hover {
-        background: none;
-      }
-
-      svg {
-        color: ${colorTokens.action.primary.default};
-        width: 100%;
-        height: 100%;
-      }
-
-      &:focus {
-        box-shadow: ${shadow.focus};
-      }
-
-      :focus-visible {
-        box-shadow: none;
-        outline: 2px solid ${colorTokens.stroke.brand};
-        outline-offset: 1px;
-      }
-    }
-
     [data-generate-quiz-button] {
       border: 1px solid ${colorTokens.stroke.divider};
-
-      svg {
-        width: 24px;
-        height: 24px;
-      }
     }
   `,
   questionList: css`

--- a/assets/src/scss/frontend/components/_upcoming-lesson-card.scss
+++ b/assets/src/scss/frontend/components/_upcoming-lesson-card.scss
@@ -5,37 +5,38 @@
 @use '@Core/scss/mixins' as *;
 
 .tutor-upcoming-lesson-card {
+  background-color: $tutor-surface-l1;
   padding: $tutor-spacing-6;
   border: 1px solid $tutor-border-idle;
   border-radius: $tutor-radius-2xl;
 
   &:hover {
     background-color: $tutor-surface-l1-hover;
-		@include tutor-breakpoint-up(sm) {
-			.tutor-upcoming-lesson-card-live-tag-badge {
-				opacity: 0;
-				visibility: hidden;
-			}
-			.tutor-upcoming-lesson-card-action {
-				opacity: 1;
-				visibility: visible;
-				pointer-events: auto;
-			}
-		}
+    @include tutor-breakpoint-up(sm) {
+      .tutor-upcoming-lesson-card-live-tag-badge {
+        opacity: 0;
+        visibility: hidden;
+      }
+      .tutor-upcoming-lesson-card-action {
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+      }
+    }
   }
 
   &:focus-within {
-		@include tutor-breakpoint-up(sm) {
-			.tutor-upcoming-lesson-card-live-tag-badge {
-				opacity: 0;
-				visibility: hidden;
-			}
-			.tutor-upcoming-lesson-card-action {
-				opacity: 1;
-				visibility: visible;
-				pointer-events: auto;
-			}
-		}
+    @include tutor-breakpoint-up(sm) {
+      .tutor-upcoming-lesson-card-live-tag-badge {
+        opacity: 0;
+        visibility: hidden;
+      }
+      .tutor-upcoming-lesson-card-action {
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+      }
+    }
   }
 
   &-header {
@@ -54,42 +55,41 @@
     @include tutor-flex-center;
   }
 
-	&-live-tag {
-		position: relative;
-		
+  &-live-tag {
+    position: relative;
 
-		&-badge {
-			@include tutor-flex(row, center, center);
-			opacity: 1;
-			visibility: visible;
-			z-index: $tutor-z-positive;
-			@include tutor-transition((opacity, visibility));
-		}
-	}
+    &-badge {
+      @include tutor-flex(row, center, center);
+      opacity: 1;
+      visibility: visible;
+      z-index: $tutor-z-positive;
+      @include tutor-transition((opacity, visibility));
+    }
+  }
 
-	&-action {
-		@include tutor-flex(row, center, center);
-		position: absolute;
-		top: 0;
-		right: 0;
-		opacity: 0;
-		visibility: hidden;
-		pointer-events: none;
-		z-index: $tutor-z-dropdown;
-		@include tutor-transition((opacity, visibility));
+  &-action {
+    @include tutor-flex(row, center, center);
+    position: absolute;
+    top: 0;
+    right: 0;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    z-index: $tutor-z-dropdown;
+    @include tutor-transition((opacity, visibility));
 
-		&:hover {
-			color: $tutor-text-primary-inverse;
-		}
-	}
+    &:hover {
+      color: $tutor-text-primary-inverse;
+    }
+  }
 
   &-title {
     @include tutor-typography('small', 'medium', 'primary', 'body');
     margin: 0 0 $tutor-spacing-5 0;
 
     @include tutor-breakpoint-down(sm) {
-			color: $tutor-text-brand;
-		}
+      color: $tutor-text-brand;
+    }
   }
 
   &-course {

--- a/assets/src/scss/frontend/dashboard/_profile.scss
+++ b/assets/src/scss/frontend/dashboard/_profile.scss
@@ -2,29 +2,10 @@
 @use '@Core/scss/tokens' as *;
 
 .tutor-user-profile {
-  .tutor-profile-header {
-    @include tutor-breakpoint-down(sm) {
-      display: none;
-    }
-  }
-
-  .tutor-profile-page-title {
-    @include tutor-typography(h4, semibold, primary, heading);
-
-    @include tutor-breakpoint-up(sm) {
-      display: none;
-    }
-  }
-
   .tutor-profile-card {
     @include tutor-card-base;
     border-radius: $tutor-radius-2xl;
     padding: $tutor-spacing-6;
-    margin-top: $tutor-spacing-9;
-
-    @include tutor-breakpoint-down(sm) {
-      margin-top: $tutor-spacing-6;
-    }
   }
 
   .tutor-profile-card-header {
@@ -73,6 +54,7 @@
 
     .tutor-user-profile-title {
       @include tutor-typography(h3, semibold, primary, heading);
+      margin-top: $tutor-spacing-none;
       margin-bottom: $tutor-spacing-2;
 
       @include tutor-breakpoint-down(sm) {
@@ -160,6 +142,7 @@
 
     .tutor-statistic-title {
       @include tutor-typography(h5, semibold, primary, heading);
+      margin-top: $tutor-spacing-none;
       margin-bottom: $tutor-spacing-4;
     }
 

--- a/assets/src/scss/frontend/dashboard/layout/_header.scss
+++ b/assets/src/scss/frontend/dashboard/layout/_header.scss
@@ -9,7 +9,7 @@
   top: 0;
   height: 80px;
   z-index: $tutor-z-header;
-  background-color: $tutor-surface-sidebar-l1;
+  background-color: $tutor-surface-base;
   border-bottom: 1px solid $tutor-border-idle;
   padding: $tutor-spacing-6 $tutor-spacing-8;
 

--- a/assets/src/scss/frontend/learning-area/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/_quiz.scss
@@ -825,7 +825,7 @@ $tutor-quiz-content-bottom-offset: calc(
             box-shadow: none;
 
             button {
-              display: flex;
+              display: flex !important;
             }
 
             &:hover {

--- a/components/DateFilter.php
+++ b/components/DateFilter.php
@@ -105,6 +105,15 @@ class DateFilter extends BaseComponent {
 	protected $show_label = true;
 
 	/**
+	 * Whether to hide the initial label when no date range is selected.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @var bool
+	 */
+	protected $hide_initial_label = false;
+
+	/**
 	 * Query params to clear when a date filter is applied or cleared (e.g. 'current_page').
 	 *
 	 * @since 4.0.0
@@ -191,6 +200,20 @@ class DateFilter extends BaseComponent {
 	 */
 	public function show_label( bool $show_label ) {
 		$this->show_label = $show_label;
+		return $this;
+	}
+
+	/**
+	 * Hide or show the initial label text before a date range is selected.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param bool $hide_initial_label True to hide the initial label, false to show it.
+	 *
+	 * @return self
+	 */
+	public function hide_initial_label( bool $hide_initial_label = true ): self {
+		$this->hide_initial_label = $hide_initial_label;
 		return $this;
 	}
 
@@ -324,7 +347,7 @@ class DateFilter extends BaseComponent {
 		$end_date   = Input::get( ( 'end_date' ) );
 
 		if ( ! $start_date || ! $end_date ) {
-			return __( 'All Time', 'tutor' );
+			return $this->hide_initial_label ? '' : __( 'All Time', 'tutor' );
 		}
 
 		$presets = array(

--- a/components/DateFilter.php
+++ b/components/DateFilter.php
@@ -208,12 +208,10 @@ class DateFilter extends BaseComponent {
 	 *
 	 * @since 4.0.0
 	 *
-	 * @param bool $hide_initial_label True to hide the initial label, false to show it.
-	 *
 	 * @return self
 	 */
-	public function hide_initial_label( bool $hide_initial_label = true ): self {
-		$this->hide_initial_label = $hide_initial_label;
+	public function hide_initial_label(): self {
+		$this->hide_initial_label = true;
 		return $this;
 	}
 

--- a/components/Table.php
+++ b/components/Table.php
@@ -157,7 +157,7 @@ class Table extends BaseComponent {
 		foreach ( $this->cell_headers as $heading ) {
 			$headings .= sprintf(
 				'<th class="%s">%s</th>',
-				$heading['class'],
+				isset( $heading['class'] ) ? $heading['class'] : '',
 				apply_filters( 'tutor_table_heading', $heading['content'] )
 			);
 		}

--- a/components/Table.php
+++ b/components/Table.php
@@ -157,7 +157,7 @@ class Table extends BaseComponent {
 		foreach ( $this->cell_headers as $heading ) {
 			$headings .= sprintf(
 				'<th class="%s">%s</th>',
-				isset( $heading['class'] ) ? $heading['class'] : '',
+				$heading['class'] ?? '',
 				apply_filters( 'tutor_table_heading', $heading['content'] )
 			);
 		}

--- a/templates/dashboard/account/profile.php
+++ b/templates/dashboard/account/profile.php
@@ -52,8 +52,8 @@ if ( $show_statistics ) {
 
 <div class="tutor-profile-wrapper">
 	<?php require_once tutor_get_template( 'account-header' ); ?>
-	
-	<div class="tutor-user-profile">
+
+	<div class="tutor-user-profile tutor-my-9 tutor-sm-my-6">
 		<div class="tutor-account-container">
 			<?php tutor_load_template( 'user-profile' ); ?>
 

--- a/templates/dashboard/account/settings/security.php
+++ b/templates/dashboard/account/settings/security.php
@@ -48,8 +48,6 @@ $form_id = 'tutor-reset-password-form';
 				->placeholder( __( 'Enter Your Email', 'tutor' ) )
 				->disabled()
 				->attr( 'x-bind', "register('account_email', { required: true })" )
-				// ->attr( 'style', 'padding: 7px 12px;' )
-				->size( Size::SM )
 				->render();
 
 			echo '</div>';

--- a/templates/dashboard/account/settings/withdraw.php
+++ b/templates/dashboard/account/settings/withdraw.php
@@ -57,7 +57,7 @@ if ( empty( $withdrawal_methods ) ) {
 		<h5 class="tutor-h5 tutor-md-hidden tutor-my-none"><?php echo esc_html__( 'Withdraw Method', 'tutor' ); ?></h5>
 		<?php
 			EmptyState::make()
-				->title( "There's no Withdrawal method selected yet! To select a Withdraw method, please contact the Site Admin.", 'tutor' )
+				->title( __( "There's no Withdrawal method selected yet! To select a Withdraw method, please contact the Site Admin.", 'tutor' ) )
 				->render();
 		?>
 	</section>

--- a/templates/dashboard/announcements.php
+++ b/templates/dashboard/announcements.php
@@ -93,6 +93,7 @@ $create_modal_id = 'tutor-announcement-form-modal';
 			->label( __( 'New Announcement', 'tutor' ) )
 			->size( Size::SMALL )
 			->icon( Icon::ADD )
+			->icon_only()
 			->attr( '@click', 'openCreateModal()' )
 			->render();
 		?>
@@ -117,7 +118,7 @@ $create_modal_id = 'tutor-announcement-form-modal';
 					->size( Size::SMALL )
 					->icon( Icon::ADD )
 					->attr( '@click', 'openCreateModal()' )
-					->attr( 'class', 'tutor-sm-hidden' )
+					->attr( 'class', 'tutor-force-sm-hidden' )
 					->render();
 			?>
 		</div>

--- a/templates/dashboard/discussions/comment-card.php
+++ b/templates/dashboard/discussions/comment-card.php
@@ -85,7 +85,7 @@ $single_url = UrlHelper::add_query_params(
 			Button::make()
 				->label( __( 'Reply', 'tutor' ) )
 				->attr( '@click', 'toggleCommentReply(' . (int) $lesson_comment->comment_ID . ')' )
-				->attr( 'class', 'tutor-btn tutor-btn-primary tutor-btn-x-small tutor-sm-hidden' )
+				->attr( 'class', 'tutor-btn tutor-btn-primary tutor-btn-x-small tutor-force-sm-hidden' )
 				->attr( 'type', 'button' )
 				->size( Size::X_SMALL )
 				->render();

--- a/templates/dashboard/discussions/comment-card.php
+++ b/templates/dashboard/discussions/comment-card.php
@@ -83,9 +83,11 @@ $single_url = UrlHelper::add_query_params(
 		<div class="tutor-discussion-card-actions" x-show="replyingCommentId !== <?php echo (int) $lesson_comment->comment_ID; ?>">
 			<?php
 			Button::make()
+				->variant( Variant::PRIMARY )
+				->size( Size::X_SMALL )
 				->label( __( 'Reply', 'tutor' ) )
 				->attr( '@click', 'toggleCommentReply(' . (int) $lesson_comment->comment_ID . ')' )
-				->attr( 'class', 'tutor-btn tutor-btn-primary tutor-btn-x-small tutor-force-sm-hidden' )
+				->attr( 'class', 'tutor-force-sm-hidden' )
 				->attr( 'type', 'button' )
 				->size( Size::X_SMALL )
 				->render();

--- a/templates/dashboard/discussions/qna-card.php
+++ b/templates/dashboard/discussions/qna-card.php
@@ -195,7 +195,7 @@ $single_url = UrlHelper::add_query_params(
 				->label( __( 'Reply', 'tutor' ) )
 				->size( Size::X_SMALL )
 				->attr( '@click', 'toggleReply(' . (int) $question_id . ')' )
-				->attr( 'class', 'tutor-btn tutor-btn-primary tutor-btn-x-small tutor-sm-hidden' )
+				->attr( 'class', 'tutor-btn tutor-btn-primary tutor-btn-x-small tutor-force-sm-hidden' )
 				->attr( 'type', 'button' )
 				->render();
 			?>
@@ -213,7 +213,7 @@ $single_url = UrlHelper::add_query_params(
 					<div class="tutor-popover-menu">
 						<?php if ( User::is_instructor_view() ) : ?>
 						<button 
-							class="tutor-popover-menu-item tutor-gap-5 tutor-hidden tutor-sm-flex"
+							class="tutor-popover-menu-item tutor-gap-5 tutor-force-hidden tutor-force-sm-flex"
 							@click="handleQnASingleAction(<?php echo esc_html( $question_id ); ?>, 'solved')"
 							:disabled="qnaSingleActionMutation?.isPending"
 						>
@@ -234,7 +234,7 @@ $single_url = UrlHelper::add_query_params(
 						</button>
 
 						<button 
-							class="tutor-popover-menu-item tutor-gap-5 tutor-hidden tutor-sm-flex"
+							class="tutor-popover-menu-item tutor-gap-5 tutor-force-hidden tutor-force-sm-flex"
 							@click="handleQnASingleAction(<?php echo esc_html( $question_id ); ?>, 'important')"
 							:disabled="qnaSingleActionMutation?.isPending"
 						>

--- a/templates/dashboard/discussions/qna-card.php
+++ b/templates/dashboard/discussions/qna-card.php
@@ -192,10 +192,12 @@ $single_url = UrlHelper::add_query_params(
 		<div class="tutor-discussion-card-actions" x-show="replyingId !== <?php echo (int) $question_id; ?>" x-cloak>
 			<?php
 			Button::make()
+				->variant( Variant::PRIMARY )
+				->size( Size::X_SMALL )
 				->label( __( 'Reply', 'tutor' ) )
 				->size( Size::X_SMALL )
 				->attr( '@click', 'toggleReply(' . (int) $question_id . ')' )
-				->attr( 'class', 'tutor-btn tutor-btn-primary tutor-btn-x-small tutor-force-sm-hidden' )
+				->attr( 'class', 'tutor-force-sm-hidden' )
 				->attr( 'type', 'button' )
 				->render();
 			?>

--- a/templates/learning-area/quiz/questions/matching.php
+++ b/templates/learning-area/quiz/questions/matching.php
@@ -72,7 +72,7 @@ $register_attr = "register('{$answer_field_name}'{$register_rules})";
 							->icon_only()
 							->attrs(
 								array(
-									'class'          => 'tutor-hidden',
+									'class'          => 'tutor-force-hidden',
 									'@click.prevent' => 'clearDropZone',
 								)
 							)

--- a/templates/learning-area/subpages/qna/card.php
+++ b/templates/learning-area/subpages/qna/card.php
@@ -96,7 +96,7 @@ $single_url = UrlHelper::add_query_params(
 			Button::make()
 				->label( __( 'Reply', 'tutor' ) )
 				->attr( '@click', 'toggleReply(' . (int) $question_id . ')' )
-				->attr( 'class', 'tutor-btn tutor-btn-primary tutor-btn-x-small tutor-sm-hidden' )
+				->attr( 'class', 'tutor-btn tutor-btn-primary tutor-btn-x-small tutor-force-sm-hidden' )
 				->attr( 'type', 'button' )
 				->size( Size::X_SMALL )
 				->render();


### PR DESCRIPTION
Several UI and component fixes:

- SCSS: Cleaned up table and upcoming-lesson-card styles (removed/reset borders, added background colors, fixed nesting/indentation, whitespace, and responsive rules). Adjusted profile card/title/statistic margins and removed some redundant responsive hiding.
- DateFilter: Added $hide_initial_label property and hide_initial_label(bool) setter. When enabled, the default "All Time" label returns an empty string.
- Table: Guard against missing heading class by defaulting to an empty string when rendering <th>.
- Templates: Added spacing utility classes to profile wrapper; removed an unused size/style call in security template input; wrapped Withdraw empty-state title with translation function.

These changes improve visual consistency, responsiveness, and robustness of component rendering.