### PR TITLE
✨ Hide autofill button in input fields

### DIFF
--- a/assets/core/scss/mixins/_inputs.scss
+++ b/assets/core/scss/mixins/_inputs.scss
@@ -23,7 +23,8 @@
 
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button,
-  &::-webkit-search-cancel-button {
+  &::-webkit-search-cancel-button,
+  &::-webkit-autofill-button {
     -webkit-appearance: none;
     margin: 0;
   }
@@ -83,12 +84,7 @@
   cursor: pointer;
   position: relative;
   flex-shrink: 0;
-  @include tutor-transition((
-    background-color,
-    border-color,
-    box-shadow,
-    color
-  ));
+  @include tutor-transition((background-color, border-color, box-shadow, color));
 
   color: $tutor-icon-idle;
 
@@ -171,11 +167,7 @@
   cursor: pointer;
   position: relative;
   flex-shrink: 0;
-  @include tutor-transition((
-    background-color,
-    border-color,
-    box-shadow
-  ));
+  @include tutor-transition((background-color, border-color, box-shadow));
 
   &:checked {
     background-color: $tutor-surface-brand-primary;

--- a/assets/core/scss/mixins/_inputs.scss
+++ b/assets/core/scss/mixins/_inputs.scss
@@ -34,6 +34,7 @@
     pointer-events: none;
     width: 0;
     height: 0;
+    margin: 0;
   }
 
   &:placeholder-shown:not(:focus):not(:disabled) {

--- a/assets/core/scss/mixins/_inputs.scss
+++ b/assets/core/scss/mixins/_inputs.scss
@@ -24,9 +24,15 @@
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button,
   &::-webkit-search-cancel-button,
-  &::-webkit-autofill-button {
-    -webkit-appearance: none;
-    margin: 0;
+  &::-webkit-autofill-button,
+  &::-webkit-contacts-auto-fill-button,
+  &::-webkit-credentials-auto-fill-button {
+    display: none;
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    width: 0;
+    height: 0;
   }
 
   &:placeholder-shown:not(:focus):not(:disabled) {

--- a/assets/core/scss/mixins/_inputs.scss
+++ b/assets/core/scss/mixins/_inputs.scss
@@ -27,6 +27,7 @@
   &::-webkit-autofill-button,
   &::-webkit-contacts-auto-fill-button,
   &::-webkit-credentials-auto-fill-button {
+    -webkit-appearance: none;
     display: none;
     visibility: hidden;
     opacity: 0;


### PR DESCRIPTION
Update assets/core/scss/mixins/_inputs.scss to include ::-webkit-autofill-button alongside other WebKit pseudo-elements so its appearance is reset. Also collapse multiline tutor-transition argument lists into single-line tuples in two places for consistency and readability.