### PR TITLE
Fix: Login page gets removed if setting updated

### DIFF
--- a/classes/Options_V2.php
+++ b/classes/Options_V2.php
@@ -527,10 +527,20 @@ class Options_V2 {
 
 		! current_user_can( 'manage_options' ) ? wp_send_json_error() : 0;
 
-		$data_before = get_option( 'tutor_option' );
+		$data_before   = get_option( 'tutor_option' );
+		$login_page_id = 0;
+
+		if ( isset( $data_before['tutor_login_page'] ) ) {
+			$login_page_id = $data_before['tutor_login_page'];
+		}
+
 		$option = (array) tutor_utils()->array_get( 'tutor_option', $_POST, array() ); //phpcs:ignore
 
 		do_action( 'tutor_option_save_before', $option );
+
+		if ( ! isset( $option['tutor_login_page'] ) ) {
+			$option['tutor_login_page'] = $login_page_id ?? 0;
+		}
 
 		$option = Input::sanitize_array(
 			$option,


### PR DESCRIPTION
In tutor tools, after regenerating the pages the Tutor Login page is generated and shows id, however after updating any settings value and the tutor login page becomes 0, this is due to the tutor login page not having any input field in settings, when saving the options, the options are obtained from the $_POST superglobal, as tutor login page does not have any field it gets removed and the settings get updated without the tutor login page field, to fix this i have first checked if there is the `tutor_login_page` key from the tutor_options then after obtaining the options from the $_POST field i append the login page id with the same key to the `options` array