### PR TITLE
fix(course-builder/curriculum): Hide Quiz Details From Students when hidden from tutor course settings & fix topic header padding when collapsed

### DIFF
--- a/assets/src/js/v3/entries/course-builder/components/curriculum/TopicHeader.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/curriculum/TopicHeader.tsx
@@ -128,6 +128,9 @@ const TopicHeader = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEdit]);
 
+  const summaryValue = form.watch('summary') ?? '';
+  const hasSummary = summaryValue.trim().length > 0;
+
   return (
     <>
       <div css={styles.header({ isCollapsed: topic.isCollapsed, isEdit, isDeletePopoverOpen, isDragging })}>
@@ -135,7 +138,7 @@ const TopicHeader = ({
           css={styles.headerContent({
             isSaved: topic.isSaved,
             isCollapsed: topic.isCollapsed,
-            hasSummary: topic.summary.length > 0,
+            hasSummary,
           })}
         >
           <div
@@ -259,10 +262,10 @@ const TopicHeader = ({
         <Show
           when={isEdit}
           fallback={
-            <Show when={topic.summary.length > 0}>
+            <Show when={hasSummary}>
               <animated.div style={{ ...collapseAnimationDescription }}>
                 <div css={styles.description({ isEdit })} ref={descriptionRef} onDoubleClick={() => setIsEdit(true)}>
-                  {form.watch('summary')}
+                  {summaryValue}
                 </div>
               </animated.div>
             </Show>

--- a/assets/src/js/v3/entries/course-builder/components/curriculum/TopicHeader.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/curriculum/TopicHeader.tsx
@@ -131,7 +131,13 @@ const TopicHeader = ({
   return (
     <>
       <div css={styles.header({ isCollapsed: topic.isCollapsed, isEdit, isDeletePopoverOpen, isDragging })}>
-        <div css={styles.headerContent({ isSaved: topic.isSaved, isCollapsed: topic.isCollapsed })}>
+        <div
+          css={styles.headerContent({
+            isSaved: topic.isSaved,
+            isCollapsed: topic.isCollapsed,
+            hasSummary: topic.summary.length > 0,
+          })}
+        >
           <div
             css={styles.grabberInput}
             onClick={() => onCollapse(topic.id)}
@@ -398,12 +404,20 @@ const styles = {
       }
     }
   `,
-  headerContent: ({ isSaved = true, isCollapsed = false }: { isSaved: boolean; isCollapsed: boolean }) => css`
+  headerContent: ({
+    isSaved = true,
+    isCollapsed = false,
+    hasSummary = false,
+  }: {
+    isSaved: boolean;
+    isCollapsed: boolean;
+    hasSummary: boolean;
+  }) => css`
     display: grid;
     grid-template-columns: ${isSaved ? '1fr auto' : '1fr'};
     gap: ${spacing[12]};
     width: 100%;
-    padding-bottom: ${!isCollapsed ? spacing[12] : '0px'};
+    padding-bottom: ${!isCollapsed && hasSummary ? spacing[12] : '0px'};
   `,
   grabberInput: css`
     ${styleUtils.display.flex()};
@@ -458,6 +472,7 @@ const styles = {
 
     ${isEdit &&
     css`
+      padding-top: ${spacing[12]};
       padding-right: 0;
     `}
   `,

--- a/assets/src/js/v3/entries/course-builder/components/curriculum/TopicHeader.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/curriculum/TopicHeader.tsx
@@ -131,7 +131,7 @@ const TopicHeader = ({
   return (
     <>
       <div css={styles.header({ isCollapsed: topic.isCollapsed, isEdit, isDeletePopoverOpen, isDragging })}>
-        <div css={styles.headerContent({ isSaved: topic.isSaved })}>
+        <div css={styles.headerContent({ isSaved: topic.isSaved, isCollapsed: topic.isCollapsed })}>
           <div
             css={styles.grabberInput}
             onClick={() => onCollapse(topic.id)}
@@ -271,7 +271,7 @@ const TopicHeader = ({
                   {...controllerProps}
                   placeholder={__('Add a summary', 'tutor')}
                   isSecondary
-                  rows={2}
+                  rows={5}
                   enableResize
                 />
               )}
@@ -377,11 +377,6 @@ const styles = {
     `}
 
     ${!isEdit &&
-    css`
-      padding-bottom: 0;
-    `}
-
-    ${!isEdit &&
     !isDeletePopoverOpen &&
     css`
       [data-visually-hidden] {
@@ -403,12 +398,12 @@ const styles = {
       }
     }
   `,
-  headerContent: ({ isSaved = true }: { isSaved: boolean }) => css`
+  headerContent: ({ isSaved = true, isCollapsed = false }: { isSaved: boolean; isCollapsed: boolean }) => css`
     display: grid;
     grid-template-columns: ${isSaved ? '1fr auto' : '1fr'};
     gap: ${spacing[12]};
     width: 100%;
-    padding-bottom: ${spacing[12]};
+    padding-bottom: ${!isCollapsed ? spacing[12] : '0px'};
   `,
   grabberInput: css`
     ${styleUtils.display.flex()};
@@ -455,7 +450,6 @@ const styles = {
     color: ${colorTokens.text.hints};
     padding-inline: ${spacing[8]};
     margin-left: ${spacing[24]};
-    padding-bottom: ${spacing[12]};
 
     ${!isEdit &&
     css`
@@ -473,6 +467,7 @@ const styles = {
     ${styleUtils.display.flex()};
     gap: ${spacing[8]};
     justify-content: end;
+    margin-top: ${spacing[12]};
   `,
   actions: css`
     ${styleUtils.display.flex()};

--- a/package.json
+++ b/package.json
@@ -124,6 +124,5 @@
     "typescript": "^5.8.3",
     "uuid": "^9.0.1",
     "vanilla-calendar-pro": "^3.0.5"
-  },
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -124,5 +124,6 @@
     "typescript": "^5.8.3",
     "uuid": "^9.0.1",
     "vanilla-calendar-pro": "^3.0.5"
-  }
+  },
+  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"
 }

--- a/templates/shared/components/student-quiz-attempt-row.php
+++ b/templates/shared/components/student-quiz-attempt-row.php
@@ -32,6 +32,9 @@ $details_url      = $quiz_attempt_obj->get_review_url(
 	array( 'action' => 'view_details' )
 ) ?? '#';
 
+$hide_quiz_details = Quiz_Attempts_List::is_attempt_details_hidden();
+$quiz_details_url  = $hide_quiz_details ? '#' : $details_url;
+
 ?>
 <div class="tutor-quiz-attempts-item" data-learning-area="<?php echo esc_attr( $is_learning_area ? 'true' : 'false' ); ?>">
 	<div class="tutor-quiz-item-info">
@@ -39,7 +42,7 @@ $details_url      = $quiz_attempt_obj->get_review_url(
 		if ( $show_quiz_title && ! empty( $quiz_title ) ) :
 			?>
 			<div class="tutor-quiz-item-info-expanded">
-				<a href="<?php echo esc_url( $quiz_attempt_obj->get_review_url( $attempt ) ); ?>" class="tutor-quiz-item-info-title">
+				<a href="<?php echo esc_url( $quiz_details_url ); ?>" class="tutor-quiz-item-info-title">
 					<?php echo esc_html( $quiz_title ); ?>
 				</a>
 				<?php if ( $attempts_count > 1 ) : ?>
@@ -61,7 +64,7 @@ $details_url      = $quiz_attempt_obj->get_review_url(
 
 		<?php if ( $attempt_number ) : ?>
 			<div class="tutor-flex tutor-items-start tutor-justify-start tutor-gap-4">
-				<a href="<?php echo esc_url( $quiz_attempt_obj->get_review_url( $attempt ) ); ?>" class="tutor-quiz-item-info-title">
+				<a href="<?php echo esc_url( $quiz_details_url ); ?>" class="tutor-quiz-item-info-title">
 					<?php
 					/* translators: %d: attempt number */
 					echo esc_html( sprintf( __( 'Attempt %d', 'tutor' ), $attempt_number ) );

--- a/templates/shared/components/student-quiz-attempt-row.php
+++ b/templates/shared/components/student-quiz-attempt-row.php
@@ -42,9 +42,15 @@ $quiz_details_url  = $hide_quiz_details ? '#' : $details_url;
 		if ( $show_quiz_title && ! empty( $quiz_title ) ) :
 			?>
 			<div class="tutor-quiz-item-info-expanded">
-				<a href="<?php echo esc_url( $quiz_details_url ); ?>" class="tutor-quiz-item-info-title">
-					<?php echo esc_html( $quiz_title ); ?>
-				</a>
+				<?php if ( $hide_quiz_details ) : ?>
+					<div class="tutor-medium tutor-font-semibold">
+						<?php echo esc_html( $quiz_title ); ?>
+					</div>
+				<?php else : ?>
+					<a href="<?php echo esc_url( $quiz_details_url ); ?>" class="tutor-quiz-item-info-title">
+						<?php echo esc_html( $quiz_title ); ?>
+					</a>
+				<?php endif; ?>
 				<?php if ( $attempts_count > 1 ) : ?>
 					<button @click="expanded = !expanded" class="tutor-quiz-attempts-expand-btn">
 						<?php
@@ -64,12 +70,21 @@ $quiz_details_url  = $hide_quiz_details ? '#' : $details_url;
 
 		<?php if ( $attempt_number ) : ?>
 			<div class="tutor-flex tutor-items-start tutor-justify-start tutor-gap-4">
-				<a href="<?php echo esc_url( $quiz_details_url ); ?>" class="tutor-quiz-item-info-title">
+				<?php if ( $hide_quiz_details ) : ?>
+					<div class="tutor-medium tutor-font-semibold">
 					<?php
 					/* translators: %d: attempt number */
 					echo esc_html( sprintf( __( 'Attempt %d', 'tutor' ), $attempt_number ) );
 					?>
-				</a>
+					</div>
+				<?php else : ?>
+					<a href="<?php echo esc_url( $quiz_details_url ); ?>" class="tutor-quiz-item-info-title">
+						<?php
+						/* translators: %d: attempt number */
+						echo esc_html( sprintf( __( 'Attempt %d', 'tutor' ), $attempt_number ) );
+						?>
+					</a>
+				<?php endif; ?>
 			</div>
 		<?php endif; ?>
 


### PR DESCRIPTION
This fixes extra vertical space when topics are collapsed. Increase summary textarea rows from 2 to 5 for improved editing experience.

Hide Quiz Details From Students when hidden from tutor course settings

conditionally set the quiz details link URL to # when attempt details are hidden, using the Quiz_Attempts_List::is_attempt_details_hidden() check.