### PR TITLE
🐛 Align quiz settings and reveal flow

### DIFF
--- a/assets/src/js/frontend/learning-area/quiz/timer.ts
+++ b/assets/src/js/frontend/learning-area/quiz/timer.ts
@@ -8,6 +8,12 @@ const QUIZ_TIMER_CLASSES = {
 
 type QuizExpireAction = 'auto_submit' | 'auto_abandon' | 'autosubmit';
 type TimerState = 'initial' | 'warning' | 'critical';
+type TimerFormat = 'compact' | 'hours' | 'days';
+type TimerDisplayToken = {
+  key: string;
+  type: 'digit' | 'separator' | 'suffix' | 'spacer';
+  value: string;
+};
 
 interface QuizTimerConfig {
   duration: number;
@@ -31,6 +37,7 @@ const quizTimer = (config: QuizTimerConfig) => {
     remaining: total,
     hasLimit,
     expired: false,
+    isReady: false,
     expiresAction,
     formId: config.formId ?? '',
     timer: null as number | null,
@@ -41,6 +48,7 @@ const quizTimer = (config: QuizTimerConfig) => {
 
     init() {
       if (!this.hasLimit) {
+        this.isReady = true;
         return;
       }
 
@@ -54,10 +62,12 @@ const quizTimer = (config: QuizTimerConfig) => {
       }) as EventListener);
 
       if (this.remaining <= 0) {
+        this.isReady = true;
         this.handleExpire();
         return;
       }
 
+      this.isReady = true;
       this.start();
     },
 
@@ -146,11 +156,69 @@ const quizTimer = (config: QuizTimerConfig) => {
     },
 
     get minutes() {
-      return String(Math.floor(this.remaining / 60)).padStart(2, '0');
+      if (this.days > 0 || this.hours > 0) {
+        return Math.floor((this.remaining % 3600) / 60);
+      }
+
+      return Math.floor(this.remaining / 60);
+    },
+
+    get hours() {
+      if (this.days > 0) {
+        return Math.floor((this.remaining % 86400) / 3600);
+      }
+
+      return Math.floor(this.remaining / 3600);
+    },
+
+    get days() {
+      return Math.floor(this.remaining / 86400);
     },
 
     get seconds() {
-      return String(this.remaining % 60).padStart(2, '0');
+      return this.remaining % 60;
+    },
+
+    get timerFormat(): TimerFormat {
+      if (this.days > 0) {
+        return 'days';
+      }
+
+      if (this.hours > 0) {
+        return 'hours';
+      }
+
+      return 'compact';
+    },
+
+    get displayTokens(): TimerDisplayToken[] {
+      const tokens: TimerDisplayToken[] = [];
+      const pushDigits = (prefix: string, value: string) => {
+        value.split('').forEach((char, index) => {
+          tokens.push({
+            key: `${prefix}-${index}`,
+            type: 'digit',
+            value: char,
+          });
+        });
+      };
+
+      if (this.timerFormat === 'days') {
+        pushDigits('days', String(this.days));
+        tokens.push({ key: 'days-suffix', type: 'suffix', value: 'd' });
+        tokens.push({ key: 'days-spacer', type: 'spacer', value: ' ' });
+      }
+
+      if (this.timerFormat === 'days' || this.timerFormat === 'hours') {
+        pushDigits('hours', String(this.hours).padStart(2, '0'));
+        tokens.push({ key: 'hours-separator', type: 'separator', value: ':' });
+      }
+
+      pushDigits('minutes', String(this.minutes).padStart(2, '0'));
+      tokens.push({ key: 'minutes-separator', type: 'separator', value: ':' });
+      pushDigits('seconds', String(this.seconds).padStart(2, '0'));
+
+      return tokens;
     },
 
     get progress() {

--- a/assets/src/js/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
@@ -806,7 +806,7 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
               <div data-subtitle>{__('Passing grade', 'tutor')}</div>
 
               <div data-footer>
-                <SVGIcon name="stopwatch" width={12} height={12} />
+                <SVGIcon name="starLine" width={12} height={12} />
                 {questionsOrder === 'rand'
                   ? '-'
                   : sprintf(

--- a/assets/src/js/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
@@ -588,13 +588,15 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
 
                 <hr />
 
-                <Controller
-                  control={form.control}
-                  name="quiz_option.hide_previous_button"
-                  render={(controllerProps) => (
-                    <FormSwitch {...controllerProps} label={__('Hide previous button from students', 'tutor')} />
-                  )}
-                />
+                <Show when={!form.watch('quiz_option.enable_pagination')}>
+                  <Controller
+                    control={form.control}
+                    name="quiz_option.hide_previous_button"
+                    render={(controllerProps) => (
+                      <FormSwitch {...controllerProps} label={__('Hide previous button from students', 'tutor')} />
+                    )}
+                  />
+                </Show>
 
                 <Controller
                   control={form.control}

--- a/assets/src/js/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/curriculum/QuizSettings.tsx
@@ -227,7 +227,7 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
 
             <hr />
 
-            <div css={styles.inlineForm}>
+            <div css={styles.inlineForm({ minHeight: '32px' })}>
               <Controller
                 name="quiz_option.limit_attempts_allowed"
                 control={form.control}
@@ -270,7 +270,7 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
             </div>
 
             <Show when={contentType !== 'tutor_h5p_quiz'}>
-              <div css={styles.inlineForm}>
+              <div css={styles.inlineForm({ minHeight: '32px' })}>
                 <Controller
                   name="quiz_option.limit_questions_to_answer"
                   control={form.control}
@@ -331,7 +331,7 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
 
           <div css={styles.innerCard}>
             <Show when={contentType !== 'tutor_h5p_quiz'}>
-              <div css={styles.inlineForm}>
+              <div css={styles.inlineForm({ minHeight: '32px' })}>
                 <Controller
                   name="quiz_option.enable_time_limit"
                   control={form.control}
@@ -399,7 +399,7 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
               <hr />
             </Show>
 
-            <div css={styles.inlineForm}>
+            <div css={styles.inlineForm({ minHeight: '34px' })}>
               <Controller
                 name="quiz_option.quiz_auto_start"
                 control={form.control}
@@ -482,7 +482,7 @@ const QuizSettings = ({ contentDripType }: QuizSettingsProps) => {
               <Show when={form.watch('quiz_option.question_layout_view') === 'single_question'}>
                 <hr />
 
-                <div css={styles.inlineForm}>
+                <div css={styles.inlineForm({ minHeight: '34px' })}>
                   <Controller
                     control={form.control}
                     name="quiz_option.enable_pagination"
@@ -990,12 +990,16 @@ const styles = {
     border-radius: ${borderRadius[8]};
     background-color: ${colorTokens.surface.courseBuilder};
   `,
-  inlineForm: ({ withPrefix }: { withPrefix?: boolean } = {}) => css`
+  inlineForm: ({ withPrefix, minHeight }: { withPrefix?: boolean; minHeight?: string } = {}) => css`
     ${styleUtils.display.flex('row')};
     width: 100%;
     align-items: center;
     justify-content: space-between;
     gap: ${spacing[8]};
+    ${minHeight &&
+    css`
+      min-height: ${minHeight};
+    `}
 
     ${withPrefix &&
     css`

--- a/assets/src/js/v3/entries/course-builder/components/modals/QuizModal.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/modals/QuizModal.tsx
@@ -38,13 +38,13 @@ import { styleUtils } from '@TutorShared/utils/style-utils';
 import { useCourseBuilderSlot } from '@CourseBuilderContexts/CourseBuilderSlotContext';
 import { type ContentDripType } from '@CourseBuilderServices/course';
 import { getCourseId } from '@CourseBuilderUtils/utils';
+import { tutorConfig } from '@TutorShared/config/config';
 import { AnimationType } from '@TutorShared/hooks/useAnimation';
 import { useFormWithGlobalError } from '@TutorShared/hooks/useFormWithGlobalError';
 import { POPOVER_PLACEMENTS } from '@TutorShared/hooks/usePortalPopover';
 import { validateQuizQuestion } from '@TutorShared/utils/quiz';
 import { type ID, isDefined, type TopicContentType } from '@TutorShared/utils/types';
 import { findSlotFields } from '@TutorShared/utils/util';
-import { tutorConfig } from '@TutorShared/config/config';
 
 interface QuizModalProps extends ModalProps {
   quizId?: ID;
@@ -97,6 +97,11 @@ const QuizModal = ({
         quiz_auto_start: false,
         question_layout_view: contentType === 'tutor_h5p_quiz' ? 'question_below_each_other' : 'single_question',
         questions_order: 'rand',
+        enable_pagination: false,
+        pagination_type: 'shape',
+        enable_answer_reveal: false,
+        answers_reveal_duration: 5,
+        hide_previous_button: false,
         hide_question_number_overview: false,
         short_answer_characters_limit: 200,
         open_ended_answer_characters_limit: 500,

--- a/assets/src/js/v3/entries/course-builder/services/quiz.ts
+++ b/assets/src/js/v3/entries/course-builder/services/quiz.ts
@@ -137,7 +137,6 @@ export interface QuizForm {
     hide_question_number_overview: boolean;
     short_answer_characters_limit: number;
     open_ended_answer_characters_limit: number;
-    show_pagination: boolean;
     pagination_type: QuizPaginationType;
     content_drip_settings: {
       unlock_date: string;
@@ -203,7 +202,6 @@ export const convertQuizResponseToFormData = (quiz: QuizDetailsResponse, slotFie
       answers_reveal_duration: String(quiz.quiz_option.answers_reveal_duration ?? 5),
       hide_previous_button: quiz.quiz_option.hide_previous_button === '1',
       questions_order: quiz.quiz_option.questions_order ?? 'rand',
-      show_pagination: quiz.quiz_option.question_layout_view === 'question_pagination',
       pagination_type: quiz.quiz_option.pagination_type ?? 'shape',
       hide_question_number_overview: quiz.quiz_option.hide_question_number_overview === '1',
       short_answer_characters_limit: quiz.quiz_option.short_answer_characters_limit ?? 200,

--- a/assets/src/scss/frontend/learning-area/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/_quiz.scss
@@ -160,20 +160,18 @@ $tutor-quiz-content-bottom-offset: calc(
       width: 100%;
     }
 
-    &-animate {
-      svg path:nth-child(2) {
-        @include tutor-spin;
-        transform-origin: center;
-      }
-    }
   }
 
   &-timer-frame {
-    @include tutor-flex(row, center, center);
+    @include tutor-flex(row, center, flex-start);
     position: relative;
-    display: inline-flex;
+    display: inline-grid;
     flex-shrink: 0;
-    @include tutor-transition(color);
+    transition:
+      color 0.2s ease,
+      width 0.25s ease,
+      min-width 0.25s ease;
+    min-height: 33px;
 
     &.is-initial {
       color: $tutor-text-brand;
@@ -191,21 +189,93 @@ $tutor-quiz-content-bottom-offset: calc(
       animation: tutor-quiz-timer-shake 0.5s ease-in-out;
     }
 
-    svg {
-      display: block;
+    &[data-format='compact'] {
+      --tutor-quiz-timer-padding-inline-start: #{$tutor-spacing-4};
+      --tutor-quiz-timer-padding-inline-end: #{$tutor-spacing-4};
     }
+
+    &[data-format='hours'] {
+      --tutor-quiz-timer-padding-inline-start: #{$tutor-spacing-4};
+      --tutor-quiz-timer-padding-inline-end: #{$tutor-spacing-5};
+    }
+
+    &[data-format='days'] {
+      --tutor-quiz-timer-padding-inline-start: #{$tutor-spacing-4};
+      --tutor-quiz-timer-padding-inline-end: #{$tutor-spacing-5};
+    }
+  }
+
+  &-timer-frame-shape {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  &-timer-frame-tabs {
+    position: absolute;
+    top: 0;
+    inset-inline: 0;
+    height: 4px;
+    pointer-events: none;
+  }
+
+  &-timer-frame-tab {
+    position: absolute;
+    top: 0;
+    width: 10px;
+    height: 4px;
+    border-radius: 2px 2px 0 0;
+    background: currentColor;
+    opacity: 0.2;
+  }
+
+  &-timer-frame-tab-start {
+    left: 13px;
+  }
+
+  &-timer-frame-tab-end {
+    right: 13px;
+  }
+
+  &-timer-frame-body {
+    position: absolute;
+    inset-inline: 0;
+    top: 5px;
+    bottom: 0;
+  }
+
+  &-timer-frame-body-fill,
+  &-timer-frame-body-stroke {
+    position: absolute;
+    inset: 0;
+    @include tutor-card-radius(md);
+  }
+
+  &-timer-frame-body-fill {
+    background: currentColor;
+    opacity: 0.06;
+  }
+
+  &-timer-frame-body-stroke {
+    border: 1px solid currentColor;
+    opacity: 0.4;
   }
 
   &-timer-text {
     @include tutor-typography('h5', 'semibold');
     @include tutor-flex-center;
-    position: absolute;
-    inset-inline: 0;
-    bottom: 0;
-    height: 27px;
+    grid-area: 1 / 1;
+    position: relative;
+    min-height: 33px;
+    margin-top: 4px;
+    padding-inline-start: var(--tutor-quiz-timer-padding-inline-start, #{$tutor-spacing-4});
+    padding-inline-end: var(--tutor-quiz-timer-padding-inline-end, #{$tutor-spacing-4});
     line-height: 1;
     font-variant-numeric: tabular-nums;
+    text-box-trim: trim-both;
+    text-box-edge: cap alphabetic;
     @include tutor-transition(color);
+    z-index: $tutor-z-positive;
 
     &.is-initial {
       color: $tutor-text-brand;
@@ -220,9 +290,25 @@ $tutor-quiz-content-bottom-offset: calc(
     }
   }
 
+  &-timer-text-sizer {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
   &-timer-separator {
     line-height: 1;
     margin-bottom: $tutor-spacing-1;
+  }
+
+  &-timer-suffix {
+    line-height: 1;
+    margin-inline-start: 1px;
+    margin-bottom: $tutor-spacing-1;
+  }
+
+  &-timer-spacer {
+    width: $tutor-spacing-2;
+    flex: 0 0 $tutor-spacing-2;
   }
 
   &-timer-digit-wrapper {

--- a/assets/src/scss/frontend/learning-area/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/_quiz.scss
@@ -717,14 +717,15 @@ $tutor-quiz-content-bottom-offset: calc(
     margin-inline-start: auto;
   }
 
-  &-answer-next-btn,
-  &-previous-btn,
-  &-submit-btn {
+  &-answer-next-btn.tutor-btn,
+  &-previous-btn.tutor-btn,
+  &-submit-btn.tutor-btn {
     padding-inline: $tutor-spacing-9;
 
-    &:disabled {
+    &:disabled,
+    &.disabled {
       background-color: $tutor-button-disabled;
-      border-color: $tutor-button-disabled;
+      --tutor-button-border-shadow: #{$tutor-button-outline-border-shadow-disabled};
       color: $tutor-text-subdued;
       opacity: 1;
       cursor: default;

--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -321,6 +321,7 @@ class Quiz {
 
 		if ( 'question_below_each_other' === $question_layout_view ) {
 			$settings['hide_question_number_overview'] = '0';
+			$enable_answer_reveal                      = false;
 		}
 
 		if ( $enable_pagination ) {

--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -319,6 +319,14 @@ class Quiz {
 			$enable_pagination    = true;
 		}
 
+		if ( 'question_below_each_other' === $question_layout_view ) {
+			$settings['hide_question_number_overview'] = '0';
+		}
+
+		if ( $enable_pagination ) {
+			$settings['hide_previous_button'] = '0';
+		}
+
 		$settings['question_layout_view']   = $question_layout_view;
 		$settings['enable_pagination']      = $enable_pagination ? '1' : '0';
 		$settings['pagination_type']        = $pagination_type;

--- a/helpers/TimerHelper.php
+++ b/helpers/TimerHelper.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Tutor LMS Timer Utility
+ *
+ * Clean, reusable countdown formatter using PHP built-in DateTime APIs.
+ *
+ * Features:
+ * - Uses DateInterval / DateTimeImmutable
+ * - Multiple formats
+ * - Token generation
+ * - Render helper
+ * - No mixed business/render logic
+ * - Stable/reusable API
+ *
+ * @package Tutor\Helper
+ * @author Themeum <support@themeum.com>
+ * @link https://themeum.com
+ * @since 4.0.0
+ */
+
+namespace Tutor\Helpers;
+
+defined( 'ABSPATH' ) || exit;
+
+use DateTimeImmutable;
+
+/**
+ * TimerHelper class
+ *
+ * @since 4.0.0
+ */
+final class TimerHelper {
+
+	/**
+	 * Convert seconds into normalized time parts.
+	 *
+	 * @param int $seconds Total seconds.
+	 *
+	 * @return array{
+	 *     days:int,
+	 *     hours:int,
+	 *     minutes:int,
+	 *     seconds:int,
+	 *     total_hours:int
+	 * }
+	 */
+	public static function decompose( int $seconds ): array {
+
+		$seconds = max( 0, $seconds );
+
+		$start = new DateTimeImmutable( '@0' );
+		$end   = new DateTimeImmutable( '@' . $seconds );
+
+		$diff = $start->diff( $end );
+
+		$total_hours = (int) floor( $seconds / HOUR_IN_SECONDS );
+
+		return array(
+			'days'        => (int) $diff->days,
+			'hours'       => (int) $diff->h,
+			'minutes'     => (int) $diff->i,
+			'seconds'     => (int) $diff->s,
+			'total_hours' => $total_hours,
+		);
+	}
+
+	/**
+	 * Format as digital timer.
+	 *
+	 * Examples:
+	 * - 05:12
+	 * - 01:05:12
+	 * - 2d 01:05:12
+	 *
+	 * @param int  $seconds Total seconds.
+	 * @param bool $show_days Whether to show day segment.
+	 *
+	 * @return string
+	 */
+	public static function format_digital(
+		int $seconds,
+		bool $show_days = true
+	): string {
+
+		$time = self::decompose( $seconds );
+
+		$days    = $time['days'];
+		$hours   = $time['hours'];
+		$minutes = $time['minutes'];
+		$secs    = $time['seconds'];
+
+		// Show days.
+		if ( $show_days && $days > 0 ) {
+			return sprintf(
+				'%dd %02d:%02d:%02d',
+				$days,
+				$hours,
+				$minutes,
+				$secs
+			);
+		}
+
+		// Show hours.
+		if ( $time['total_hours'] > 0 ) {
+			return sprintf(
+				'%02d:%02d:%02d',
+				$time['total_hours'],
+				$minutes,
+				$secs
+			);
+		}
+
+		// Minutes only.
+		return sprintf(
+			'%02d:%02d',
+			$minutes,
+			$secs
+		);
+	}
+
+	/**
+	 * Format as verbose human readable string.
+	 *
+	 * Examples:
+	 * - 2 days 3 hours 5 minutes
+	 * - 12 minutes 10 seconds
+	 *
+	 * @param int $seconds Total seconds.
+	 *
+	 * @return string
+	 */
+	public static function format_human( int $seconds ): string {
+
+		$time = self::decompose( $seconds );
+
+		$parts = array();
+
+		if ( $time['days'] > 0 ) {
+			$parts[] = sprintf(
+				/* translators: %d: number of days */
+				_n( '%d day', '%d days', $time['days'], 'tutor' ),
+				$time['days']
+			);
+		}
+
+		if ( $time['hours'] > 0 ) {
+			$parts[] = sprintf(
+				/* translators: %d: number of hours */
+				_n( '%d hour', '%d hours', $time['hours'], 'tutor' ),
+				$time['hours']
+			);
+		}
+
+		if ( $time['minutes'] > 0 ) {
+			$parts[] = sprintf(
+				/* translators: %d: number of minutes */
+				_n( '%d minute', '%d minutes', $time['minutes'], 'tutor' ),
+				$time['minutes']
+			);
+		}
+
+		if ( $time['seconds'] > 0 || empty( $parts ) ) {
+			$parts[] = sprintf(
+				/* translators: %d: number of seconds */
+				_n( '%d second', '%d seconds', $time['seconds'], 'tutor' ),
+				$time['seconds']
+			);
+		}
+
+		return implode( ' ', $parts );
+	}
+
+	/**
+	 * Build render able timer tokens.
+	 *
+	 * Example output:
+	 * [
+	 *   ['type' => 'digit', 'value' => '0'],
+	 *   ['type' => 'digit', 'value' => '2'],
+	 *   ['type' => 'separator', 'value' => ':'],
+	 * ]
+	 *
+	 * @param int $seconds Total seconds.
+	 *
+	 * @return array
+	 */
+	public static function build_tokens( int $seconds ): array {
+
+		$formatted = self::format_digital( $seconds );
+
+		$tokens = array();
+
+		$chars = preg_split( '//u', $formatted, -1, PREG_SPLIT_NO_EMPTY );
+
+		foreach ( $chars as $char ) {
+
+			if ( ':' === $char ) {
+
+				$tokens[] = array(
+					'type'  => 'separator',
+					'value' => $char,
+				);
+
+			} elseif ( ctype_digit( $char ) ) {
+
+				$tokens[] = array(
+					'type'  => 'digit',
+					'value' => $char,
+				);
+
+			} elseif ( 'd' === $char ) {
+
+				$tokens[] = array(
+					'type'  => 'suffix',
+					'value' => $char,
+				);
+
+			} elseif ( ' ' === $char ) {
+
+				$tokens[] = array(
+					'type'  => 'spacer',
+					'value' => $char,
+				);
+			}
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Render timer HTML.
+	 *
+	 * @param int $seconds Total seconds.
+	 *
+	 * @return void
+	 */
+	public static function render( int $seconds ): void {
+
+		$tokens = self::build_tokens( $seconds );
+
+		echo '<div class="tutor-timer">';
+
+		foreach ( $tokens as $token ) {
+
+			$type  = $token['type'];
+			$value = $token['value'];
+
+			$class = 'tutor-timer-' . sanitize_html_class( $type );
+
+			printf(
+				'<span class="%1$s">%2$s</span>',
+				esc_attr( $class ),
+				esc_html( $value )
+			);
+		}
+
+		echo '</div>';
+	}
+
+	/**
+	 * Get remaining seconds between two timestamps.
+	 *
+	 * @param int $future_timestamp Future UNIX timestamp.
+	 *
+	 * @return int
+	 */
+	public static function remaining_seconds( int $future_timestamp ): int {
+
+		return max(
+			0,
+			$future_timestamp - time()
+		);
+	}
+}

--- a/models/QuizModel.php
+++ b/models/QuizModel.php
@@ -887,6 +887,43 @@ class QuizModel {
 	}
 
 	/**
+	 * Filter attempt answers for attempt-details views.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param array $attempt_answers Attempt answer rows.
+	 * @param bool  $is_instructor_review Whether the current view is instructor review.
+	 *
+	 * @return array
+	 */
+	public static function filter_attempt_answers_for_details( $attempt_answers, bool $is_instructor_review = false ): array {
+		if ( ! is_array( $attempt_answers ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				$attempt_answers,
+				static function ( $attempt_answer ) use ( $is_instructor_review ) {
+					if ( ! is_object( $attempt_answer ) ) {
+						return false;
+					}
+
+					if ( $is_instructor_review ) {
+						return true;
+					}
+
+					if ( ! self::is_attempt_answer_skipped( $attempt_answer ) ) {
+						return true;
+					}
+
+					return null !== ( $attempt_answer->is_correct ?? null );
+				}
+			)
+		);
+	}
+
+	/**
 	 * Get normalized attempt-answer status.
 	 *
 	 * Status rules follow legacy attempt-details logic:

--- a/models/QuizModel.php
+++ b/models/QuizModel.php
@@ -913,11 +913,7 @@ class QuizModel {
 						return true;
 					}
 
-					if ( ! self::is_attempt_answer_skipped( $attempt_answer ) ) {
-						return true;
-					}
-
-					return null !== ( $attempt_answer->is_correct ?? null );
+					return ! self::is_attempt_answer_skipped( $attempt_answer );
 				}
 			)
 		);

--- a/templates/learning-area/quiz/attempt.php
+++ b/templates/learning-area/quiz/attempt.php
@@ -332,7 +332,7 @@ $default_values = array(
 						->size( Size::LARGE )
 						->attr( 'type', 'submit' )
 						->attr( 'x-show', 'currentIndex === totalQuestions' )
-						->attr( ':disabled', 'isRevealSubmitting || isRevealing' )
+						->attr( ':disabled', 'isRevealSubmitting' )
 						->attr( ':class', '{ \'tutor-btn-loading\': submitQuizMutation?.isPending }' )
 						->attr( 'class', 'tutor-quiz-submit-btn' )
 						->render();
@@ -348,7 +348,7 @@ $default_values = array(
 					->size( Size::LARGE )
 					->attr( 'form', $form_id )
 					->attr( 'type', 'submit' )
-					->attr( ':disabled', 'isRevealSubmitting || isRevealing' )
+					->attr( ':disabled', 'isRevealSubmitting' )
 					->attr( ':class', '{ \'tutor-btn-loading\': submitQuizMutation?.isPending }' )
 					->attr( 'style', 'display: block; margin: 0 auto; min-width: 290px;' )
 					->render();

--- a/templates/learning-area/quiz/attempt.php
+++ b/templates/learning-area/quiz/attempt.php
@@ -41,6 +41,10 @@ $remaining_time_context = tutor_utils()->seconds_to_time_context( $remaining_tim
 // Quiz settings.
 $quiz_when_time_expires = tutor_utils()->get_option( 'quiz_when_time_expires', 'auto_abandon' );
 $quiz_settings          = tutor_utils()->get_quiz_option( (int) $tutor_is_started_quiz->quiz_id );
+$show_timeout_attempts  = 'auto_abandon' !== $quiz_when_time_expires;
+$timeout_modal_message  = 'auto_abandon' === $quiz_when_time_expires
+	? __( 'Your quiz was abandoned automatically because time expired before you submitted it.', 'tutor' )
+	: __( 'Your quiz has been submitted automatically.', 'tutor' );
 $reveal_wait_ms         = 1000 * $quiz_settings['answers_reveal_duration'];
 $show_previous_button   = (bool) tutor_utils()->get_option( 'quiz_previous_button_enabled', true );
 $hide_previous_button   = '1' === (string) ( $quiz_settings['hide_previous_button'] ?? '0' );
@@ -390,9 +394,9 @@ $default_values = array(
 				array(
 					'modal_id'      => $timeout_modal_id,
 					'title'         => __( 'Times up!', 'tutor' ),
-					'message'       => __( 'Your quiz has been submitted automatically.', 'tutor' ),
+					'message'       => $timeout_modal_message,
 					'icon_html'     => tutor_utils()->get_themed_svg( 'images/illustrations/quiz-timeout.svg' ),
-					'show_attempts' => true,
+					'show_attempts' => $show_timeout_attempts,
 					'action_url'    => $attempt_details_url,
 					'action_label'  => __( 'View Results', 'tutor' ),
 				)

--- a/templates/learning-area/quiz/progress-bar.php
+++ b/templates/learning-area/quiz/progress-bar.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Tutor\Components\Button;
 use Tutor\Components\Constants\Variant;
+use Tutor\Helpers\TimerHelper;
 
 global $tutor_is_started_quiz;
 
@@ -24,58 +25,8 @@ $hide_quiz_time_display = isset( $hide_quiz_time_display ) ? (bool) $hide_quiz_t
 $total_questions        = isset( $total_questions ) ? (int) $total_questions : 0;
 $quiz_title             = get_the_title( $tutor_is_started_quiz->quiz_id );
 
-$build_timer_tokens = static function ( int $seconds, int $reserved_day_digits = 0 ): array {
-	$seconds = max( 0, $seconds );
-	$days    = (int) floor( $seconds / DAY_IN_SECONDS );
-	$hours   = $days > 0 ? (int) floor( ( $seconds % DAY_IN_SECONDS ) / HOUR_IN_SECONDS ) : (int) floor( $seconds / HOUR_IN_SECONDS );
-	$minutes = ( $days > 0 || $hours > 0 ) ? (int) floor( ( $seconds % HOUR_IN_SECONDS ) / MINUTE_IN_SECONDS ) : (int) floor( $seconds / MINUTE_IN_SECONDS );
-	$secs    = (int) ( $seconds % MINUTE_IN_SECONDS );
-	$tokens  = array();
-
-	$push_digits = static function ( array &$token_list, string $value ) {
-		foreach ( str_split( $value ) as $char ) {
-			$token_list[] = array(
-				'type'  => 'digit',
-				'value' => $char,
-			);
-		}
-	};
-
-	if ( $days > 0 || $reserved_day_digits > 0 ) {
-		$day_value = $days > 0 ? str_pad( (string) $days, $reserved_day_digits, '0', STR_PAD_LEFT ) : str_repeat( '0', max( 1, $reserved_day_digits ) );
-		$push_digits( $tokens, $day_value );
-		$tokens[] = array(
-			'type'  => 'suffix',
-			'value' => 'd',
-		);
-		$tokens[] = array(
-			'type'  => 'spacer',
-			'value' => ' ',
-		);
-	}
-
-	if ( $days > 0 || $hours > 0 || $reserved_day_digits > 0 || $seconds >= HOUR_IN_SECONDS ) {
-		$push_digits( $tokens, str_pad( (string) $hours, 2, '0', STR_PAD_LEFT ) );
-		$tokens[] = array(
-			'type'  => 'separator',
-			'value' => ':',
-		);
-	}
-
-	$push_digits( $tokens, str_pad( (string) $minutes, 2, '0', STR_PAD_LEFT ) );
-	$tokens[] = array(
-		'type'  => 'separator',
-		'value' => ':',
-	);
-	$push_digits( $tokens, str_pad( (string) $secs, 2, '0', STR_PAD_LEFT ) );
-
-	return $tokens;
-};
-
-$reserved_day_digits = max( 0, strlen( (string) floor( max( 0, $remaining_time_secs ) / DAY_IN_SECONDS ) ) );
-$reserved_day_digits = $remaining_time_secs >= DAY_IN_SECONDS ? $reserved_day_digits : 0;
-$initial_tokens      = $build_timer_tokens( $remaining_time_secs, 0 );
-$sizer_tokens        = $build_timer_tokens( $remaining_time_secs, $reserved_day_digits );
+$initial_tokens = TimerHelper::build_tokens( $remaining_time_secs );
+$sizer_tokens   = TimerHelper::build_tokens( $remaining_time_secs );
 
 $render_timer_tokens = static function ( array $tokens ) {
 	foreach ( $tokens as $token ) {

--- a/templates/learning-area/quiz/progress-bar.php
+++ b/templates/learning-area/quiz/progress-bar.php
@@ -10,8 +10,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use TUTOR\Icon;
-use Tutor\Components\SvgIcon;
 use Tutor\Components\Button;
 use Tutor\Components\Constants\Variant;
 
@@ -25,6 +23,90 @@ $has_time_limit         = isset( $has_time_limit ) ? (bool) $has_time_limit : $r
 $hide_quiz_time_display = isset( $hide_quiz_time_display ) ? (bool) $hide_quiz_time_display : false;
 $total_questions        = isset( $total_questions ) ? (int) $total_questions : 0;
 $quiz_title             = get_the_title( $tutor_is_started_quiz->quiz_id );
+
+$build_timer_tokens = static function ( int $seconds, int $reserved_day_digits = 0 ): array {
+	$seconds = max( 0, $seconds );
+	$days    = (int) floor( $seconds / DAY_IN_SECONDS );
+	$hours   = $days > 0 ? (int) floor( ( $seconds % DAY_IN_SECONDS ) / HOUR_IN_SECONDS ) : (int) floor( $seconds / HOUR_IN_SECONDS );
+	$minutes = ( $days > 0 || $hours > 0 ) ? (int) floor( ( $seconds % HOUR_IN_SECONDS ) / MINUTE_IN_SECONDS ) : (int) floor( $seconds / MINUTE_IN_SECONDS );
+	$secs    = (int) ( $seconds % MINUTE_IN_SECONDS );
+	$tokens  = array();
+
+	$push_digits = static function ( array &$token_list, string $value ) {
+		foreach ( str_split( $value ) as $char ) {
+			$token_list[] = array(
+				'type'  => 'digit',
+				'value' => $char,
+			);
+		}
+	};
+
+	if ( $days > 0 || $reserved_day_digits > 0 ) {
+		$day_value = $days > 0 ? str_pad( (string) $days, $reserved_day_digits, '0', STR_PAD_LEFT ) : str_repeat( '0', max( 1, $reserved_day_digits ) );
+		$push_digits( $tokens, $day_value );
+		$tokens[] = array(
+			'type'  => 'suffix',
+			'value' => 'd',
+		);
+		$tokens[] = array(
+			'type'  => 'spacer',
+			'value' => ' ',
+		);
+	}
+
+	if ( $days > 0 || $hours > 0 || $reserved_day_digits > 0 || $seconds >= HOUR_IN_SECONDS ) {
+		$push_digits( $tokens, str_pad( (string) $hours, 2, '0', STR_PAD_LEFT ) );
+		$tokens[] = array(
+			'type'  => 'separator',
+			'value' => ':',
+		);
+	}
+
+	$push_digits( $tokens, str_pad( (string) $minutes, 2, '0', STR_PAD_LEFT ) );
+	$tokens[] = array(
+		'type'  => 'separator',
+		'value' => ':',
+	);
+	$push_digits( $tokens, str_pad( (string) $secs, 2, '0', STR_PAD_LEFT ) );
+
+	return $tokens;
+};
+
+$reserved_day_digits = max( 0, strlen( (string) floor( max( 0, $remaining_time_secs ) / DAY_IN_SECONDS ) ) );
+$reserved_day_digits = $remaining_time_secs >= DAY_IN_SECONDS ? $reserved_day_digits : 0;
+$initial_tokens      = $build_timer_tokens( $remaining_time_secs, 0 );
+$sizer_tokens        = $build_timer_tokens( $remaining_time_secs, $reserved_day_digits );
+
+$render_timer_tokens = static function ( array $tokens ) {
+	foreach ( $tokens as $token ) {
+		$type  = (string) ( $token['type'] ?? '' );
+		$value = (string) ( $token['value'] ?? '' );
+		$cls   = '';
+
+		if ( 'digit' === $type ) {
+			$cls = 'tutor-quiz-timer-digit-wrapper';
+		} elseif ( 'separator' === $type ) {
+			$cls = 'tutor-quiz-timer-separator';
+		} elseif ( 'suffix' === $type ) {
+			$cls = 'tutor-quiz-timer-suffix';
+		} elseif ( 'spacer' === $type ) {
+			$cls = 'tutor-quiz-timer-spacer';
+		}
+
+		if ( ! $cls ) {
+			continue;
+		}
+		?>
+		<span class="<?php echo esc_attr( $cls ); ?>">
+			<?php if ( 'digit' === $type ) : ?>
+				<?php echo esc_html( $value ); ?>
+			<?php elseif ( 'spacer' !== $type ) : ?>
+				<?php echo esc_html( $value ); ?>
+			<?php endif; ?>
+		</span>
+		<?php
+	}
+};
 
 ?>
 
@@ -43,58 +125,57 @@ $quiz_title             = get_the_title( $tutor_is_started_quiz->quiz_id );
 		<div class="tutor-quiz-progress-header">
 			<div class="tutor-quiz-progress-meta">
 				<?php if ( $has_time_limit && ! $hide_quiz_time_display ) : ?>
-					<div class="tutor-quiz-timer-frame" :class="'is-' + timerState" :data-shaking="shaking ? '1' : '0'">
-						<?php
-							SvgIcon::make()
-								->name( Icon::CLOCK_FRAME )
-								->width( 66 )
-								->height( 33 )
-								->render();
-						?>
+					<div
+						class="tutor-quiz-timer-frame"
+						:class="['is-' + timerState, 'is-' + timerFormat]"
+						:data-shaking="shaking ? '1' : '0'"
+						:data-format="timerFormat"
+					>
+						<div class="tutor-quiz-timer-frame-shape" aria-hidden="true">
+							<div class="tutor-quiz-timer-frame-tabs">
+								<span class="tutor-quiz-timer-frame-tab tutor-quiz-timer-frame-tab-start"></span>
+								<span class="tutor-quiz-timer-frame-tab tutor-quiz-timer-frame-tab-end"></span>
+							</div>
+							<div class="tutor-quiz-timer-frame-body">
+								<div class="tutor-quiz-timer-frame-body-fill"></div>
+								<div class="tutor-quiz-timer-frame-body-stroke"></div>
+							</div>
+						</div>
 
-						<div class="tutor-quiz-timer-text" :class="'is-' + timerState">
-							<?php
-							$digit_positions = array(
-								array(
-									'field' => 'minutes',
-									'index' => 0,
-								),
-								array(
-									'field' => 'minutes',
-									'index' => 1,
-								),
-								'separator',
-								array(
-									'field' => 'seconds',
-									'index' => 0,
-								),
-								array(
-									'field' => 'seconds',
-									'index' => 1,
-								),
-							);
+						<div class="tutor-quiz-timer-text tutor-quiz-timer-text-sizer" aria-hidden="true">
+							<?php $render_timer_tokens( $sizer_tokens ); ?>
+						</div>
 
-							foreach ( $digit_positions as $pos ) :
-								if ( 'separator' === $pos ) :
-									?>
-									<span class="tutor-quiz-timer-separator">:</span>
-									<?php
-								else :
-									?>
-									<span class="tutor-quiz-timer-digit-wrapper">
+						<div class="tutor-quiz-timer-text tutor-quiz-timer-text-fallback" :class="'is-' + timerState" x-show="!isReady">
+							<?php $render_timer_tokens( $initial_tokens ); ?>
+						</div>
+
+						<div class="tutor-quiz-timer-text tutor-quiz-timer-text-live" :class="'is-' + timerState" x-show="isReady">
+							<template x-for="token in displayTokens" :key="token.key">
+								<span
+									:class="{
+										'tutor-quiz-timer-digit-wrapper': token.type === 'digit',
+										'tutor-quiz-timer-separator': token.type === 'separator',
+										'tutor-quiz-timer-suffix': token.type === 'suffix',
+										'tutor-quiz-timer-spacer': token.type === 'spacer'
+									}"
+								>
+									<template x-if="token.type === 'digit'">
 										<span
 											class="tutor-quiz-timer-reel"
-											:style="'transform: translateY(-' + (<?php echo esc_attr( $pos['field'] ); ?>.charAt(<?php echo esc_attr( $pos['index'] ); ?>) * 1.25) + 'em)'"
+											:style="'transform: translateY(-' + (Number(token.value) * 1.25) + 'em)'"
 										>
 											<?php for ( $i = 0; $i < 10; $i++ ) : ?>
 												<span><?php echo esc_html( $i ); ?></span>
 											<?php endfor; ?>
 										</span>
-									</span>
-									<?php
-								endif;
-							endforeach;
-							?>
+									</template>
+
+									<template x-if="token.type !== 'digit'">
+										<span x-text="token.type === 'spacer' ? '' : token.value"></span>
+									</template>
+								</span>
+							</template>
 						</div>
 					</div>
 				<?php endif; ?>

--- a/templates/shared/components/quiz/attempt-details.php
+++ b/templates/shared/components/quiz/attempt-details.php
@@ -112,6 +112,7 @@ $course_contents = tutor_utils()->get_course_prev_next_contents_by_id( $quiz_id 
 			'shared.components.quiz.attempt-details.summary',
 			array(
 				'attempt_data'         => $attempt_data,
+				'answers'              => $questions, // $questions holds quiz answers data, mapped to 'answers' key for summary template
 				'is_instructor_review' => $is_instructor_review,
 			)
 		);

--- a/templates/shared/components/quiz/attempt-details.php
+++ b/templates/shared/components/quiz/attempt-details.php
@@ -70,7 +70,9 @@ if ( ! $quiz_id ) {
 	$quiz_id = (int) ( $attempt_data->quiz_id ?? 0 );
 }
 
-$questions       = QuizModel::get_quiz_answers_by_attempt_id( (int) $attempt_data->attempt_id );
+$questions = QuizModel::get_quiz_answers_by_attempt_id( (int) $attempt_data->attempt_id );
+$questions = QuizModel::filter_attempt_answers_for_details( $questions, $is_instructor_review );
+
 $course_contents = tutor_utils()->get_course_prev_next_contents_by_id( $quiz_id );
 ?>
 <div class="tutor-quiz-summary-page">
@@ -121,8 +123,10 @@ $course_contents = tutor_utils()->get_course_prev_next_contents_by_id( $quiz_id 
 		tutor_load_template(
 			'shared.components.quiz.attempt-details.questions-sidebar',
 			array(
-				'quiz_id'      => $quiz_id,
-				'attempt_data' => $attempt_data,
+				'quiz_id'              => $quiz_id,
+				'attempt_data'         => $attempt_data,
+				'questions'            => $questions,
+				'is_instructor_review' => $is_instructor_review,
 			)
 		);
 		?>

--- a/templates/shared/components/quiz/attempt-details/questions-sidebar.php
+++ b/templates/shared/components/quiz/attempt-details/questions-sidebar.php
@@ -31,8 +31,8 @@ $status_priority     = array(
 );
 
 if ( isset( $attempt_data ) && is_object( $attempt_data ) && ! empty( $attempt_data->attempt_id ) ) {
-	$questions = QuizModel::get_quiz_answers_by_attempt_id( (int) $attempt_data->attempt_id );
-	$questions = is_array( $questions ) ? $questions : array();
+	$questions = isset( $questions ) ? $questions : QuizModel::get_quiz_answers_by_attempt_id( (int) $attempt_data->attempt_id );
+	$questions = QuizModel::filter_attempt_answers_for_details( $questions, ! empty( $is_instructor_review ) );
 
 	foreach ( $questions as $answer_row ) {
 		$question_id = (int) ( $answer_row->question_id ?? 0 );

--- a/templates/shared/components/quiz/attempt-details/summary.php
+++ b/templates/shared/components/quiz/attempt-details/summary.php
@@ -52,7 +52,7 @@ $timing                 = QuizModel::get_quiz_attempt_timing( $attempt_data );
 $attempt_duration       = $timing['attempt_duration'] ?? '';
 $attempt_duration_taken = $timing['attempt_duration_taken'] ?? '';
 
-$answers   = QuizModel::get_quiz_answers_by_attempt_id( $attempt_id );
+$answers   = isset( $answers ) ? $answers : QuizModel::get_quiz_answers_by_attempt_id( $attempt_id );
 $correct   = 0;
 $incorrect = 0;
 


### PR DESCRIPTION
- Normalizes quiz settings so full-page and paginated layouts force incompatible options off.
- Hides the previous-button control in the course builder when pagination is enabled.
- Updates timeout modal messaging so auto-abandon does not report unsaved attempted counts.
- Allows learners to submit immediately after answer reveal instead of waiting for the reveal timeout.
