### PR TITLE
Fixing WordPress Multisite Compatibility Issues in Tutor LMS

### DIFF
--- a/classes/Tutor.php
+++ b/classes/Tutor.php
@@ -936,7 +936,7 @@ final class Tutor extends Singleton {
 			PRIMARY KEY (id),
 			KEY order_id (order_id),
 			KEY meta_key (meta_key),
-			CONSTRAINT fk_tutor_ordermeta_order_id FOREIGN KEY (order_id) REFERENCES {$wpdb->prefix}tutor_orders(id) ON DELETE CASCADE
+			CONSTRAINT fk_{$wpdb->prefix}tutor_ordermeta_order_id FOREIGN KEY (order_id) REFERENCES {$wpdb->prefix}tutor_orders(id) ON DELETE CASCADE
 		) $charset_collate;";
 
 		$order_items_table = "CREATE TABLE {$wpdb->prefix}tutor_order_items (
@@ -950,7 +950,7 @@ final class Tutor extends Singleton {
 			PRIMARY KEY (id),
 			KEY order_id (order_id),
 			KEY item_id (item_id),
-			CONSTRAINT fk_tutor_order_item_order_id FOREIGN KEY (order_id) REFERENCES {$wpdb->prefix}tutor_orders(id) ON DELETE CASCADE
+			CONSTRAINT fk_{$wpdb->prefix}tutor_order_item_order_id FOREIGN KEY (order_id) REFERENCES {$wpdb->prefix}tutor_orders(id) ON DELETE CASCADE
 		) $charset_collate;";
 
 		$coupons_table = "CREATE TABLE {$wpdb->prefix}tutor_coupons (
@@ -984,7 +984,7 @@ final class Tutor extends Singleton {
 			reference_id BIGINT(20) UNSIGNED NOT NULL,
 			KEY coupon_code (coupon_code),
 			KEY reference_id (reference_id),
-			CONSTRAINT fk_tutor_coupon_application_coupon_code FOREIGN KEY (coupon_code) REFERENCES {$wpdb->prefix}tutor_coupons(coupon_code) ON DELETE CASCADE
+			CONSTRAINT fk_{$wpdb->prefix}tutor_coupon_application_coupon_code FOREIGN KEY (coupon_code) REFERENCES {$wpdb->prefix}tutor_coupons(coupon_code) ON DELETE CASCADE
 		) $charset_collate;";
 
 		$coupon_usage_table = "CREATE TABLE {$wpdb->prefix}tutor_coupon_usages (
@@ -994,8 +994,8 @@ final class Tutor extends Singleton {
 			PRIMARY KEY (id),
 			KEY coupon_code (coupon_code),
 			KEY user_id (user_id),
-			CONSTRAINT fk_tutor_coupon_usage_coupon_code FOREIGN KEY (coupon_code) REFERENCES {$wpdb->prefix}tutor_coupons(coupon_code) ON DELETE CASCADE,
-			CONSTRAINT fk_tutor_coupon_usage_user_id FOREIGN KEY (user_id) REFERENCES {$wpdb->prefix}users(ID) ON DELETE CASCADE
+			CONSTRAINT fk_{$wpdb->prefix}tutor_coupon_usage_coupon_code FOREIGN KEY (coupon_code) REFERENCES {$wpdb->prefix}tutor_coupons(coupon_code) ON DELETE CASCADE,
+			CONSTRAINT fk_{$wpdb->prefix}tutor_coupon_usage_user_id FOREIGN KEY (user_id) REFERENCES {$wpdb->users}(ID) ON DELETE CASCADE
 		) $charset_collate;";
 
 		$cart_table = "CREATE TABLE {$wpdb->prefix}tutor_carts (
@@ -1007,7 +1007,7 @@ final class Tutor extends Singleton {
 			PRIMARY KEY (id),
 			KEY user_id (user_id),
 			KEY coupon_code (coupon_code),
-			CONSTRAINT fk_tutor_cart_user_id FOREIGN KEY (user_id) REFERENCES {$wpdb->prefix}users(ID) ON DELETE CASCADE
+			CONSTRAINT fk_{$wpdb->prefix}tutor_cart_user_id FOREIGN KEY (user_id) REFERENCES {$wpdb->users}(ID) ON DELETE CASCADE
 		) $charset_collate;";
 
 		$cart_items_table = "CREATE TABLE {$wpdb->prefix}tutor_cart_items (
@@ -1017,8 +1017,8 @@ final class Tutor extends Singleton {
 			PRIMARY KEY (id),
 			KEY cart_id (cart_id),
 			KEY course_id (course_id),
-			CONSTRAINT fk_tutor_cart_item_cart_id FOREIGN KEY (cart_id) REFERENCES {$wpdb->prefix}tutor_carts(id) ON DELETE CASCADE,
-			CONSTRAINT fk_tutor_cart_item_course_id FOREIGN KEY (course_id) REFERENCES {$wpdb->prefix}posts(ID) ON DELETE CASCADE
+			CONSTRAINT fk_{$wpdb->prefix}tutor_cart_item_cart_id FOREIGN KEY (cart_id) REFERENCES {$wpdb->prefix}tutor_carts(id) ON DELETE CASCADE,
+			CONSTRAINT fk_{$wpdb->prefix}tutor_cart_item_course_id FOREIGN KEY (course_id) REFERENCES {$wpdb->prefix}posts(ID) ON DELETE CASCADE
 		) $charset_collate;";
 
 		$customer_table = "CREATE TABLE {$wpdb->prefix}tutor_customers (

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -272,7 +272,7 @@ class Upgrader {
 				PRIMARY KEY (id),
 				KEY item_id (item_id),
 				KEY meta_key (meta_key),
-				CONSTRAINT fk_tutor_itemmeta FOREIGN KEY (item_id) REFERENCES {$wpdb->prefix}tutor_order_items(id) ON DELETE CASCADE
+				CONSTRAINT fk_{$wpdb->prefix}tutor_itemmeta FOREIGN KEY (item_id) REFERENCES {$wpdb->prefix}tutor_order_items(id) ON DELETE CASCADE
 			) $charset_collate;";
 				dbDelta( $item_meta_table );
 			}

--- a/helpers/QueryHelper.php
+++ b/helpers/QueryHelper.php
@@ -707,10 +707,10 @@ class QueryHelper {
 		// Count only.
 		if ( $count ) {
 			$sql_query = "SELECT COUNT(*)
-						FROM {$table_with_alias} 
-						{$join_clause} 
-						{$where_clause} 
-						{$groupby_clause} 
+						FROM {$table_with_alias}
+						{$join_clause}
+						{$where_clause}
+						{$groupby_clause}
 						{$having_clause}";
 
 			return (int) $wpdb->get_var( $sql_query ); //phpcs:ignore
@@ -718,11 +718,11 @@ class QueryHelper {
 
 		// Single record.
 		if ( $single ) {
-			$sql_query = "SELECT {$select_clause} 
-						FROM {$table_with_alias} 
-						{$join_clause} 
-						{$where_clause} 
-						{$groupby_clause} 
+			$sql_query = "SELECT {$select_clause}
+						FROM {$table_with_alias}
+						{$join_clause}
+						{$where_clause}
+						{$groupby_clause}
 						{$having_clause}
 						{$order_by_clause}
 						LIMIT 1";
@@ -741,11 +741,11 @@ class QueryHelper {
 
 		$limit_clause = self::prepare_limit_clause( $limit, $offset );
 
-		$sql_query = "SELECT {$calc_found_rows} {$select_clause} 
-					FROM {$table_with_alias} 
-					{$join_clause} 
-					{$where_clause} 
-					{$groupby_clause} 
+		$sql_query = "SELECT {$calc_found_rows} {$select_clause}
+					FROM {$table_with_alias}
+					{$join_clause}
+					{$where_clause}
+					{$groupby_clause}
 					{$having_clause}
 					{$order_by_clause}
 					{$limit_clause}";
@@ -913,7 +913,7 @@ class QueryHelper {
 				$value = esc_sql( sanitize_text_field( $value ) );
 				$set  .= is_numeric( $value ) ? "$key = $value" : "$key = '" . $value ."'";
 			}
-			
+
 			$set .= ",";
 		}
 		return rtrim( $set, ',' );
@@ -1038,7 +1038,7 @@ class QueryHelper {
 		$order_by_clause = self::prepare_order_clause( $order_by, $order );
 		$limit_clause    = self::prepare_limit_clause( $limit, $offset );
 
-		$query = "SELECT SQL_CALC_FOUND_ROWS 
+		$query = "SELECT SQL_CALC_FOUND_ROWS
 				{$select_clause}
 				FROM {$from_clause}
 				{$join_clauses}
@@ -1051,7 +1051,7 @@ class QueryHelper {
 		}
 
 		$results     = $wpdb->get_results( $query, $output );
-		$has_records = is_array( $results ) && count( $results );	
+		$has_records = is_array( $results ) && count( $results );
 		$total_count = $has_records ? (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' ) : 0;
 
 		// Throw exception if error occurred.
@@ -1119,7 +1119,7 @@ class QueryHelper {
 	 */
 	public static function get_joined_count(string $primary_table, array $joining_tables, array $where = [], array $search = [], string $count_column = '*'): int {
 		global $wpdb;
-		
+
 		$from_clause  = self::prepare_table_name( $primary_table );
 		$join_clauses = self::prepare_join_clause( $joining_tables );
 		$where_clause = self::prepare_where_search_clause( $where, $search, 'AND' );
@@ -1166,33 +1166,33 @@ class QueryHelper {
 		$where_clause    = self::prepare_where_search_clause( $where, $search, 'AND' );
 		$order_by_clause = self::prepare_order_clause( $order_by, $order );
 		$limit_clause    = self::prepare_limit_clause( $limit, $offset );
-	
+
 		// If error occurred then throw new exception.
 		if ( $wpdb->last_error ) {
 			throw new \Exception( $wpdb->last_error );
 		}
-	
+
 		$query = "SELECT SQL_CALC_FOUND_ROWS *
 			 FROM {$table}
 			 {$where_clause}
 			 {$order_by_clause}
 			 {$limit_clause}";
-	
+
 		$results     = $wpdb->get_results( $query, $output );
 		$has_records = is_array( $results ) && count( $results );
 		$total_count = $has_records ? (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' ) : 0;
-	
+
 		// If error occurred then throw new exception.
 		if ( $wpdb->last_error ) {
 			throw new \Exception( $wpdb->last_error );
 		}
-	
+
 		// Prepare response array.
 		$response = array(
 			'results'     => $results,
 			'total_count' => $total_count,
 		);
-	
+
 		return $response;
 	}
 
@@ -1268,10 +1268,32 @@ class QueryHelper {
 	 * @return string
 	 */
 	public static function prepare_table_name( string $table_name ) {
-		$table_prefix = self::get_table_prefix();
-		if ( strpos( $table_name,$table_prefix ) !== 0 ) {
-			$table_name = $table_prefix . $table_name;
+		global $wpdb;
+
+		// Clean up the input and extract the actual table name without its alias (e.g. "wp_users u")
+		$trimmed_table = trim( $table_name );
+		$parts         = preg_split( '/\s+/', $trimmed_table );
+		$actual_table  = $parts[0] ?? '';
+
+		// List of global tables that should never receive the subsite prefix
+		$global_tables = array(
+			$wpdb->users,
+			$wpdb->usermeta,
+			$wpdb->blogs ?? '',
+			$wpdb->blogmeta ?? '',
+			$wpdb->site ?? '',
+			$wpdb->sitemeta ?? '',
+		);
+
+		// If the targeted table is a global table, return it as-is without modification
+		if ( in_array( $actual_table, array_filter( $global_tables ), true ) ) {
+			return $table_name;
 		}
+
+		$table_prefix = self::get_table_prefix();
+		if ( strpos( $table_name, $table_prefix ) !== 0 ) {
+ 			$table_name = $table_prefix . $table_name;
+ 		}
 
 		return $table_name;
 	}
@@ -1318,7 +1340,7 @@ class QueryHelper {
 		$values       = array_values( $row );
 
 		$insert_sql = $wpdb->prepare(
-			"INSERT INTO `$table_name` (`" . implode( '`, `', $columns ) . "`) 
+			"INSERT INTO `$table_name` (`" . implode( '`, `', $columns ) . "`)
 			VALUES (" . implode( ', ', $placeholders ) . ")",
 			...$values
 		);
@@ -1357,7 +1379,7 @@ class QueryHelper {
 	 * @return array Returns an array of table columns and their details.
 	 */
 	public static function get_table_schema( $table_name) {
-		
+
 		global $wpdb;
 
 		$result = $wpdb->get_results( "DESCRIBE {$table_name}", ARRAY_A );

--- a/models/WithdrawModel.php
+++ b/models/WithdrawModel.php
@@ -160,27 +160,27 @@ class WithdrawModel {
 		//phpcs:disable
 		$data = $wpdb->get_row(
 			$wpdb->prepare(
-				"SELECT ID, display_name, 
+				"SELECT ID, display_name,
                     total_income,
-					total_withdraw, 
-                    (total_income-total_withdraw) current_balance, 
+					total_withdraw,
+                    (total_income-total_withdraw) current_balance,
                     total_matured,
 					total_pending,
-                    greatest(0, total_matured - total_withdraw) available_for_withdraw 
-                
+                    greatest(0, total_matured - total_withdraw) available_for_withdraw
+
                 FROM (
-                        SELECT ID,display_name, 
+                        SELECT ID,display_name,
                     COALESCE((SELECT SUM(instructor_amount) FROM {$wpdb->prefix}tutor_earnings WHERE order_status='%s' {$date_clause} GROUP BY user_id HAVING user_id=u.ID),0) total_income,
-                    
+
                         COALESCE((
-                        SELECT sum(amount) total_withdraw FROM {$wpdb->prefix}tutor_withdraws 
+                        SELECT sum(amount) total_withdraw FROM {$wpdb->prefix}tutor_withdraws
                         WHERE status='%s' {$date_clause}
                         GROUP BY user_id
                         HAVING user_id=u.ID
                     ),0) total_withdraw,
-					
+
 					COALESCE((
-                        SELECT sum(amount) total_pending FROM {$wpdb->prefix}tutor_withdraws 
+                        SELECT sum(amount) total_pending FROM {$wpdb->prefix}tutor_withdraws
                         WHERE status='pending' {$date_clause}
                         GROUP BY user_id
                         HAVING user_id=u.ID
@@ -194,9 +194,9 @@ class WithdrawModel {
                         GROUP BY user_id
                         HAVING user_id = u.ID
                     ),0) total_matured
-                    
-                FROM {$wpdb->prefix}users u WHERE u.ID=%d
-                
+
+                FROM {$wpdb->users} u WHERE u.ID=%d
+
                 ) a",
 				'completed',
 				self::STATUS_APPROVED,


### PR DESCRIPTION
This PR resolves multiple database, schema installation, and page-rendering bugs when running Tutor LMS on a WordPress Multisite network (specifically where subsites use a custom table prefix like `wp_2_`).
#### 1. Bypassing Subsite Prefixes for Shared Global Tables
* **Problem**: In a WordPress Multisite, global tables like `wp_users`, `wp_usermeta`, `wp_blogs`, etc., are shared network-wide and do not receive subsite prefixes. Tutor LMS's `QueryHelper::prepare_table_name()` automatically prepends the subsite table prefix (`wp_2_`) to all incoming tables, causing SQL execution failures like `Table 'wp_2_wp_users' doesn't exist`.
* **Fix**: Updated `QueryHelper::prepare_table_name()` to recognize all standard global WordPress tables (e.g. `$wpdb->users`, `$wpdb->usermeta`, `$wpdb->blogs`, etc.) and return them unmodified without prepending the prefix.
#### 2. Resolving Hardcoded Foreign Key Constraint Name Conflicts
* **Problem**: MySQL/InnoDB requires foreign key constraint names to be globally unique within the database schema. Tutor LMS hardcoded constraint names (such as `fk_tutor_itemmeta`, `fk_tutor_ordermeta_order_id`, etc.) in its table creation SQL statements. Activating or upgrading the plugin on a second subsite would fail with `errno: 150 (Foreign key constraint is incorrectly formed)` because the constraint name was already registered by the primary site.
* **Fix**: Modified `Tutor.php` and `Upgrader.php` to dynamically prefix all database constraints with `{$wpdb->prefix}` (e.g., `fk_{$wpdb->prefix}tutor_itemmeta`), preventing schema conflicts across multiple sites.
#### 3. Resolving Instructor Dashboard Render Crash
* **Problem**: The main `/dashboard/` page crashed (showing only the header and failing to render the content/footer) because `WithdrawModel::get_withdraw_summary` hardcoded the query source as `FROM {$wpdb->prefix}users u`. Since there is no site-specific users table (`wp_2_users`), the query threw a fatal SQL exception.
* **Fix**: Corrected the query in `WithdrawModel.php` to reference the global `$wpdb->users` table instead.