### PR TITLE
fix: correct area-hidden typo to aria-hidden across templates

### DIFF
--- a/assets/react/admin-dashboard/segments/import-export.js
+++ b/assets/react/admin-dashboard/segments/import-export.js
@@ -38,18 +38,18 @@ function tutor_option_history_load(dataset) {
 					<button class="tutor-btn tutor-btn-outline-primary tutor-btn-sm apply_settings" data-tutor-modal-target="tutor-modal-bulk-action" data-btntext="${__('Yes, Restore Settings" data-heading="Restore Previous Settings?', 'tutor')}" data-message="${__('WARNING! This will overwrite all existing settings, please proceed with caution.', 'tutor')}" data-id="${dataKey}">${__('Apply', 'tutor')}</button>
 					<div class="tutor-dropdown-parent tutor-ml-16">
 						<button type="button" class="tutor-iconic-btn" action-tutor-dropdown="toggle">
-							<span class="tutor-icon-kebab-menu" area-hidden="true"></span>
+							<span class="tutor-icon-kebab-menu" aria-hidden="true"></span>
 						</button>
 						<ul class="tutor-dropdown tutor-dropdown-dark tutor-text-left">
 							<li>
 								<a href="javascript:;" class="tutor-dropdown-item export_single_settings" data-id="${dataKey}">
-									<span class="tutor-icon-archive tutor-mr-8" area-hidden="true"></span>
+									<span class="tutor-icon-archive tutor-mr-8" aria-hidden="true"></span>
 									<span>${__('Download', 'tutor')}</span>
 								</a>
 							</li>
 							<li>
 								<a href="javascript:;" class="tutor-dropdown-item delete_single_settings" data-tutor-modal-target="tutor-modal-bulk-action" data-btntext="Yes, Delete Settings" data-heading="Delete This Settings?" data-message="WARNING! This will remove the settings history data from your system, please proceed with caution." data-id="${dataKey}">
-									<span class="tutor-icon-trash-can-bold tutor-mr-8" area-hidden="true"></span>
+									<span class="tutor-icon-trash-can-bold tutor-mr-8" aria-hidden="true"></span>
 									<span>${__('Delete', 'tutor')}</span>
 								</a>
 							</li>

--- a/assets/react/front/_select_dd_search.js
+++ b/assets/react/front/_select_dd_search.js
@@ -163,7 +163,7 @@ window.selectSearchField = (selectElement) => {
 				<div class="tutor-form-select-search tutor-pt-8 tutor-px-8">
 					<div class="tutor-form-wrap">
 						<span class="tutor-form-icon">
-							<i class="tutor-icon-search" area-hidden="true"></i>
+							<i class="tutor-icon-search" aria-hidden="true"></i>
 						</span>
 						<input type="search" class="tutor-form-control" placeholder="${window.wp.i18n.__('Search ...', 'tutor')}" />
 					</div>

--- a/assets/react/front/course/_archive.js
+++ b/assets/react/front/course/_archive.js
@@ -123,7 +123,7 @@ window.jQuery(document).ready($ => {
             pushFilterToState(filter_criteria);
         }
 
-        content_container.html('<div class="tutor-spinner-wrap"><span class="tutor-spinner" area-hidden="true"></span></div>');
+        content_container.html('<div class="tutor-spinner-wrap"><span class="tutor-spinner" aria-hidden="true"></span></div>');
         course_filter_container.find('[action-tutor-clear-filter]').closest('.tutor-widget-course-filter').removeClass('tutor-d-none');
         
         if (!('category' in filter_criteria.supported_filters)) {
@@ -192,7 +192,7 @@ window.jQuery(document).ready($ => {
         $('body').toggleClass('tutor-course-filter-open');
 
         if ($('.tutor-course-filter-backdrop').length == 0) {
-            $('body').append($('<div class="tutor-course-filter-backdrop" area-hidden="true"></div>').hide().fadeIn(150));
+            $('body').append($('<div class="tutor-course-filter-backdrop" aria-hidden="true"></div>').hide().fadeIn(150));
         }
     });
 

--- a/assets/react/front/course/_spotlight-quiz.js
+++ b/assets/react/front/course/_spotlight-quiz.js
@@ -32,7 +32,7 @@ window.jQuery(document).ready($ => {
 
     function get_hint_markup(text) {
         return `<span class="tutor-quiz-answer-single-info tutor-color-success tutor-mt-8">
-            <i class="tutor-icon-mark tutor-color-success" area-hidden="true"></i>
+            <i class="tutor-icon-mark tutor-color-success" aria-hidden="true"></i>
             ${text}
         </span>`
     }

--- a/assets/react/front/pages/instructor-list-filter.js
+++ b/assets/react/front/pages/instructor-list-filter.js
@@ -28,7 +28,7 @@ jQuery(document).ready(function($) {
 			filter_args.action = 'load_filtered_instructor';
 
 			// Append spinner
-			result_container.html('<div class="tutor-spinner-wrap"><span class="tutor-spinner" area-hidden="true"></span></div>');
+			result_container.html('<div class="tutor-spinner-wrap"><span class="tutor-spinner" aria-hidden="true"></span></div>');
 
 			$.ajax({
 				url: window._tutorobject.ajaxurl,

--- a/assets/react/lib/tutor.js
+++ b/assets/react/lib/tutor.js
@@ -26,7 +26,7 @@ window.tutor_popup = function($, icon) {
 			html += '<div class="tutor-modal-overlay"></div>';
 			html += '<div class="tutor-modal-window">';
 				html += '<div class="tutor-modal-content tutor-modal-content-white">';
-					html += '<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close><span class="tutor-icon-times" area-hidden="true"></span></button>';
+					html += '<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close><span class="tutor-icon-times" aria-hidden="true"></span></button>';
 					html += '<div class="tutor-modal-body tutor-text-center">';
 						html += '<div class="tutor-px-lg-48 tutor-py-lg-24">';
 						

--- a/assets/react/v2/pagination.js
+++ b/assets/react/v2/pagination.js
@@ -56,7 +56,7 @@ window.jQuery(document).ready($=>{
                     link_el.addClass('is-loading');
                 } else {
                     // Otherwise replace the content container with loading icon
-                    content_container.html('<div class="tutor-spinner-wrap"><span class="tutor-spinner" area-hidden="true"></span></div>');
+                    content_container.html('<div class="tutor-spinner-wrap"><span class="tutor-spinner" aria-hidden="true"></span></div>');
                 }
                 
                 // move to top

--- a/includes/tutor-general-functions.php
+++ b/includes/tutor-general-functions.php
@@ -1113,7 +1113,7 @@ if ( ! function_exists( 'tutor_closeable_alert_msg' ) ) {
 			<span>
 				<?php echo is_array( $allowed_tags ) && count( $allowed_tags ) ? wp_kses( $message, $allowed_tags ) : esc_html( $message ); ?>
 			</span>
-			<span class="tutor-icon-times" area-hidden="true" onclick="this.closest('div').remove()" style="cursor: pointer;"></span>
+			<span class="tutor-icon-times" aria-hidden="true" onclick="this.closest('div').remove()" style="cursor: pointer;"></span>
 		</div>
 		<?php
 	}
@@ -1174,7 +1174,7 @@ if ( ! function_exists( 'tutor_snackbar' ) ) {
 							<?php echo esc_html( isset( $button['title'] ) ? $button['title'] : '' ); ?>
 						</a>
 					<?php endforeach; ?>
-					<span class="tutor-icon-times" area-hidden="true" onclick="this.closest('#tutor-reuseable-snackbar').remove()" style="cursor: pointer;"></span>
+					<span class="tutor-icon-times" aria-hidden="true" onclick="this.closest('#tutor-reuseable-snackbar').remove()" style="cursor: pointer;"></span>
 				</div>
 			</div>
 		</div>

--- a/restapi/RestAuth.php
+++ b/restapi/RestAuth.php
@@ -375,15 +375,15 @@ class RestAuth {
 			<td>
 				<div class="tutor-dropdown-parent">
 					<button type="button" class="tutor-iconic-btn" action-tutor-dropdown="toggle">
-						<span class="tutor-icon-kebab-menu" area-hidden="true"></span>
+						<span class="tutor-icon-kebab-menu" aria-hidden="true"></span>
 					</button>
 					<div class="tutor-dropdown tutor-dropdown-dark tutor-text-left">
 						<a href="javascript:void(0)" class="tutor-dropdown-item" data-tutor-modal-target="tutor-update-permission-modal" data-update-id="<?php echo esc_attr( $meta_id ); ?>" data-permission="<?php echo esc_attr( $permission ); ?>" data-description="<?php echo esc_attr( $description ); ?>">
-							<i class="tutor-icon-edit tutor-mr-8" area-hidden="true" data-update-id="<?php echo esc_attr( $meta_id ); ?>" data-permission="<?php echo esc_attr( $permission ); ?>" data-description="<?php echo esc_attr( $description ); ?>"></i>
+							<i class="tutor-icon-edit tutor-mr-8" aria-hidden="true" data-update-id="<?php echo esc_attr( $meta_id ); ?>" data-permission="<?php echo esc_attr( $permission ); ?>" data-description="<?php echo esc_attr( $description ); ?>"></i>
 							<span data-update-id="<?php echo esc_attr( $meta_id ); ?>" data-permission="<?php echo esc_attr( $permission ); ?>" data-description="<?php echo esc_attr( $description ); ?>"><?php esc_html_e( 'Edit', 'tutor' ); ?></span>
 						</a>
 						<a href="javascript:void(0)" class="tutor-dropdown-item" data-meta-id="<?php echo esc_attr( $meta_id ); ?>">
-							<i class="tutor-icon-trash-can-bold tutor-mr-8" area-hidden="true" data-meta-id="<?php echo esc_attr( $meta_id ); ?>"></i>
+							<i class="tutor-icon-trash-can-bold tutor-mr-8" aria-hidden="true" data-meta-id="<?php echo esc_attr( $meta_id ); ?>"></i>
 							<span data-meta-id="<?php echo esc_attr( $meta_id ); ?>"><?php esc_html_e( 'Revoke', 'tutor' ); ?></span>
 						</a>
 					</div>

--- a/templates/course-embed.php
+++ b/templates/course-embed.php
@@ -60,14 +60,14 @@ $placeholder_img   = tutor()->url . 'assets/images/placeholder.svg';
 			<div class="tutor-meta tutor-mt-12 tutor-mb-20">
 				<?php if ( tutor_utils()->get_option( 'enable_course_total_enrolled' ) ) : ?>
 					<div>
-						<span class="tutor-meta-icon tutor-icon-user-line" area-hidden="true"></span>
+						<span class="tutor-meta-icon tutor-icon-user-line" aria-hidden="true"></span>
 						<span class="tutor-meta-value"><?php echo esc_html( $course_students ); ?></span>
 					</div>
 				<?php endif; ?>
 
 				<?php if ( ! empty( $course_duration ) ) : ?>
 					<div>
-						<span class="tutor-icon-clock-line tutor-meta-icon" area-hidden="true"></span>
+						<span class="tutor-icon-clock-line tutor-meta-icon" aria-hidden="true"></span>
 						<span class="tutor-meta-value">
 							<?php
 								//phpcs:ignore --data sanitize through helper method

--- a/templates/course-filter/filters.php
+++ b/templates/course-filter/filters.php
@@ -26,7 +26,7 @@ $reset_link        = remove_query_arg( $supported_filters, get_pagenum_link() );
 
 <form class="tutor-course-filter-form tutor-form">
 	<div class="tutor-mb-16 tutor-d-block tutor-d-xl-none tutor-text-right">
-		<a href="#" class="tutor-iconic-btn tutor-mr-n8" tutor-hide-course-filter><span class="tutor-icon-times" area-hidden="true"></span></a>
+		<a href="#" class="tutor-iconic-btn tutor-mr-n8" tutor-hide-course-filter><span class="tutor-icon-times" aria-hidden="true"></span></a>
 	</div>
 
 	<?php do_action( 'tutor_course_filter/before' ); ?>
@@ -34,7 +34,7 @@ $reset_link        = remove_query_arg( $supported_filters, get_pagenum_link() );
 	<?php if ( in_array( 'search', $supported_filters ) ) : ?>
 		<div class="tutor-widget tutor-widget-search">
 			<div class="tutor-form-wrap">
-				<span class="tutor-icon-search tutor-form-icon" area-hidden="true"></span>
+				<span class="tutor-icon-search tutor-form-icon" aria-hidden="true"></span>
 				<input type="Search" class="tutor-form-control" name="keyword" placeholder="<?php esc_attr_e( 'Search', 'tutor' ); ?>"/>
 			</div>
 		</div>

--- a/templates/dashboard/announcements.php
+++ b/templates/dashboard/announcements.php
@@ -64,7 +64,7 @@ $image_base = tutor()->url . '/assets/images/';
 	<div class="tutor-row tutor-align-lg-center">
 		<div class="tutor-col-lg-auto tutor-mb-16 tutor-mb-lg-0">
 			<div class="tutor-round-box tutor-p-8">
-				<i class="tutor-icon-bullhorn tutor-fs-3" area-hidden="true"></i>
+				<i class="tutor-icon-bullhorn tutor-fs-3" aria-hidden="true"></i>
 			</div>
 		</div>
 

--- a/templates/dashboard/assignments/review.php
+++ b/templates/dashboard/assignments/review.php
@@ -44,7 +44,7 @@ if ( ! tutor_utils()->can_user_edit_course( get_current_user_id(), $course_id ) 
 
 	<div class="submitted-assignment-title tutor-mb-16">
 		<a class="tutor-btn tutor-btn-ghost" href="<?php echo esc_url( $submitted_url . '?assignment=' . $assignment_id ); ?>">
-			<span class="tutor-icon-previous tutor-mr-8" area-hidden="true"></span>
+			<span class="tutor-icon-previous tutor-mr-8" aria-hidden="true"></span>
 			<?php esc_html_e( 'Back', 'tutor' ); ?>
 		</a>
 	</div>

--- a/templates/dashboard/assignments/submitted.php
+++ b/templates/dashboard/assignments/submitted.php
@@ -40,7 +40,7 @@ $comment_parent = ! empty( $assignments_submitted ) ? $assignments_submitted[0]-
 <div class="tutor-dashboard-content-inner tutor-dashboard-assignment-submits">
 	<div class="tutor-mb-24">
 		<a class="tutor-btn tutor-btn-ghost" href="<?php echo esc_url( tutor_utils()->get_tutor_dashboard_page_permalink( 'assignments' ) ); ?>">
-			<span class="tutor-icon-previous tutor-mr-8" area-hidden="true"></span>
+			<span class="tutor-icon-previous tutor-mr-8" aria-hidden="true"></span>
 			<?php esc_html_e( 'Back', 'tutor' ); ?>
 		</a>
 	</div>

--- a/templates/dashboard/dashboard.php
+++ b/templates/dashboard/dashboard.php
@@ -41,7 +41,7 @@ if ( tutor_utils()->get_option( 'enable_profile_completion' ) ) {
 								<div class="tutor-row tutor-gx-1">
 									<?php for ( $i = 1; $i <= $total_count; $i++ ) : ?>
 										<div class="tutor-col">
-											<div class="tutor-progress-bar" style="--tutor-progress-value: <?php echo $i > $complete_count ? 0 : 100; ?>%; height: 8px;"><div class="tutor-progress-value" area-hidden="true"></div></div>
+											<div class="tutor-progress-bar" style="--tutor-progress-value: <?php echo $i > $complete_count ? 0 : 100; ?>%; height: 8px;"><div class="tutor-progress-value" aria-hidden="true"></div></div>
 										</div>
 									<?php endfor; ?>
 								</div>
@@ -49,7 +49,7 @@ if ( tutor_utils()->get_option( 'enable_profile_completion' ) ) {
 
 							<div class="tutor-col-auto">
 								<span class="tutor-round-box tutor-my-n20">
-									<i class="tutor-icon-trophy" area-hidden="true"></i>
+									<i class="tutor-icon-trophy" aria-hidden="true"></i>
 								</span>
 							</div>
 						</div>
@@ -160,7 +160,7 @@ if ( tutor_utils()->get_option( 'enable_profile_completion' ) ) {
 			<div class="tutor-card">
 				<div class="tutor-d-flex tutor-flex-lg-column tutor-align-center tutor-text-lg-center tutor-px-12 tutor-px-lg-24 tutor-py-8 tutor-py-lg-32">
 					<span class="tutor-round-box tutor-mr-12 tutor-mr-lg-0 tutor-mb-lg-12">
-						<i class="tutor-icon-book-open" area-hidden="true"></i>
+						<i class="tutor-icon-book-open" aria-hidden="true"></i>
 					</span>
 					<div class="tutor-fs-3 tutor-fw-bold tutor-d-none tutor-d-lg-block"><?php echo esc_html( $enrolled_course_count ); ?></div>
 					<div class="tutor-fs-7 tutor-color-secondary"><?php esc_html_e( 'Enrolled Courses', 'tutor' ); ?></div>
@@ -173,7 +173,7 @@ if ( tutor_utils()->get_option( 'enable_profile_completion' ) ) {
 			<div class="tutor-card">
 				<div class="tutor-d-flex tutor-flex-lg-column tutor-align-center tutor-text-lg-center tutor-px-12 tutor-px-lg-24 tutor-py-8 tutor-py-lg-32">
 					<span class="tutor-round-box tutor-mr-12 tutor-mr-lg-0 tutor-mb-lg-12">
-						<i class="tutor-icon-mortarboard-o" area-hidden="true"></i>
+						<i class="tutor-icon-mortarboard-o" aria-hidden="true"></i>
 					</span>
 					<div class="tutor-fs-3 tutor-fw-bold tutor-d-none tutor-d-lg-block"><?php echo esc_html( $active_course_count ); ?></div>
 					<div class="tutor-fs-7 tutor-color-secondary"><?php esc_html_e( 'Active Courses', 'tutor' ); ?></div>
@@ -186,7 +186,7 @@ if ( tutor_utils()->get_option( 'enable_profile_completion' ) ) {
 			<div class="tutor-card">
 				<div class="tutor-d-flex tutor-flex-lg-column tutor-align-center tutor-text-lg-center tutor-px-12 tutor-px-lg-24 tutor-py-8 tutor-py-lg-32">
 					<span class="tutor-round-box tutor-mr-12 tutor-mr-lg-0 tutor-mb-lg-12">
-						<i class="tutor-icon-trophy" area-hidden="true"></i>
+						<i class="tutor-icon-trophy" aria-hidden="true"></i>
 					</span>
 					<div class="tutor-fs-3 tutor-fw-bold tutor-d-none tutor-d-lg-block"><?php echo esc_html( $completed_course_count ); ?></div>
 					<div class="tutor-fs-7 tutor-color-secondary"><?php esc_html_e( 'Completed Courses', 'tutor' ); ?></div>
@@ -202,7 +202,7 @@ if ( tutor_utils()->get_option( 'enable_profile_completion' ) ) {
 				<div class="tutor-card">
 					<div class="tutor-d-flex tutor-flex-lg-column tutor-align-center tutor-text-lg-center tutor-px-12 tutor-px-lg-24 tutor-py-8 tutor-py-lg-32">
 						<span class="tutor-round-box tutor-mr-12 tutor-mr-lg-0 tutor-mb-lg-12">
-							<i class="tutor-icon-user-graduate" area-hidden="true"></i>
+							<i class="tutor-icon-user-graduate" aria-hidden="true"></i>
 						</span>
 						<div class="tutor-fs-3 tutor-fw-bold tutor-d-none tutor-d-lg-block"><?php echo esc_html( $total_students ); ?></div>
 						<div class="tutor-fs-7 tutor-color-secondary"><?php esc_html_e( 'Total Students', 'tutor' ); ?></div>
@@ -215,7 +215,7 @@ if ( tutor_utils()->get_option( 'enable_profile_completion' ) ) {
 				<div class="tutor-card">
 					<div class="tutor-d-flex tutor-flex-lg-column tutor-align-center tutor-text-lg-center tutor-px-12 tutor-px-lg-24 tutor-py-8 tutor-py-lg-32">
 						<span class="tutor-round-box tutor-mr-12 tutor-mr-lg-0 tutor-mb-lg-12">
-							<i class="tutor-icon-box-open" area-hidden="true"></i>
+							<i class="tutor-icon-box-open" aria-hidden="true"></i>
 						</span>
 						<div class="tutor-fs-3 tutor-fw-bold tutor-d-none tutor-d-lg-block"><?php echo esc_html( count( $my_courses ) ); ?></div>
 						<div class="tutor-fs-7 tutor-color-secondary"><?php esc_html_e( 'Total Courses', 'tutor' ); ?></div>
@@ -228,7 +228,7 @@ if ( tutor_utils()->get_option( 'enable_profile_completion' ) ) {
 				<div class="tutor-card">
 					<div class="tutor-d-flex tutor-flex-lg-column tutor-align-center tutor-text-lg-center tutor-px-12 tutor-px-lg-24 tutor-py-8 tutor-py-lg-32">
 						<span class="tutor-round-box tutor-mr-12 tutor-mr-lg-0 tutor-mb-lg-12">
-							<i class="tutor-icon-coins" area-hidden="true"></i>
+							<i class="tutor-icon-coins" aria-hidden="true"></i>
 						</span>
 						<div class="tutor-fs-3 tutor-fw-bold tutor-d-none tutor-d-lg-block"><?php echo wp_kses_post( tutor_utils()->tutor_price( $earning_sum->total_income ) ); ?></div>
 						<div class="tutor-fs-7 tutor-color-secondary"><?php esc_html_e( 'Total Earnings', 'tutor' ); ?></div>
@@ -302,7 +302,7 @@ $courses_in_progress = CourseModel::get_active_courses_by_user( get_current_user
 
 							<div class="tutor-row tutor-align-center">
 								<div class="tutor-col">
-									<div class="tutor-progress-bar tutor-mr-16" style="--tutor-progress-value:<?php echo esc_attr( $course_progress['completed_percent'] ); ?>%"><span class="tutor-progress-value" area-hidden="true"></span></div>
+									<div class="tutor-progress-bar tutor-mr-16" style="--tutor-progress-value:<?php echo esc_attr( $course_progress['completed_percent'] ); ?>%"><span class="tutor-progress-value" aria-hidden="true"></span></div>
 								</div>
 
 								<div class="tutor-col-auto">

--- a/templates/dashboard/my-courses.php
+++ b/templates/dashboard/my-courses.php
@@ -141,7 +141,7 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 							<div class="tutor-meta tutor-mt-16">
 								<?php if ( ! empty( $course_duration ) ) : ?>
 									<div>
-										<span class="tutor-icon-clock-line tutor-meta-icon" area-hidden="true"></span>
+										<span class="tutor-icon-clock-line tutor-meta-icon" aria-hidden="true"></span>
 										<span class="tutor-meta-value">
 										<?php
 										echo wp_kses(
@@ -157,7 +157,7 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 	
 								<?php if ( ! empty( $course_students ) ) : ?>
 									<div>
-										<span class="tutor-icon-user-line tutor-meta-icon" area-hidden="true"></span>
+										<span class="tutor-icon-user-line tutor-meta-icon" aria-hidden="true"></span>
 										<span class="tutor-meta-value">
 										<?php
 										echo wp_kses(
@@ -196,11 +196,11 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 								</div>
 								<div class="tutor-iconic-btn-group tutor-mr-n8">
 									<a href="<?php echo esc_url( $course_edit_link ); ?>" class="tutor-iconic-btn tutor-my-course-edit">
-										<i class="tutor-icon-edit" area-hidden="true"></i>
+										<i class="tutor-icon-edit" aria-hidden="true"></i>
 									</a>
 									<div class="tutor-dropdown-parent">
 										<button type="button" class="tutor-iconic-btn" action-tutor-dropdown="toggle">
-											<span class="tutor-icon-kebab-menu" area-hidden="true"></span>
+											<span class="tutor-icon-kebab-menu" aria-hidden="true"></span>
 										</button>
 										<div id="table-dashboard-course-list-<?php echo esc_attr( $post->ID ); ?>" class="tutor-dropdown tutor-dropdown-dark tutor-text-left">
 
@@ -217,7 +217,7 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 												);
 												?>
 											<a class="tutor-dropdown-item" href="?<?php echo esc_attr( $params ); ?>">
-												<i class="tutor-icon-share tutor-mr-8" area-hidden="true"></i>
+												<i class="tutor-icon-share tutor-mr-8" aria-hidden="true"></i>
 												<span>
 													<?php
 													$can_publish_course = current_user_can( 'administrator' ) || (bool) tutor_utils()->get_option( 'instructor_can_publish_course' );
@@ -243,7 +243,7 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 												);
 												?>
 											<a class="tutor-dropdown-item" href="?<?php echo esc_attr( $params ); ?>">
-												<i class="tutor-icon-copy-text tutor-mr-8" area-hidden="true"></i>
+												<i class="tutor-icon-copy-text tutor-mr-8" aria-hidden="true"></i>
 												<span><?php esc_html_e( 'Duplicate', 'tutor' ); ?></span>
 											</a>
 											<?php endif; ?>
@@ -262,7 +262,7 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 												);
 												?>
 											<a class="tutor-dropdown-item" href="?<?php echo esc_attr( $params ); ?>">
-												<i class="tutor-icon-archive tutor-mr-8" area-hidden="true"></i>
+												<i class="tutor-icon-archive tutor-mr-8" aria-hidden="true"></i>
 												<span><?php esc_html_e( 'Move to Draft', 'tutor' ); ?></span>
 											</a>
 											<?php endif; ?>
@@ -281,7 +281,7 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 												);
 												?>
 											<a href="?<?php echo esc_attr( $params ); ?>" class="tutor-dropdown-item">
-												<i class="tutor-icon-times tutor-mr-8" area-hidden="true"></i>
+												<i class="tutor-icon-times tutor-mr-8" aria-hidden="true"></i>
 												<span><?php esc_html_e( 'Cancel Submission', 'tutor' ); ?></span>
 											</a>
 											<?php endif; ?>
@@ -291,7 +291,7 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 											<?php if ( $is_main_instructor && in_array( $post->post_status, array( CourseModel::STATUS_PUBLISH, CourseModel::STATUS_DRAFT, CourseModel::STATUS_FUTURE ) ) ) : ?>
 												<?php if ( $show_course_delete ) : ?>
 												<a href="#" data-tutor-modal-target="<?php echo esc_attr( $id_string_delete ); ?>" class="tutor-dropdown-item tutor-admin-course-delete">
-													<i class="tutor-icon-trash-can-bold tutor-mr-8" area-hidden="true"></i>
+													<i class="tutor-icon-trash-can-bold tutor-mr-8" aria-hidden="true"></i>
 													<span><?php esc_html_e( 'Delete', 'tutor' ); ?></span>
 												</a>
 												<?php endif; ?>
@@ -310,7 +310,7 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 							<div class="tutor-modal-window">
 								<div class="tutor-modal-content tutor-modal-content-white">
 									<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-										<span class="tutor-icon-times" area-hidden="true"></span>
+										<span class="tutor-icon-times" aria-hidden="true"></span>
 									</button>
 
 									<div class="tutor-modal-body tutor-text-center">

--- a/templates/dashboard/purchase_history.php
+++ b/templates/dashboard/purchase_history.php
@@ -286,7 +286,7 @@ if ( Ecommerce::MONETIZE_BY === $monetize_by ) {
 										<?php endif; ?>
 										<?php $courses_data_string = implode( ',', array_map( fn( $course_data ) => get_the_title( $course_data['course_id'] ), $courses ) ); ?>
 										<a href="javascript:;" class="tutor-export-purchase-history tutor-iconic-btn tutor-iconic-btn-secondary" data-order="<?php echo esc_attr( $order->ID ); ?>" data-course-name="<?php echo esc_attr( '"' . $courses_data_string . '"' ); ?>" data-price="<?php echo esc_attr( $raw_price ); ?>" data-date="<?php echo esc_attr( '"' . date_i18n( get_option( 'date_format' ), strtotime( $order->post_date ) ) . '"' ); ?>" data-status="<?php echo esc_attr( $order_status_text ); ?>">
-											<span class="tutor-icon-receipt-line" area-hidden="true"></span>
+											<span class="tutor-icon-receipt-line" aria-hidden="true"></span>
 										</a>
 									</div>
 								</td>

--- a/templates/dashboard/reviews/given-reviews.php
+++ b/templates/dashboard/reviews/given-reviews.php
@@ -72,12 +72,12 @@ $received_count = tutor_utils()->get_reviews_by_instructor( 0, 0, 0 )->count;
 							<div class="tutor-col-auto">
 								<div class="tutor-given-review-actions tutor-d-flex">
 									<span class="tutor-btn tutor-btn-ghost" data-tutor-modal-target="<?php echo esc_html( $update_id ); ?>" role="button">
-										<i class="tutor-icon-edit tutor-mr-8" area-hidden="true"></i>
+										<i class="tutor-icon-edit tutor-mr-8" aria-hidden="true"></i>
 										<span><?php esc_html_e( 'Edit', 'tutor' ); ?></span>
 									</span>
 
 									<span class="tutor-btn tutor-btn-ghost tutor-ml-16" data-tutor-modal-target="<?php echo esc_html( $delete_id ); ?>" role="button">
-										<i class="tutor-icon-trash-can-line tutor-mr-8"  area-hidden="true"></i>
+										<i class="tutor-icon-trash-can-line tutor-mr-8"  aria-hidden="true"></i>
 										<span><?php esc_html_e( 'Delete', 'tutor' ); ?></span>
 									</span>
 								</div>
@@ -95,7 +95,7 @@ $received_count = tutor_utils()->get_reviews_by_instructor( 0, 0, 0 )->count;
 						<div class="tutor-modal-window">
 							<div class="tutor-modal-content tutor-modal-content-white">
 								<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-									<span class="tutor-icon-times" area-hidden="true"></span>
+									<span class="tutor-icon-times" aria-hidden="true"></span>
 								</button>
 
 								<div class="tutor-modal-body tutor-text-center">

--- a/templates/dashboard/settings/profile.php
+++ b/templates/dashboard/settings/profile.php
@@ -74,7 +74,7 @@ $max_filesize   = floatval( ini_get( 'upload_max_filesize' ) ) * ( 1024 * 1024 )
 			</span>
 			<div class="tutor_overlay">
 				<button class="tutor_cover_uploader tutor-btn tutor-btn-primary">
-					<i class="tutor-icon-camera tutor-mr-12" area-hidden="true"></i>
+					<i class="tutor-icon-camera tutor-mr-12" aria-hidden="true"></i>
 					<span><?php echo $profile_photo_id ? esc_html__( 'Update Cover Photo', 'tutor' ) : esc_html__( 'Upload Cover Photo', 'tutor' ); ?></span>
 				</button>
 			</div>

--- a/templates/dashboard/withdraw.php
+++ b/templates/dashboard/withdraw.php
@@ -60,7 +60,7 @@ $current_balance_formated         = tutor_utils()->tutor_price( $summary_data->c
 		<div class="tutor-row tutor-align-lg-center">
 			<div class="tutor-col-lg-auto tutor-mb-16 tutor-mb-lg-0">
 				<div class="tutor-round-box tutor-p-8">
-					<i class="tutor-icon-wallet" area-hidden="true"></i>
+					<i class="tutor-icon-wallet" aria-hidden="true"></i>
 				</div>
 			</div>
 
@@ -135,13 +135,13 @@ $current_balance_formated         = tutor_utils()->tutor_price( $summary_data->c
 			<div class="tutor-modal-window">
 				<div class="tutor-modal-content tutor-modal-content-white">
 					<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-						<span class="tutor-icon-times" area-hidden="true"></span>
+						<span class="tutor-icon-times" aria-hidden="true"></span>
 					</button>
 
 					<div class="tutor-modal-body">
 						<div class="tutor-py-20 tutor-px-24">
 							<div class="tutor-round-box tutor-round-box-lg tutor-mb-16">
-								<span class="tutor-icon-wallet" area-hidden="true"></span>
+								<span class="tutor-icon-wallet" aria-hidden="true"></span>
 							</div>
 
 							<div class="tutor-fs-4 tutor-fw-medium tutor-color-black tutor-mb-24"><?php esc_html_e( 'Withdrawal Request', 'tutor' ); ?></div>
@@ -160,7 +160,7 @@ $current_balance_formated         = tutor_utils()->tutor_price( $summary_data->c
 							</div>
 						</div>
 
-						<div class="tutor-mx-n32 tutor-my-32"><div class="tutor-hr" area-hidden="true"></div></div>
+						<div class="tutor-mx-n32 tutor-my-32"><div class="tutor-hr" aria-hidden="true"></div></div>
 
 						<form id="tutor-earning-withdraw-form" method="post">
 							<div class="tutor-py-20 tutor-px-24">
@@ -176,7 +176,7 @@ $current_balance_formated         = tutor_utils()->tutor_price( $summary_data->c
 									</div>
 
 									<div class="tutor-form-help tutor-d-flex tutor-align-center">
-										<span class="tutor-icon-circle-question-mark tutor-mr-8" area-hidden="true"></span>
+										<span class="tutor-icon-circle-question-mark tutor-mr-8" aria-hidden="true"></span>
 										<span><?php echo wp_kses( __( 'Minimum withdraw amount is', 'tutor' ) . ' ' . $formatted_min_withdraw_amount, array() ); ?></span>
 									</div>
 

--- a/templates/ecommerce/checkout-details.php
+++ b/templates/ecommerce/checkout-details.php
@@ -100,7 +100,7 @@ $show_coupon_box = Settings::is_coupon_usage_enabled() && ! $checkout_data->is_c
 											</h6>
 										</div>
 										<div class="tutor-checkout-coupon-badge <?php echo esc_attr( $item->is_coupon_applied ? '' : 'tutor-d-none' ); ?>">
-											<i class="tutor-icon-tag" area-hidden="true"></i>
+											<i class="tutor-icon-tag" aria-hidden="true"></i>
 											<span><?php echo esc_html( $item->is_coupon_applied ? $checkout_data->coupon_title : '' ); ?></span>
 										</div>
 									</div>
@@ -170,12 +170,12 @@ $show_coupon_box = Settings::is_coupon_usage_enabled() && ! $checkout_data->is_c
 
 			<div class="tutor-checkout-summary-item tutor-checkout-coupon-wrapper <?php echo esc_attr( $checkout_data->is_coupon_applied ? '' : 'tutor-d-none' ); ?>">
 				<div class="tutor-checkout-coupon-badge tutor-has-delete-button">
-					<i class="tutor-icon-tag" area-hidden="true"></i>
+					<i class="tutor-icon-tag" aria-hidden="true"></i>
 					<span><?php echo esc_html( $checkout_data->coupon_title ); ?></span>
 
 					<?php if ( $checkout_data->is_coupon_applied ) : ?>
 					<button type="button" id="tutor-checkout-remove-coupon" class="tutor-btn">
-						<i class="tutor-icon-times" area-hidden="true"></i>
+						<i class="tutor-icon-times" aria-hidden="true"></i>
 					</button>
 					<?php endif; ?>
 				</div>

--- a/templates/global/attachments.php
+++ b/templates/global/attachments.php
@@ -32,7 +32,7 @@ if ( is_array( $attachments ) && count( $attachments ) ) : ?>
 
 							<div class="tutor-col-auto">
 								<a href="<?php echo esc_url( $attachment->url ); ?>" class="tutor-iconic-btn tutor-iconic-btn-secondary tutor-stretched-link" <?php echo esc_attr( $open_mode_view ? $open_mode_view : "download={$attachment->name}" ); ?>>
-									<span class="tutor-icon-download" area-hidden="true"></span>
+									<span class="tutor-icon-download" aria-hidden="true"></span>
 								</a>
 							</div>
 						</div>

--- a/templates/loop/course-price-tutor.php
+++ b/templates/loop/course-price-tutor.php
@@ -59,7 +59,7 @@ if ( tutor_utils()->is_course_purchasable() ) {
 
 				<div class="tutor-course-booking-progress tutor-d-flex tutor-align-center">
 					<div class="tutor-mr-8">
-						<div class="tutor-progress-circle" style="--pro: <?php echo esc_html( $b_total ) . '%'; ?>" area-hidden="true"></div>
+						<div class="tutor-progress-circle" style="--pro: <?php echo esc_html( $b_total ) . '%'; ?>" aria-hidden="true"></div>
 					</div>
 					<div class="tutor-fs-7 tutor-fw-medium tutor-color-black">
 					<?php echo esc_html( $b_total ) . __( '% Booked', 'tutor' ); ?>

--- a/templates/loop/course-price-woocommerce.php
+++ b/templates/loop/course-price-woocommerce.php
@@ -59,7 +59,7 @@ if ( tutor_utils()->is_course_purchasable() ) {
 
                     <div class="tutor-course-booking-progress tutor-d-flex tutor-align-center">
                         <div class="tutor-mr-8">
-                            <div class="tutor-progress-circle" style="--pro: ' . esc_html( $b_total ) . '%;" area-hidden="true"></div>
+                            <div class="tutor-progress-circle" style="--pro: ' . esc_html( $b_total ) . '%;" aria-hidden="true"></div>
                         </div>
                         <div class="tutor-fs-7 tutor-fw-medium tutor-color-black">' .
 						esc_html( $b_total ) . __( '% Booked', 'tutor' ) . '

--- a/templates/loop/course-price.php
+++ b/templates/loop/course-price.php
@@ -60,7 +60,7 @@ if ( tutor_utils()->is_course_purchasable() && 'wc' === $monetization ) {
 
                     <div class="tutor-course-booking-progress tutor-d-flex tutor-align-center">
                         <div class="tutor-mr-8">
-                            <div class="tutor-progress-circle" style="--pro: ' . esc_html( $b_total ) . '%;" area-hidden="true"></div>
+                            <div class="tutor-progress-circle" style="--pro: ' . esc_html( $b_total ) . '%;" aria-hidden="true"></div>
                         </div>
                         <div class="tutor-fs-7 tutor-fw-medium tutor-color-black">' .
 						esc_html( $b_total ) . __( '% Booked', 'tutor' ) . '

--- a/templates/loop/enrolled-course-progress.php
+++ b/templates/loop/enrolled-course-progress.php
@@ -24,6 +24,6 @@ $course_progress = tutor_utils()->get_course_completed_percent( $course_id, 0, t
 		</span>
 	</div>
 	<div class="tutor-progress-bar tutor-mt-12" style="--tutor-progress-value:<?php echo esc_attr( $course_progress['completed_percent'] ); ?>%;">
-		<span class="tutor-progress-value" area-hidden="true"></span>
+		<span class="tutor-progress-value" aria-hidden="true"></span>
 	</div>
 </div>

--- a/templates/loop/meta.php
+++ b/templates/loop/meta.php
@@ -23,14 +23,14 @@ $course_students   = apply_filters( 'tutor_course_students', tutor_utils()->coun
 <div class="tutor-meta tutor-mt-12 tutor-mb-20">
 	<?php if ( tutor_utils()->get_option( 'enable_course_total_enrolled' ) ) : ?>
 		<div>
-			<span class="tutor-meta-icon tutor-icon-user-line" area-hidden="true"></span>
+			<span class="tutor-meta-icon tutor-icon-user-line" aria-hidden="true"></span>
 			<span class="tutor-meta-value"><?php echo esc_html( $course_students ); ?></span>
 		</div>
 	<?php endif; ?>
 
 	<?php if ( ! empty( $course_duration ) ) : ?>
 		<div>
-			<span class="tutor-icon-clock-line tutor-meta-icon" area-hidden="true"></span>
+			<span class="tutor-icon-clock-line tutor-meta-icon" aria-hidden="true"></span>
 			<span class="tutor-meta-value">
 				<?php
                     //phpcs:ignore --escaping through helper method

--- a/templates/metabox-wrapper.php
+++ b/templates/metabox-wrapper.php
@@ -12,7 +12,7 @@
 <div class="tutor-course-builder-section">
 	<div class="tutor-course-builder-section-title">
 		<span class="tutor-fs-5 tutor-fw-bold tutor-color-secondary">
-			<i class="tutor-icon-angle-up" area-hidden="true"></i>
+			<i class="tutor-icon-angle-up" aria-hidden="true"></i>
 			<span><?php echo esc_html( $title ); ?></span>
 		</span>
 	</div>

--- a/templates/modal/alert.php
+++ b/templates/modal/alert.php
@@ -22,7 +22,7 @@ $close   = isset( $close ) ? (bool) $close : true;
 		<div class="tutor-modal-content tutor-modal-content-white">
 			<?php if ( $close ) : ?>
 			<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-				<span class="tutor-icon-times" area-hidden="true"></span>
+				<span class="tutor-icon-times" aria-hidden="true"></span>
 			</button>
 			<?php endif; ?>
 			<div class="tutor-modal-body tutor-text-center">

--- a/templates/modal/confirm.php
+++ b/templates/modal/confirm.php
@@ -25,7 +25,7 @@ $close   = isset( $close ) ? (bool) $close : true;
 		<div class="tutor-modal-content tutor-modal-content-white">
 			<?php if ( $close ) : ?>
 			<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-				<span class="tutor-icon-times" area-hidden="true"></span>
+				<span class="tutor-icon-times" aria-hidden="true"></span>
 			</button>
 			<?php endif; ?>
 			<div class="tutor-modal-body tutor-text-center">

--- a/templates/shortcode/instructor-filter.php
+++ b/templates/shortcode/instructor-filter.php
@@ -40,13 +40,13 @@ foreach ( $attributes as $key => $value ) {
 		<aside class="tutor-col-lg-3 tutor-mb-32 tutor-mb-lg-0" tutor-instructors-filters>
 			<div class="tutor-d-flex tutor-align-center">
 				<div>
-					<span class="tutor-icon-slider-vertical tutor-color-primary tutor-mr-8" area-hidden="true"></span>
+					<span class="tutor-icon-slider-vertical tutor-color-primary tutor-mr-8" aria-hidden="true"></span>
 					<span class="tutor-fs-5 tutor-fw-medium tutor-color-black"><?php esc_html_e( 'Filters', 'tutor' ); ?></span>
 				</div>
 
 				<div class="tutor-ml-32">
 					<a href="#" class="tutor-btn tutor-btn-ghost" tutor-instructors-filter-clear>
-						<span class="tutor-icon-times tutor-mr-8" area-hidden="true"></span>
+						<span class="tutor-icon-times tutor-mr-8" aria-hidden="true"></span>
 						<span class="tutor-fw-medium"><?php esc_html_e( 'Clear', 'tutor' ); ?></span>
 					</a>
 				</div>
@@ -73,7 +73,7 @@ foreach ( $attributes as $key => $value ) {
 
 					<?php if ( $show_more ) : ?>
 						<a href="#" class="tutor-btn-show-more tutor-btn tutor-btn-ghost tutor-mt-32" data-tutor-toggle-more=".tutor-toggle-more-content">
-							<span class="tutor-toggle-btn-icon tutor-icon tutor-icon-plus tutor-mr-8" area-hidden="true"></span>
+							<span class="tutor-toggle-btn-icon tutor-icon tutor-icon-plus tutor-mr-8" aria-hidden="true"></span>
 							<span class="tutor-toggle-btn-text"><?php esc_html_e( 'Show More', 'tutor' ); ?></span>
 						</a>
 					<?php endif; ?>
@@ -89,7 +89,7 @@ foreach ( $attributes as $key => $value ) {
 				<div class="tutor-ratings tutor-ratings-lg tutor-ratings-selectable">
 						<div class="tutor-ratings-stars">
 							<?php for ( $i = 1; $i < 6; $i++ ) : ?>
-								<i class="tutor-icon-star-line" tutor-instructors-filter-rating data-value="<?php echo esc_attr( $i ); ?>" area-hidden="true"></i>
+								<i class="tutor-icon-star-line" tutor-instructors-filter-rating data-value="<?php echo esc_attr( $i ); ?>" aria-hidden="true"></i>
 							<?php endfor; ?> 
 						</div>
 						<span class="tutor-ratings-count tutor-instructor-rating-filter" tutor-instructors-filter-rating-count></span>  
@@ -99,12 +99,12 @@ foreach ( $attributes as $key => $value ) {
 		</aside>
 
 		<?php if ( $columns < 3 ) : ?>
-		<div class="tutor-col-1 tutor-d-none tutor-d-xl-block" area-hidden="true"></div>
+		<div class="tutor-col-1 tutor-d-none tutor-d-xl-block" aria-hidden="true"></div>
 		<?php endif; ?>
 
 		<main class="tutor-col-lg-9 tutor-col-xl-<?php echo $columns < 3 ? 8 : 9; ?>">
 			<div class="tutor-form-wrap tutor-mb-24">
-				<span class="tutor-icon-search tutor-form-icon" area-hidden="true"></span>
+				<span class="tutor-icon-search tutor-form-icon" aria-hidden="true"></span>
 				<input type="text" class="tutor-form-control" name="keyword" placeholder="<?php esc_html_e( 'Search any instructor...', 'tutor' ); ?>" tutor-instructors-filter-search />
 			</div>
 			<div class="tutor-d-flex tutor-align-center tutor-mb-24">

--- a/templates/single-content-loader.php
+++ b/templates/single-content-loader.php
@@ -97,7 +97,7 @@ if ( tutor()->lesson_post_type === $post->post_type ) {
 				</div>
 				<div class="list-item-progress tutor-my-16">
 					<div class="tutor-progress-bar tutor-mt-12" style="--tutor-progress-value:<?php echo esc_attr( $course_stats['completed_percent'] ); ?>%;">
-						<span class="tutor-progress-value" area-hidden="true"></span>
+						<span class="tutor-progress-value" aria-hidden="true"></span>
 					</div>
 				</div>
 			</div>

--- a/templates/single/common/footer.php
+++ b/templates/single/common/footer.php
@@ -30,7 +30,7 @@ $next_link       = $next_is_locked || ! $next_id ? '#' : get_the_permalink( $nex
 <div class="tutor-course-topic-single-footer tutor-px-32 tutor-py-12 tutor-mt-auto">
 	<div class="tutor-single-course-content-prev">
 		<a class="tutor-btn tutor-btn-secondary tutor-btn-sm" href="<?php echo esc_url( $prev_link ); ?>"<?php echo ! $previous_id ? ' disabled="disabled"' : ''; ?>>
-			<span class="tutor-icon-<?php echo is_rtl() ? 'next' : 'previous'; ?>" area-hidden="true"></span>
+			<span class="tutor-icon-<?php echo is_rtl() ? 'next' : 'previous'; ?>" aria-hidden="true"></span>
 			<span class="tutor-ml-8"><?php esc_html_e( 'Previous', 'tutor' ); ?></span>
 		</a>
 	</div>
@@ -38,7 +38,7 @@ $next_link       = $next_is_locked || ! $next_id ? '#' : get_the_permalink( $nex
 	<div class="tutor-single-course-content-next">
 		<a class="tutor-btn tutor-btn-secondary tutor-btn-sm" href="<?php echo esc_url( $next_link ); ?>"<?php echo ! $next_id ? ' disabled="disabled"' : ''; ?>>
 			<span class="tutor-mr-8"><?php esc_html_e( 'Next', 'tutor' ); ?></span>
-			<span class="tutor-icon-<?php echo is_rtl() ? 'previous' : 'next'; ?>" area-hidden="true"></span>
+			<span class="tutor-icon-<?php echo is_rtl() ? 'previous' : 'next'; ?>" aria-hidden="true"></span>
 		</a>
 	</div>
 </div>

--- a/templates/single/common/header.php
+++ b/templates/single/common/header.php
@@ -48,11 +48,11 @@ if ( CourseModel::can_autocomplete_course( $course_id, $user_id ) ) {
 ?>
 <div class="tutor-course-topic-single-header tutor-single-page-top-bar">
 	<a href="#" class="tutor-course-topics-sidebar-toggler tutor-iconic-btn tutor-iconic-btn-secondary tutor-d-none tutor-d-xl-inline-flex tutor-flex-shrink-0" tutor-course-topics-sidebar-toggler>
-		<span class="tutor-icon-left" area-hidden="true"></span>
+		<span class="tutor-icon-left" aria-hidden="true"></span>
 	</a>
 
 	<a href="<?php echo esc_url( get_the_permalink( $course_id ) ); ?>" class="tutor-iconic-btn tutor-d-flex tutor-d-xl-none">
-		<span class="tutor-icon-previous" area-hidden="true"></span>
+		<span class="tutor-icon-previous" aria-hidden="true"></span>
 	</a>
 
 	<div class="tutor-course-topic-single-header-title tutor-fs-6 tutor-ml-12 tutor-ml-xl-24">
@@ -92,13 +92,13 @@ if ( CourseModel::can_autocomplete_course( $course_id, $user_id ) ) {
 		}
 		?>
 		<a class="tutor-iconic-btn tutor-flex-shrink-0" href="<?php echo esc_url( get_the_permalink( $course_id ) ); ?>">
-			<span class="tutor-icon-times" area-hidden="true"></span>
+			<span class="tutor-icon-times" aria-hidden="true"></span>
 		</a>
 	</div>
 
 	<div class="tutor-ml-auto tutor-align-center tutor-d-block tutor-d-xl-none">
 		<a class="tutor-iconic-btn" href="#" tutor-course-topics-sidebar-offcanvas-toggler>
-			<span class="tutor-icon-hamburger-menu" area-hidden="true"></span>
+			<span class="tutor-icon-hamburger-menu" aria-hidden="true"></span>
 		</a>
 	</div>
 </div>

--- a/templates/single/course/course-benefits.php
+++ b/templates/single/course/course-benefits.php
@@ -25,7 +25,7 @@ if ( empty( $course_benefits ) ) {
 		<ul class="tutor-course-details-widget-list tutor-color-black tutor-fs-6 tutor-m-0 tutor-mt-16">
 			<?php foreach ( $course_benefits as $benefit ) : ?>
 				<li class="tutor-d-flex tutor-mb-12">
-					<span class="tutor-icon-bullet-point tutor-color-muted tutor-mt-2 tutor-mr-8 tutor-fs-8" area-hidden="true"></span>
+					<span class="tutor-icon-bullet-point tutor-color-muted tutor-mt-2 tutor-mr-8 tutor-fs-8" aria-hidden="true"></span>
 					<span><?php echo esc_html( $benefit ); ?></span>
 				</li>
 			<?php endforeach; ?>

--- a/templates/single/course/course-content.php
+++ b/templates/single/course/course-content.php
@@ -37,7 +37,7 @@ if ( tutor_utils()->get_option( 'enable_course_about', true, true ) ) {
 
 		<?php if ( $has_show_more ) : ?>
 		<a href="#" class="tutor-btn-show-more tutor-btn tutor-btn-ghost tutor-mt-32" data-tutor-toggle-more=".tutor-toggle-more-content">
-			<span class="tutor-toggle-btn-icon tutor-icon tutor-icon-plus tutor-mr-8" area-hidden="true"></span>
+			<span class="tutor-toggle-btn-icon tutor-icon tutor-icon-plus tutor-mr-8" aria-hidden="true"></span>
 			<span class="tutor-toggle-btn-text"><?php esc_html_e( 'Show More', 'tutor' ); ?></span>
 		</a>
 	<?php endif; ?>

--- a/templates/single/course/course-entry-box.php
+++ b/templates/single/course/course-entry-box.php
@@ -99,7 +99,7 @@ $login_url    = tutor_utils()->get_option( 'enable_tutor_native_login', null, tr
 							</span>
 						</div>
 						<div class="tutor-progress-bar tutor-mt-12" style="--tutor-progress-value:<?php echo esc_attr( $completed_percent ); ?>%;">
-							<span class="tutor-progress-value" area-hidden="true"></span>
+							<span class="tutor-progress-value" aria-hidden="true"></span>
 						</div>
 					</div>
 				</div>
@@ -234,7 +234,7 @@ $login_url    = tutor_utils()->get_option( 'enable_tutor_native_login', null, tr
 				?>
 					<div class="tutor-alert tutor-warning tutor-mt-28">
 						<div class="tutor-alert-text">
-							<span class="tutor-icon-circle-info tutor-alert-icon tutor-mr-12" area-hidden="true"></span>
+							<span class="tutor-icon-circle-info tutor-alert-icon tutor-mr-12" aria-hidden="true"></span>
 							<span>
 								<?php esc_html_e( 'This course is full right now. We limit the number of students to create an optimized and productive group dynamic.', 'tutor' ); ?>
 							</span>

--- a/templates/single/course/course-requirements.php
+++ b/templates/single/course/course-requirements.php
@@ -27,7 +27,7 @@ if ( is_array( $course_requirements ) && count( $course_requirements ) ) {
 		<ul class="tutor-course-details-widget-list tutor-fs-6 tutor-color-black">
 			<?php
 			foreach ( $course_requirements as $requirement ) {
-				echo '<li class="tutor-d-flex tutor-mb-12"><span class="tutor-icon-bullet-point tutor-color-muted tutor-mt-2 tutor-mr-8 tutor-fs-8" area-hidden="true"></span><span>' . esc_html( $requirement ) . '</span></li>';
+				echo '<li class="tutor-d-flex tutor-mb-12"><span class="tutor-icon-bullet-point tutor-color-muted tutor-mt-2 tutor-mr-8 tutor-fs-8" aria-hidden="true"></span><span>' . esc_html( $requirement ) . '</span></li>';
 			}
 			?>
 		</ul>

--- a/templates/single/course/course-target-audience.php
+++ b/templates/single/course/course-target-audience.php
@@ -26,7 +26,7 @@ if ( empty( $target_audience ) ) {
 		<ul class="tutor-course-details-widget-list tutor-fs-6 tutor-color-black">
 			<?php foreach ( $target_audience as $audience ) : ?>
 				<li class="tutor-d-flex tutor-mb-12">
-					<span class="tutor-icon-bullet-point tutor-color-muted tutor-mt-2 tutor-mr-8 tutor-fs-8" area-hidden="true"></span>
+					<span class="tutor-icon-bullet-point tutor-color-muted tutor-mt-2 tutor-mr-8 tutor-fs-8" aria-hidden="true"></span>
 					<span><?php echo esc_html( $audience ); ?></span>
 				</li>
 			<?php endforeach; ?>

--- a/templates/single/course/course-topics.php
+++ b/templates/single/course/course-topics.php
@@ -139,7 +139,7 @@ do_action( 'tutor_course/single/before/topics' );
 											<span class="tutor-course-content-list-item-duration tutor-fs-7 tutor-color-muted">
 												<?php echo esc_html( $play_time ? tutor_utils()->get_optimized_duration( $play_time ) : '' ); ?>
 											</span>
-											<span class="tutor-course-content-list-item-status <?php echo $is_locked ? 'tutor-icon-lock-line' : 'tutor-icon-eye-line'; ?> tutor-color-muted tutor-ml-20" area-hidden="true"></span>
+											<span class="tutor-course-content-list-item-status <?php echo $is_locked ? 'tutor-icon-lock-line' : 'tutor-icon-eye-line'; ?> tutor-color-muted tutor-ml-20" aria-hidden="true"></span>
 										</div>
 									</li>
 								<?php endwhile; ?>

--- a/templates/single/course/material-includes.php
+++ b/templates/single/course/material-includes.php
@@ -26,7 +26,7 @@ if ( is_array( $materials ) && count( $materials ) ) {
 		<ul class="tutor-course-details-widget-list tutor-fs-6 tutor-color-black">
 			<?php foreach ( $materials as $material ) : ?>
 				<li class="tutor-d-flex tutor-mb-12">
-					<span class="tutor-icon-bullet-point tutor-color-muted tutor-mt-2 tutor-mr-8 tutor-fs-8" area-hidden="true"></span>
+					<span class="tutor-icon-bullet-point tutor-color-muted tutor-mt-2 tutor-mr-8 tutor-fs-8" aria-hidden="true"></span>
 					<span><?php echo esc_html( $material ); ?></span>
 				</li>
 			<?php endforeach; ?>

--- a/templates/single/course/reviews.php
+++ b/templates/single/course/reviews.php
@@ -91,7 +91,7 @@ do_action( 'tutor_course/single/enrolled/before/reviews' );
 									<div class="tutor-col-auto">
 										<div class="tutor-ratings">
 											<div class="tutor-ratings-stars">
-												<span class="tutor-icon-star-line" area-hidden="true"></span>
+												<span class="tutor-icon-star-line" aria-hidden="true"></span>
 											</div>
 											<div class="tutor-ratings-average">
 												<?php echo esc_html( $key ); ?>
@@ -101,7 +101,7 @@ do_action( 'tutor_course/single/enrolled/before/reviews' );
 
 									<div class="tutor-col">
 										<div class="tutor-progress-bar tutor-ratings-progress-bar" style="--tutor-progress-value: <?php echo esc_attr( $rating_count_percent ); ?>%">
-											<span class="tutor-progress-value" area-hidden="true"></span>
+											<span class="tutor-progress-value" aria-hidden="true"></span>
 										</div>
 									</div>
 
@@ -120,7 +120,7 @@ do_action( 'tutor_course/single/enrolled/before/reviews' );
 				</div>
 			</div>
 
-			<div class="tutor-hr" area-hidden="true"></div>
+			<div class="tutor-hr" aria-hidden="true"></div>
 			
 			<div class="tutor-reviews tutor-card-list tutor-pagination-content-appendable">
 				<?php tutor_load_template( 'single.course.reviews-loop', array( 'reviews' => $reviews ) ); ?>

--- a/templates/single/lesson/complete_form.php
+++ b/templates/single/lesson/complete_form.php
@@ -25,7 +25,7 @@ if ( ! $is_completed_lesson ) {
 		<input type="hidden" value="tutor_complete_lesson" name="tutor_action" />
 		<button type="submit" class="tutor-topbar-mark-btn tutor-btn tutor-btn-primary tutor-ws-nowrap"
 			name="complete_lesson_btn" value="complete_lesson">
-			<span class="tutor-icon-circle-mark-line tutor-mr-8" area-hidden="true"></span>
+			<span class="tutor-icon-circle-mark-line tutor-mr-8" aria-hidden="true"></span>
 			<span><?php esc_html_e( 'Mark as Complete', 'tutor' ); ?></span>
 		</button>
 	</form>

--- a/templates/single/lesson/lesson_sidebar.php
+++ b/templates/single/lesson/lesson_sidebar.php
@@ -42,7 +42,7 @@ $is_public_course             = \TUTOR\Course_List::is_public( $course_id );
 	<span class="tutor-fs-6 tutor-fw-medium tutor-color-secondary"><?php esc_html_e( 'Course Content', 'tutor' ); ?></span>
 	<span class="tutor-d-block tutor-d-xl-none">
 		<a href="#" class="tutor-iconic-btn" tutor-hide-course-single-sidebar>
-			<span class="tutor-icon-times" area-hidden="true"></span>
+			<span class="tutor-icon-times" aria-hidden="true"></span>
 		</a>
 	</span>
 </div>
@@ -117,7 +117,7 @@ if ( $topics->have_posts() ) {
 						<div class="tutor-course-topic-item tutor-course-topic-item-quiz<?php echo ( get_the_ID() == $current_post->ID ) ? ' is-active' : ''; ?>" data-quiz-id="<?php echo esc_attr( $quiz->ID ); ?>">
 							<a href="<?php echo $show_permalink ? esc_url( get_permalink( $quiz->ID ) ) : '#'; ?>" data-quiz-id="<?php echo esc_attr( $quiz->ID ); ?>">
 								<div class="tutor-d-flex tutor-mr-32">
-									<span class="tutor-course-topic-item-icon tutor-icon-quiz-o tutor-mr-8 tutor-mt-2" area-hidden="true"></span>
+									<span class="tutor-course-topic-item-icon tutor-icon-quiz-o tutor-mr-8 tutor-mt-2" aria-hidden="true"></span>
 									<span class="tutor-course-topic-item-title tutor-fs-7 tutor-fw-medium">
 										<?php echo esc_html( $quiz->post_title ); ?>
 									</span>
@@ -178,7 +178,7 @@ if ( $topics->have_posts() ) {
 												readonly="readonly" 
 												<?php echo esc_attr( $attempt_ended ? 'checked="checked"' : '' ); ?> />
 									<?php else : ?>
-										<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" area-hidden="true"></i>
+										<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" aria-hidden="true"></i>
 									<?php endif; ?>
 								</div>
 							</a>
@@ -187,7 +187,7 @@ if ( $topics->have_posts() ) {
 						<div class="tutor-course-topic-item tutor-course-topic-item-assignment<?php echo esc_attr( get_the_ID() == $current_post->ID ? ' is-active' : '' ); ?>">
 							<a href="<?php echo $show_permalink ? esc_url( get_permalink( $post->ID ) ) : '#'; ?>" data-assignment-id="<?php echo esc_attr( $post->ID ); ?>">
 								<div class="tutor-d-flex tutor-mr-32">
-									<span class="tutor-course-topic-item-icon tutor-icon-assignment tutor-mr-8" area-hidden="true"></span>
+									<span class="tutor-course-topic-item-icon tutor-icon-assignment tutor-mr-8" aria-hidden="true"></span>
 									<span class="tutor-course-topic-item-title tutor-fs-7 tutor-fw-medium">
 										<?php echo esc_html( $post->post_title ); ?>
 									</span>
@@ -196,7 +196,7 @@ if ( $topics->have_posts() ) {
 									<?php if ( $show_permalink ) : ?>
 										<?php do_action( 'tutor/assignment/right_icon_area', $post, $lock_icon ); ?>
 									<?php else : ?>
-										<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" area-hidden="true"></i>
+										<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" aria-hidden="true"></i>
 									<?php endif; ?>
 								</div>
 							</a>
@@ -205,7 +205,7 @@ if ( $topics->have_posts() ) {
 						<div class="tutor-course-topic-item tutor-course-topic-item-zoom<?php echo esc_attr( ( get_the_ID() == $current_post->ID ) ? ' is-active' : '' ); ?>">
 							<a href="<?php echo $show_permalink ? esc_url( get_permalink( $post->ID ) ) : '#'; ?>">
 								<div class="tutor-d-flex tutor-mr-32">
-									<span class="tutor-course-topic-item-icon tutor-icon-brand-zoom-o tutor-mr-8 tutor-mt-2" area-hidden="true"></span>
+									<span class="tutor-course-topic-item-icon tutor-icon-brand-zoom-o tutor-mr-8 tutor-mt-2" aria-hidden="true"></span>
 									<span class="tutor-course-topic-item-title tutor-fs-7 tutor-fw-medium">
 										<?php echo esc_html( $post->post_title ); ?>
 									</span>
@@ -214,7 +214,7 @@ if ( $topics->have_posts() ) {
 									<?php if ( $show_permalink ) : ?>
 										<?php do_action( 'tutor/zoom/right_icon_area', $post->ID, $lock_icon ); ?>
 									<?php else : ?>
-										<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" area-hidden="true"></i>
+										<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" aria-hidden="true"></i>
 									<?php endif; ?>
 								</div>
 							</a>
@@ -223,7 +223,7 @@ if ( $topics->have_posts() ) {
 						<div class="tutor-course-topic-item tutor-course-topic-item-zoom<?php echo esc_attr( get_the_ID() == $current_post->ID ? ' is-active' : '' ); ?>">
 							<a href="<?php echo $show_permalink ? esc_url( get_permalink( $post->ID ) ) : '#'; ?>">
 								<div class="tutor-d-flex tutor-mr-32">
-									<span class="tutor-course-topic-item-icon tutor-icon-brand-google-meet tutor-mr-8 tutor-mt-2" area-hidden="true"></span>
+									<span class="tutor-course-topic-item-icon tutor-icon-brand-google-meet tutor-mr-8 tutor-mt-2" aria-hidden="true"></span>
 									<span class="tutor-course-topic-item-title tutor-fs-7 tutor-fw-medium">
 										<?php echo esc_html( $post->post_title ); ?>
 									</span>
@@ -232,7 +232,7 @@ if ( $topics->have_posts() ) {
 									<?php if ( $show_permalink ) : ?>
 										<?php do_action( 'tutor/google_meet/right_icon_area', $post->ID, false ); ?>
 									<?php else : ?>
-										<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" area-hidden="true"></i>
+										<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" aria-hidden="true"></i>
 									<?php endif; ?>
 								</div>
 							</a>
@@ -251,13 +251,13 @@ if ( $topics->have_posts() ) {
 								<div class="tutor-d-flex tutor-mr-32">
 									<?php
 									$tutor_lesson_type_icon = $play_time ? 'brand-youtube-bold' : 'document-text';
-									$markup                 = '<span class="tutor-course-topic-item-icon tutor-icon-' . $tutor_lesson_type_icon . ' tutor-mr-8 tutor-mt-2" area-hidden="true"></span>';
+									$markup                 = '<span class="tutor-course-topic-item-icon tutor-icon-' . $tutor_lesson_type_icon . ' tutor-mr-8 tutor-mt-2" aria-hidden="true"></span>';
 									echo wp_kses(
 										$markup,
 										array(
 											'span' => array(
 												'class' => true,
-												'area-hidden' => true,
+												'aria-hidden' => true,
 											),
 										)
 									);
@@ -296,13 +296,13 @@ if ( $topics->have_posts() ) {
 											)
 										);
 									} else {
-										$markup = '<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" area-hidden="true"></i>';
+										$markup = '<i class="tutor-icon-lock-line tutor-fs-7 tutor-color-muted tutor-mr-4" aria-hidden="true"></i>';
 										echo wp_kses(
 											$markup,
 											array(
 												'i' => array(
 													'class' => true,
-													'area-hidden' => true,
+													'aria-hidden' => true,
 												),
 											)
 										);

--- a/templates/single/password-protected.php
+++ b/templates/single/password-protected.php
@@ -23,7 +23,7 @@ $password_error = get_transient( 'tutor_post_password_error' );
 		<div class="tutor-modal-window" style="max-width: 834px;">
 			<div class="tutor-modal-content tutor-bg-white tutor-p-40">
 				<a href="<?php echo esc_url( tutor_utils()->course_archive_page_url() ); ?>" class="tutor-iconic-btn tutor-modal-close-o">
-					<span class="tutor-icon-times" area-hidden="true"></span>
+					<span class="tutor-icon-times" aria-hidden="true"></span>
 				</a>
 				<div class="tutor-row">
 					<div class="tutor-col-md-7">

--- a/templates/single/quiz/parts/question.php
+++ b/templates/single/quiz/parts/question.php
@@ -200,7 +200,7 @@
 							if ( $show_previous_button && $previous_question ) {
 								?>
 										<button type="button" class="tutor-btn tutor-btn-outline-primary tutor-btn-md tutor-quiz-answer-previous-btn tutor-mr-20">
-											<span class="tutor-icon-previous tutor-mr-8" area-hidden="true"></span> <?php esc_html_e( 'Back', 'tutor' ); ?>
+											<span class="tutor-icon-previous tutor-mr-8" aria-hidden="true"></span> <?php esc_html_e( 'Back', 'tutor' ); ?>
 										</button>
 									<?php
 							}

--- a/templates/single/video/embedded.php
+++ b/templates/single/video/embedded.php
@@ -21,7 +21,7 @@ do_action( 'tutor_lesson/single/before/video/embedded' );
 <?php if ( $video_info ) : ?>
 	<div class="tutor-video-player">
 		<input type="hidden" id="tutor_video_tracking_information" value="<?php echo esc_attr( json_encode( $jsonData ?? null ) ); ?>">
-		<div class="loading-spinner" area-hidden="true"></div>
+		<div class="loading-spinner" aria-hidden="true"></div>
 		<div class="tutor-ratio tutor-ratio-16x9">
 			<?php
 			echo wp_kses(

--- a/templates/single/video/external_url.php
+++ b/templates/single/video/external_url.php
@@ -24,7 +24,7 @@ do_action( 'tutor_lesson/single/before/video/external_url' );
 <?php if ( $video_info ) : ?>
 	<div class="tutor-video-player">
 		<input type="hidden" id="tutor_video_tracking_information" value="<?php echo esc_attr( json_encode( $jsonData ?? null ) ); ?>">
-		<div class="loading-spinner" area-hidden="true"></div>
+		<div class="loading-spinner" aria-hidden="true"></div>
 		<video poster="<?php echo esc_url( $poster_url ); ?>" class="tutorPlayer" playsinline controls >
 			<source src="<?php echo esc_url( tutor_utils()->array_get( 'source_external_url', $video_info ) ); ?>" type="<?php echo esc_attr( tutor_utils()->avalue_dot( 'type', $video_info ) ); ?>">
 		</video>

--- a/templates/single/video/html5.php
+++ b/templates/single/video/html5.php
@@ -26,7 +26,7 @@ do_action( 'tutor_lesson/single/before/video/html5' );
 <?php if ( $video_url ) : ?>
 	<div class="tutor-video-player">
 		<input type="hidden" id="tutor_video_tracking_information" value="<?php echo esc_attr( json_encode( $jsonData ?? null ) ); ?>">
-		<div class="loading-spinner" area-hidden="true"></div>
+		<div class="loading-spinner" aria-hidden="true"></div>
 		<video poster="<?php echo esc_url( $poster_url ); ?>" class="tutorPlayer" playsinline controls >
 			<source src="<?php echo esc_url( $video_url ); ?>" type="<?php echo esc_attr( tutor_utils()->avalue_dot( 'type', $video_info_array ) ); ?>">
 		</video>

--- a/templates/single/video/shortcode.php
+++ b/templates/single/video/shortcode.php
@@ -19,7 +19,7 @@ $video_info = $video_info ? (array) $video_info : array();
 do_action( 'tutor_lesson/single/before/video/shortcode' );
 ?>
 	<div class="tutor-video-player">
-		<div class="loading-spinner" area-hidden="true"></div>
+		<div class="loading-spinner" aria-hidden="true"></div>
 		<div class="tutor-ratio tutor-ratio-16x9">
 			<?php echo do_shortcode( tutor_utils()->array_get( 'source_shortcode', $video_info ) ); ?>
 		</div>

--- a/templates/single/video/vimeo.php
+++ b/templates/single/video/vimeo.php
@@ -30,7 +30,7 @@ do_action( 'tutor_lesson/single/before/video/vimeo' );
 
 <?php if ( $video_id ) : ?>
 	<div class="tutor-video-player">
-		<div class="loading-spinner" area-hidden="true"></div>
+		<div class="loading-spinner" aria-hidden="true"></div>
 		<div class="<?php echo $disable_default_player_vimeo ? 'plyr__video-embed tutorPlayer' : 'tutor-ratio tutor-ratio-16x9'; ?>">
 			<?php if ( ! $disable_default_player_vimeo ) : ?>
 				<iframe src="https://player.vimeo.com/video/<?php echo esc_attr( $video_id ); ?>" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>

--- a/templates/single/video/youtube.php
+++ b/templates/single/video/youtube.php
@@ -23,7 +23,7 @@ do_action( 'tutor_lesson/single/before/video/youtube' );
 
 <?php if ( $youtube_video_id ) : ?>
 	<div class="tutor-video-player">
-		<div class="loading-spinner" area-hidden="true"></div>
+		<div class="loading-spinner" aria-hidden="true"></div>
 		<div class="<?php echo $disable_default_player_youtube ? 'plyr__video-embed tutorPlayer' : 'tutor-ratio tutor-ratio-16x9'; ?>">
 			<?php if ( ! $disable_default_player_youtube ) : ?>
 				<iframe src="https://www.youtube.com/embed/<?php echo esc_attr( $youtube_video_id ); ?>" frameborder="0" allowfullscreen allowtransparency allow="autoplay"></iframe>

--- a/views/course-share.php
+++ b/views/course-share.php
@@ -28,7 +28,7 @@ $share_config = array(
 	<div class="tutor-modal-window">
 		<div class="tutor-modal-content tutor-modal-content-white">
 			<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-				<span class="tutor-icon-times" area-hidden="true"></span>
+				<span class="tutor-icon-times" aria-hidden="true"></span>
 			</button>
 			<div class="tutor-modal-body">
 				<div class="tutor-fs-5 tutor-fw-medium tutor-color-black tutor-mb-16">

--- a/views/elements/bulk-confirm-popup.php
+++ b/views/elements/bulk-confirm-popup.php
@@ -16,7 +16,7 @@
 	<div class="tutor-modal-window">
 		<div class="tutor-modal-content tutor-modal-content-white">
 			<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-				<span class="tutor-icon-times" area-hidden="true"></span>
+				<span class="tutor-icon-times" aria-hidden="true"></span>
 			</button>
 
 			<div class="tutor-modal-body tutor-text-center">

--- a/views/elements/common-confirm-popup.php
+++ b/views/elements/common-confirm-popup.php
@@ -19,7 +19,7 @@
 	<div class="tutor-modal-window">
 		<div class="tutor-modal-content tutor-modal-content-white">
 			<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-				<span class="tutor-icon-times" area-hidden="true"></span>
+				<span class="tutor-icon-times" aria-hidden="true"></span>
 			</button>
 
 			<div class="tutor-modal-body tutor-text-center">

--- a/views/elements/filters.php
+++ b/views/elements/filters.php
@@ -82,7 +82,7 @@ if ( isset( $data ) ) : ?>
 
 						?>
 						<a class="tutor-btn tutor-btn-ghost tutor-mt-sm-28" href="<?php echo esc_url( $url ); ?>">
-							<i class="tutor-icon-refresh tutor-mr-8" area-hidden="true"></i> <?php esc_html_e( 'Reset', 'tutor' ); ?>
+							<i class="tutor-icon-refresh tutor-mr-8" aria-hidden="true"></i> <?php esc_html_e( 'Reset', 'tutor' ); ?>
 						</a>
 					</div>
 					<?php
@@ -214,7 +214,7 @@ if ( isset( $data ) ) : ?>
 								<?php esc_html_e( 'Search', 'tutor' ); ?>
 							</label>
 							<div class="tutor-form-wrap">
-								<span class="tutor-form-icon"><span class="tutor-icon-search" area-hidden="true"></span></span>
+								<span class="tutor-form-icon"><span class="tutor-icon-search" aria-hidden="true"></span></span>
 								<input type="search" class="tutor-form-control" id="tutor-backend-filter-search" name="search" placeholder="<?php esc_html_e( 'Search...', 'tutor' ); ?>" value="<?php echo esc_html( wp_unslash( $search ) ); ?>" />
 							</div>
 						</form>

--- a/views/elements/list-filters.php
+++ b/views/elements/list-filters.php
@@ -151,7 +151,7 @@ if ( isset( $data ) ) : ?>
 
 				<form action="" method="get" id="tutor-admin-search-filter-form">
 					<div class="tutor-form-wrap">
-						<span class="tutor-form-icon"><span class="tutor-icon-search" area-hidden="true"></span></span>
+						<span class="tutor-form-icon"><span class="tutor-icon-search" aria-hidden="true"></span></span>
 						<input type="search" class="tutor-form-control" id="tutor-backend-filter-search" name="search" placeholder="<?php esc_html_e( 'Search...', 'tutor' ); ?>" value="<?php echo esc_html( wp_unslash( $search_query ) ); ?>" />
 					</div>
 				</form>

--- a/views/elements/list-navbar.php
+++ b/views/elements/list-navbar.php
@@ -19,7 +19,7 @@ if ( isset( $data ) && count( $data ) ) : ?>
 				</span>
 
 				<?php if ( isset( $data['sub_page_title'] ) ) : ?>
-					<span class="tutor-mx-8" area-hidden="true">/</span>
+					<span class="tutor-mx-8" aria-hidden="true">/</span>
 					<span class="tutor-fs-7 tutor-color-muted">
 						<?php echo esc_html( $data['sub_page_title'] ); ?>
 					</span>

--- a/views/elements/navbar.php
+++ b/views/elements/navbar.php
@@ -20,7 +20,7 @@ if ( isset( $data ) && count( $data ) ) : ?>
 						</span>
 
 						<?php if ( isset( $data['sub_page_title'] ) ) : ?>
-							<span class="tutor-mx-8" area-hidden="true">/</span>
+							<span class="tutor-mx-8" aria-hidden="true">/</span>
 							<span class="tutor-fs-7 tutor-color-muted">
 								<?php echo esc_html( $data['sub_page_title'] ); ?>
 							</span>

--- a/views/fragments/announcement-list.php
+++ b/views/fragments/announcement-list.php
@@ -40,7 +40,7 @@ function tutor_announcement_modal( $id, $title, $courses, $announcement = null )
 						<?php echo esc_html( $title ); ?>
 					</div>
 					<button class="tutor-modal-close tutor-iconic-btn" data-tutor-modal-close role="button">
-						<span class="tutor-icon-times" area-hidden="true"></span>
+						<span class="tutor-icon-times" aria-hidden="true"></span>
 					</button>
 				</div>
 
@@ -119,13 +119,13 @@ function tutor_announcement_modal_details( $id, $update_modal_id, $delete_modal_
 		<div class="tutor-modal-window">
 			<div class="tutor-modal-content tutor-modal-content-white">
 				<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-					<span class="tutor-icon-times" area-hidden="true"></span>
+					<span class="tutor-icon-times" aria-hidden="true"></span>
 				</button>
 
 				<div class="tutor-modal-body">
 					<div class="tutor-py-20 tutor-px-24">
 						<span class="tutor-round-box tutor-round-box-lg tutor-mb-32">
-							<i class="tutor-icon-bullhorn" area-hidden="true"></i>
+							<i class="tutor-icon-bullhorn" aria-hidden="true"></i>
 						</span>
 						<div class="tutor-fs-4 tutor-fw-medium tutor-color-black tutor-mb-24">
 							<?php echo esc_html( $announcement->post_title ); ?>
@@ -135,7 +135,7 @@ function tutor_announcement_modal_details( $id, $update_modal_id, $delete_modal_
 						</div>
 					</div>
 
-					<div class="tutor-mx-n32 tutor-my-32"><div class="tutor-hr" area-hidden="true"></div></div>
+					<div class="tutor-mx-n32 tutor-my-32"><div class="tutor-hr" aria-hidden="true"></div></div>
 
 					<div class="tutor-py-20 tutor-px-24">
 						<div class="tutor-row tutor-mb-60">
@@ -202,7 +202,7 @@ function tutor_announcement_modal_delete( $id, $announcment_id, $row_id ) {
 		<div class="tutor-modal-window">
 			<div class="tutor-modal-content tutor-modal-content-white">
 				<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-					<span class="tutor-icon-times" area-hidden="true"></span>
+					<span class="tutor-icon-times" aria-hidden="true"></span>
 				</button>
 
 				<div class="tutor-modal-body tutor-text-center">
@@ -312,18 +312,18 @@ $courses = ( current_user_can( 'administrator' ) ) ? CourseModel::get_courses() 
 
 							<div class="tutor-dropdown-parent">
 								<button type="button" class="tutor-iconic-btn" action-tutor-dropdown="toggle">
-									<span class="tutor-icon-kebab-menu" area-hidden="true"></span>
+									<span class="tutor-icon-kebab-menu" aria-hidden="true"></span>
 								</button>
 								<ul class="tutor-dropdown tutor-dropdown-dark">
 									<li>
 										<a href="#" class="tutor-dropdown-item" data-tutor-modal-target="<?php echo esc_attr( $update_modal_id ); ?>">
-											<i class="tutor-icon-edit tutor-mr-8" area-hidden="true"></i>
+											<i class="tutor-icon-edit tutor-mr-8" aria-hidden="true"></i>
 											<span><?php esc_html_e( 'Edit', 'tutor' ); ?></span>
 										</a>
 									</li>
 									<li>
 										<a href="#" class="tutor-dropdown-item" data-tutor-modal-target="<?php echo esc_attr( $delete_modal_id ); ?>">
-											<i class="tutor-icon-trash-can-bold tutor-mr-8" area-hidden="true"></i>
+											<i class="tutor-icon-trash-can-bold tutor-mr-8" aria-hidden="true"></i>
 											<span><?php esc_html_e( 'Delete', 'tutor' ); ?></span>
 										</a>
 									</li>

--- a/views/fragments/attachments.php
+++ b/views/fragments/attachments.php
@@ -34,7 +34,7 @@ $size_below  = isset( $data['size_below'] ) && true == $data['size_below'];
 
 							<div class="tutor-col-auto">
 								<span class="tutor-delete-attachment tutor-iconic-btn tutor-iconic-btn-secondary" role="button">
-									<span class="tutor-icon-times" area-hidden="true"></span>
+									<span class="tutor-icon-times" aria-hidden="true"></span>
 								</span>
 							</div>
 						</div>

--- a/views/fragments/quiz-list-single.php
+++ b/views/fragments/quiz-list-single.php
@@ -20,11 +20,11 @@
 			<?php do_action( 'tutor_course_builder_before_quiz_btn_action', $data['quiz_id'] ); ?>
 			<?php if ( $data['topic_id'] > 0 ) : ?>
 				<a href="javascript:;" class="open-tutor-quiz-modal tutor-iconic-btn" data-quiz-id="<?php echo esc_attr( $data['quiz_id'] ); ?>" data-topic-id="<?php echo esc_attr( $data['topic_id'] ); ?>"> 
-					<span class="tutor-icon-edit" area-hidden="true"></span>
+					<span class="tutor-icon-edit" aria-hidden="true"></span>
 				</a>
 			<?php endif; ?>
 			<a href="javascript:;" class="tutor-delete-quiz-btn tutor-iconic-btn" data-quiz-id="<?php echo esc_attr( $data['quiz_id'] ); ?>">
-				<span class="tutor-icon-trash-can-line" area-hidden="true"></span>
+				<span class="tutor-icon-trash-can-line" aria-hidden="true"></span>
 			</a>
 		</div>
 	</div>

--- a/views/fragments/thumbnail-uploader.php
+++ b/views/fragments/thumbnail-uploader.php
@@ -57,7 +57,7 @@ $border_color  = ! empty( $data['border'] ) ? $data['border'] : '#eff1f7';
 			</div>
 
 			<button type="button" class="tutor-btn tutor-btn-primary tutor-btn-sm tutor-mt-16 tutor-thumbnail-upload-button">
-				<span class="tutor-icon-image-landscape tutor-mr-8" area-hidden="true"></span>
+				<span class="tutor-icon-image-landscape tutor-mr-8" aria-hidden="true"></span>
 				<span><?php esc_html_e( 'Upload Image', 'tutor' ); ?></span>
 			</button>
 		</div>

--- a/views/modal/login.php
+++ b/views/modal/login.php
@@ -15,7 +15,7 @@ $lost_pass = apply_filters( 'tutor_lostpassword_url', wp_lostpassword_url() );
 	<div class="tutor-modal-window tutor-modal-window-sm">
 		<div class="tutor-modal-content tutor-modal-content-white">
 			<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-				<span class="tutor-icon-times" area-hidden="true"></span>
+				<span class="tutor-icon-times" aria-hidden="true"></span>
 			</button>
 
 			<div class="tutor-modal-body">

--- a/views/modal/review.php
+++ b/views/modal/review.php
@@ -15,7 +15,7 @@
 	<div class="tutor-modal-window">
 		<div class="tutor-modal-content tutor-modal-content-white">
 			<button type="button" class="tutor-iconic-btn tutor-modal-close-o">
-				<span class="tutor-icon-times" area-hidden="true"></span>
+				<span class="tutor-icon-times" aria-hidden="true"></span>
 			</button>
 
 			<div class="tutor-modal-body tutor-text-center">

--- a/views/options/field-types/toggle_switch_button_thumb.php
+++ b/views/options/field-types/toggle_switch_button_thumb.php
@@ -26,6 +26,6 @@ $field_id = 'field_' . $field['key'];
 			<span class="tutor-form-toggle-control"></span>
 		</label>
 		<button class="tutor-btn tutor-btn-outline-primary tutor-btn-sm tutor-btn-sm"><?php esc_html_e( 'Edit', 'tutor' ); ?></button>
-		<span class="icon-trash-can-line" area-hidden="true"></span>
+		<span class="icon-trash-can-line" aria-hidden="true"></span>
 	</div>
 </div>

--- a/views/options/settings.php
+++ b/views/options/settings.php
@@ -22,7 +22,7 @@ $monetize_by = tutor_utils()->get_option( 'monetize_by' );
 			</div>
 			<div class="tutor-col-md-5 tutor-col-xl-6 tutor-mb-24 tutor-mb-md-0">
 				<div class="tutor-options-search tutor-form-wrap">
-					<span class="tutor-icon-search tutor-form-icon" area-hidden="true"></span>
+					<span class="tutor-icon-search tutor-form-icon" aria-hidden="true"></span>
 					<input type="search" accesskey="s" autofocus autocomplete="off" id="search_settings" class="tutor-form-control tutor-form-control-lg" placeholder="<?php esc_html_e( 'Search ...⌃⌥ + S or Alt+S for shortcut', 'tutor' ); ?>" />
 					<div class="search-popup-opener search_result"></div>
 				</div>
@@ -52,7 +52,7 @@ $monetize_by = tutor_utils()->get_option( 'monetize_by' );
 									?>
 									<li class="tutor-nav-item">
 										<a class="tutor-nav-link<?php echo esc_attr( $active_class ); ?>" data-page="<?php echo esc_attr( $get_page ); ?>" data-tab="<?php echo esc_attr( $key ); ?>">
-											<span class="<?php echo esc_attr( $section['icon'] ); ?>" area-hidden="true"></span>
+											<span class="<?php echo esc_attr( $section['icon'] ); ?>" aria-hidden="true"></span>
 											<span class="tutor-ml-12 tutor-d-sm-none tutor-d-lg-block" tutor-option-label><?php echo esc_html( $section['label'] ); ?></span>
 										</a>
 										<?php
@@ -74,7 +74,7 @@ $monetize_by = tutor_utils()->get_option( 'monetize_by' );
 												?>
 												<li class="tutor-nav-item">
 													<a class="tutor-nav-link<?php echo esc_attr( $active_class ); ?>" data-page="<?php echo esc_attr( $get_page ); ?>" data-tab="<?php echo esc_attr( $key ); ?>">
-														<span class="<?php echo esc_attr( $menu_item['icon'] ); ?> tutor-mr-12 tutor-d-lg-none" area-hidden="true"></span>
+														<span class="<?php echo esc_attr( $menu_item['icon'] ); ?> tutor-mr-12 tutor-d-lg-none" aria-hidden="true"></span>
 														<span class="tutor-d-sm-none tutor-d-lg-block" tutor-option-label><?php echo esc_html( $menu_item['label'] ); ?></span>
 													</a>
 												</li>

--- a/views/options/template/color_picker.php
+++ b/views/options/template/color_picker.php
@@ -102,7 +102,7 @@ $fields_groups = is_array( $blocks['fields_group'] ) ? $blocks['fields_group'] :
 
 			<div class="tutor-text-center tutor-mt-32">
 				<a href="#" class="tutor-btn-show-more tutor-btn tutor-btn-ghost" data-tutor-toggle-more=".tutor-toggle-more-content">
-					<span class="tutor-toggle-btn-icon tutor-icon tutor-icon-plus tutor-mr-8" area-hidden="true"></span>
+					<span class="tutor-toggle-btn-icon tutor-icon tutor-icon-plus tutor-mr-8" aria-hidden="true"></span>
 					<span class="tutor-toggle-btn-text"><?php esc_html_e( 'Show More', 'tutor' ); ?></span>
 				</a>
 			</div>

--- a/views/options/template/common/modal-confirm.php
+++ b/views/options/template/common/modal-confirm.php
@@ -16,7 +16,7 @@
 	<div class="tutor-modal-window">
 		<div class="tutor-modal-content tutor-modal-content-white">
 			<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-				<span class="tutor-icon-times" area-hidden="true"></span>
+				<span class="tutor-icon-times" aria-hidden="true"></span>
 			</button>
 			<div class="tutor-modal-body tutor-text-center">
 				<div class="tutor-px-lg-48 tutor-py-lg-24">

--- a/views/options/template/common/reset-button-template.php
+++ b/views/options/template/common/reset-button-template.php
@@ -19,7 +19,7 @@ $section_slug  = isset( $section['slug'] ) && ! empty( $section['slug'] ) ? esc_
 			data-reset="<?php echo esc_attr( $section_slug ); ?>"
 			data-heading="<?php esc_html_e( 'Reset to Default Settings?', 'tutor' ); ?>"
 			data-message="<?php esc_html_e( 'WARNING! This will overwrite all customized settings of this section and reset them to default. Proceed with caution.', 'tutor' ); ?>" disabled>
-			<i class="btn-icon tutor-icon-refresh tutor-mr-8" area-hidden="true"></i>
+			<i class="btn-icon tutor-icon-refresh tutor-mr-8" aria-hidden="true"></i>
 			<?php esc_html_e( 'Reset to Default', 'tutor' ); ?>
 	</button>
 </div>

--- a/views/options/tools.php
+++ b/views/options/tools.php
@@ -29,7 +29,7 @@
 						?>
 							<li class="tutor-nav-item">
 								<a class="tutor-nav-link<?php echo esc_attr( $active_class ); ?>" href="<?php echo esc_url( $page_url ); ?>">
-									<span class="<?php echo esc_attr( $section['icon'] ); ?>" area-hidden="true"></span>
+									<span class="<?php echo esc_attr( $section['icon'] ); ?>" aria-hidden="true"></span>
 									<span class="tutor-ml-12 tutor-d-sm-none tutor-d-lg-block"><?php echo esc_html( $section['label'] ); ?></span>
 								</a>
 							</li>

--- a/views/pages/announcements.php
+++ b/views/pages/announcements.php
@@ -110,7 +110,7 @@ $filters = array(
 			<div class="tutor-row tutor-align-lg-center">
 				<div class="tutor-col-lg-auto tutor-mb-16 tutor-mb-lg-0">
 					<div class="tutor-round-box">
-						<i class="tutor-icon-bullhorn tutor-fs-3" area-hidden="true"></i>
+						<i class="tutor-icon-bullhorn tutor-fs-3" aria-hidden="true"></i>
 					</div>
 				</div>
 

--- a/views/pages/course-list.php
+++ b/views/pages/course-list.php
@@ -438,18 +438,18 @@ if ( 0 === $total_courses_count ) {
 											</a>
 											<div class="tutor-dropdown-parent">
 												<button type="button" class="tutor-iconic-btn" action-tutor-dropdown="toggle">
-													<span class="tutor-icon-kebab-menu" area-hidden="true"></span>
+													<span class="tutor-icon-kebab-menu" aria-hidden="true"></span>
 												</button>
 												<div id="table-dashboard-course-list-<?php echo esc_attr( $post->ID ); ?>" class="tutor-dropdown tutor-dropdown-dark tutor-text-left">
 													<?php do_action( 'tutor_admin_befor_course_list_action', $post->ID ); ?>
 													<a class="tutor-dropdown-item" href="<?php echo esc_url( $edit_link ); ?>">
-														<i class="tutor-icon-edit tutor-mr-8" area-hidden="true"></i>
+														<i class="tutor-icon-edit tutor-mr-8" aria-hidden="true"></i>
 														<span><?php esc_html_e( 'Edit', 'tutor' ); ?></span>
 													</a>
 													<?php do_action( 'tutor_admin_middle_course_list_action', $post->ID ); ?>
 													<?php if ( $show_course_delete ) : ?>
 													<a href="javascript:void(0)" class="tutor-dropdown-item tutor-admin-course-delete" data-tutor-modal-target="tutor-common-confirmation-modal" data-id="<?php echo esc_attr( $post->ID ); ?>">
-														<i class="tutor-icon-trash-can-bold tutor-mr-8" area-hidden="true"></i>
+														<i class="tutor-icon-trash-can-bold tutor-mr-8" aria-hidden="true"></i>
 														<span><?php esc_html_e( 'Delete Permanently', 'tutor' ); ?></span>
 													</a>
 													<?php endif; ?>

--- a/views/pages/ecommerce/coupon-list.php
+++ b/views/pages/ecommerce/coupon-list.php
@@ -208,12 +208,12 @@ $filters = array(
 											<?php if ( 'trash' === $active_tab ) : ?>
 											<div class="tutor-dropdown-parent">
 												<button type="button" class="tutor-iconic-btn" action-tutor-dropdown="toggle">
-													<span class="tutor-icon-kebab-menu" area-hidden="true"></span>
+													<span class="tutor-icon-kebab-menu" aria-hidden="true"></span>
 												</button>
 												<div id="table-dashboard-coupon-list-<?php echo esc_attr( $coupon->id ); ?>" class="tutor-dropdown tutor-dropdown-dark tutor-text-left">
 													<a href="javascript:void(0)" class="tutor-dropdown-item tutor-delete-permanently"
 														data-tutor-modal-target="tutor-common-confirmation-modal" data-action="tutor_coupon_permanent_delete" data-id="<?php echo esc_attr( $coupon->id ); ?>">
-														<i class="tutor-icon-trash-can-bold tutor-mr-8" area-hidden="true"></i>
+														<i class="tutor-icon-trash-can-bold tutor-mr-8" aria-hidden="true"></i>
 														<span>
 															<?php esc_html_e( 'Delete Permanently', 'tutor' ); ?>
 														</span>

--- a/views/pages/instructors.php
+++ b/views/pages/instructors.php
@@ -283,7 +283,7 @@ $filters = array(
 						<?php esc_html_e( 'Add New Instructor', 'tutor' ); ?>
 					</div>
 					<button class="tutor-iconic-btn tutor-modal-close" data-tutor-modal-close>
-						<span class="tutor-icon-times" area-hidden="true"></span>
+						<span class="tutor-icon-times" aria-hidden="true"></span>
 					</button>
 				</div>
 
@@ -411,7 +411,7 @@ if ( $instructor_data && ( 'approved' === $prompt_action || 'blocked' === $promp
 		<div class="tutor-modal-window tutor-modal-window-sm">
 			<div class="tutor-modal-content tutor-modal-content-white">
 				<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-					<span class="tutor-icon-times" area-hidden="true"></span>
+					<span class="tutor-icon-times" aria-hidden="true"></span>
 				</button>
 				<div class="tutor-modal-body tutor-text-center">
 					<div class="tutor-py-lg-64">

--- a/views/pages/students.php
+++ b/views/pages/students.php
@@ -137,7 +137,7 @@ $filters = array(
 											<?php echo esc_html( $list->display_name ); ?>
 										</span>
 										<a href="<?php echo esc_url( tutor_utils()->profile_url( $list->ID, false ) ); ?>" class="tutor-iconic-btn" target="_blank">
-											<span class="tutor-icon-external-link" area-hidden="True"></span>
+											<span class="tutor-icon-external-link" aria-hidden="True"></span>
 										</a>
 									</div>
 								</td>

--- a/views/pages/tools/manage-tokens.php
+++ b/views/pages/tools/manage-tokens.php
@@ -83,7 +83,7 @@ $user        = get_userdata( get_current_user_id() );
 					<?php esc_html_e( 'Generate API Key, Secret', 'tutor' ); ?>
 				</div>
 				<button class="tutor-iconic-btn tutor-modal-close" data-tutor-modal-close>
-					<span class="tutor-icon-times" area-hidden="true"></span>
+					<span class="tutor-icon-times" aria-hidden="true"></span>
 				</button>
 			</div>
 
@@ -148,7 +148,7 @@ $user        = get_userdata( get_current_user_id() );
 					<?php esc_html_e( 'Update API', 'tutor' ); ?>
 				</div>
 				<button class="tutor-iconic-btn tutor-modal-close" data-tutor-modal-close>
-					<span class="tutor-icon-times" area-hidden="true"></span>
+					<span class="tutor-icon-times" aria-hidden="true"></span>
 				</button>
 			</div>
 

--- a/views/pages/tools/settings-log.php
+++ b/views/pages/tools/settings-log.php
@@ -66,18 +66,18 @@
 						<button class="tutor-btn tutor-btn-outline-primary tutor-btn-sm apply_settings" data-tutor-modal-target="tutor-modal-bulk-action" data-btntext="<?php esc_attr_e( 'Yes, Restore Settings', 'tutor' ); ?>" data-heading="<?php esc_attr_e( 'Restore Previous Settings?', 'tutor' ); ?>" data-message="<?php esc_attr_e( 'WARNING! This will overwrite all existing settings, please proceed with caution.', 'tutor' ); ?>" data-id="<?php echo esc_attr( $key ); ?>"><?php esc_html_e( 'Apply', 'tutor' ); ?></button>
 						<div class="tutor-dropdown-parent tutor-ml-16">
 							<button type="button" class="tutor-iconic-btn" action-tutor-dropdown="toggle">
-								<span class="tutor-icon-kebab-menu" area-hidden="true"></span>
+								<span class="tutor-icon-kebab-menu" aria-hidden="true"></span>
 							</button>
 							<ul class="tutor-dropdown tutor-dropdown-dark tutor-text-left">
 								<li>
 									<a href="javascript:;" class="tutor-dropdown-item export_single_settings" data-id="<?php echo esc_attr( $key ); ?>">
-										<span class="tutor-icon-archive tutor-mr-8" area-hidden="true"></span>
+										<span class="tutor-icon-archive tutor-mr-8" aria-hidden="true"></span>
 										<span><?php esc_html_e( 'Download', 'tutor' ); ?></span>
 									</a>
 								</li>
 								<li>
 									<a href="javascript:;" class="tutor-dropdown-item delete_single_settings" data-tutor-modal-target="tutor-modal-bulk-action" data-btntext="<?php esc_attr_e( 'Yes, Delete Settings', 'tutor' ); ?>" data-heading="<?php esc_attr_e( 'Delete This Settings?', 'tutor' ); ?>" data-message="<?php esc_attr_e( 'WARNING! This will remove the settings history data from your system, please proceed with caution.', 'tutor' ); ?>" data-id="<?php echo esc_attr( $key ); ?>">
-										<span class="icon tutor-icon-trash-can-bold tutor-mr-8" area-hidden="true"></span>
+										<span class="icon tutor-icon-trash-can-bold tutor-mr-8" aria-hidden="true"></span>
 										<span><?php esc_html_e( 'Delete', 'tutor' ); ?></span>
 									</a>
 								</li>

--- a/views/pages/withdraw_requests.php
+++ b/views/pages/withdraw_requests.php
@@ -344,7 +344,7 @@ $filters = array(
 				<div class="tutor-modal-window">
 					<form id="tutor-admin-withdraw-approve-form" class="tutor-modal-content tutor-modal-content-white">
 						<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-							<span class="tutor-icon-times" area-hidden="true"></span>
+							<span class="tutor-icon-times" aria-hidden="true"></span>
 						</button>
 
 						<div class="tutor-modal-body tutor-text-center">
@@ -395,7 +395,7 @@ $filters = array(
 				<div class="tutor-modal-window">
 					<form id="tutor-admin-withdraw-reject-form" class="tutor-modal-content tutor-modal-content-white">
 						<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-							<span class="tutor-icon-times" area-hidden="true"></span>
+							<span class="tutor-icon-times" aria-hidden="true"></span>
 						</button>
 
 						<div class="tutor-modal-body tutor-text-center">

--- a/views/qna/qna-single.php
+++ b/views/qna/qna-single.php
@@ -52,7 +52,7 @@ if ( property_exists( $question, 'user_id' ) ) {
 				<div class="tutor-col-lg">
 					<div class="tutor-d-lg-flex tutor-align-lg-center tutor-px-12 tutor-py-16">
 						<a class="tutor-btn tutor-btn-ghost" href="<?php echo esc_url( $back_url ); ?>">
-							<span class="tutor-icon-previous tutor-mr-8" area-hidden="true"></span>
+							<span class="tutor-icon-previous tutor-mr-8" aria-hidden="true"></span>
 							<?php esc_html_e( 'Back', 'tutor' ); ?>
 						</a>
 					</div>
@@ -77,7 +77,7 @@ if ( property_exists( $question, 'user_id' ) ) {
 							</span>
 						<?php endif; ?>
 						<span class="tutor-btn tutor-btn-ghost" data-tutor-modal-target="<?php echo esc_attr( $modal_id ); ?>">
-							<i class="tutor-icon-trash-can-bold tutor-mr-8" area-hidden="true"></i>
+							<i class="tutor-icon-trash-can-bold tutor-mr-8" aria-hidden="true"></i>
 							<?php esc_html_e( 'Delete', 'tutor' ); ?>
 						</span>
 					</div>
@@ -89,7 +89,7 @@ if ( property_exists( $question, 'user_id' ) ) {
 	<div class="<?php echo is_admin() ? 'tutor-admin-container' : ''; ?>">
 		<div class="tutor-qna-course-title tutor-color-black tutor-fs-6 tutor-fw-bold tutor-mb-32<?php echo is_single_course( true ) || ( Input::has( 'action' ) ) ? ' tutor-d-none' : ''; ?>">
 			<?php echo esc_html( $question->post_title ); ?>
-			<div class="tutor-hr tutor-mt-20" area-hidden="true"></div>
+			<div class="tutor-hr tutor-mt-20" aria-hidden="true"></div>
 		</div>
 		<div class="tutor-qna-single-wrapper">
 			<div class="tutor-qa-reply-wrapper tutor-mt-20">

--- a/views/qna/qna-table.php
+++ b/views/qna/qna-table.php
@@ -60,7 +60,7 @@ $view_as       = isset( $view_as ) ? $view_as : ( is_admin() ? 'instructor' : 's
 												data-action="important"
 												data-state-class-selector="i"
 											>
-												<i class="<?php echo $is_important ? 'tutor-icon-important-bold' : 'tutor-icon-important-line'; ?>  tutor-cursor-pointer" area-hidden="true"></i>
+												<i class="<?php echo $is_important ? 'tutor-icon-important-bold' : 'tutor-icon-important-line'; ?>  tutor-cursor-pointer" aria-hidden="true"></i>
 											</span>
 
 											<span class="tooltip-txt tooltip-right arrow-center">
@@ -88,7 +88,7 @@ $view_as       = isset( $view_as ) ? $view_as : ( is_admin() ? 'instructor' : 's
 									<?php $content = ( stripslashes( $qna->comment_content ) ); ?>
 									<a href="<?php echo esc_url( add_query_arg( array( 'question_id' => $qna->comment_ID ), tutor()->current_url ) ); ?>">
 										<div class="tutor-form-feedback tutor-qna-question-col <?php echo $is_read ? 'is-read' : ''; ?>">
-											<i class="tutor-icon-bullet-point tutor-form-feedback-icon" area-hidden="true"></i>
+											<i class="tutor-icon-bullet-point tutor-form-feedback-icon" aria-hidden="true"></i>
 											<div class="tutor-qna-desc">
 												<div class="tutor-qna-content tutor-fs-6 tutor-fw-bold tutor-color-black">
 													<?php
@@ -130,7 +130,7 @@ $view_as       = isset( $view_as ) ? $view_as : ( is_admin() ? 'instructor' : 's
 
 										<div class="tutor-dropdown-parent">
 											<button type="button" class="tutor-iconic-btn" action-tutor-dropdown="toggle">
-												<span class="tutor-icon-kebab-menu" area-hidden="true"></span>
+												<span class="tutor-icon-kebab-menu" aria-hidden="true"></span>
 											</button>
 											<ul class="tutor-dropdown tutor-dropdown-dark tutor-text-left">
 												<?php if ( 'frontend-dashboard-qna-table-student' != $context ) : ?>
@@ -166,7 +166,7 @@ $view_as       = isset( $view_as ) ? $view_as : ( is_admin() ? 'instructor' : 's
 											<div class="tutor-modal-window">
 												<div class="tutor-modal-content tutor-modal-content-white">
 													<button class="tutor-iconic-btn tutor-modal-close-o" data-tutor-modal-close>
-														<span class="tutor-icon-times" area-hidden="true"></span>
+														<span class="tutor-icon-times" aria-hidden="true"></span>
 													</button>
 
 													<div class="tutor-modal-body tutor-text-center">

--- a/views/quiz/header-context/backend-dashboard-students-attempts.php
+++ b/views/quiz/header-context/backend-dashboard-students-attempts.php
@@ -16,7 +16,7 @@ if ( empty( $back_url ) ) {
 <header class="tutor-wp-dashboard-header tutor-justify-between tutor-align-center tutor-px-32 tutor-py-20 tutor-mb-24 tutor-pt-16 tutor-pb-16">
 	<div class="tutor-mb-24">
 		<a class="tutor-btn tutor-btn-ghost" href="<?php echo esc_url( $back_url ); ?>">
-			<span class="tutor-icon-previous" area-hidden="true"></span>
+			<span class="tutor-icon-previous" aria-hidden="true"></span>
 			<?php esc_html_e( 'Back', 'tutor' ); ?>
 		</a>
 	</div>

--- a/views/quiz/header-context/course-single-previous-attempts.php
+++ b/views/quiz/header-context/course-single-previous-attempts.php
@@ -13,7 +13,7 @@ $passing_grade = tutor_utils()->get_quiz_option( get_the_ID(), 'passing_grade', 
 <?php if ( ! empty( $back_url ) ) : ?>
 	<div class="tutor-mb-24">
 		<a class="tutor-btn tutor-btn-ghost" href="<?php echo esc_url( $back_url ); ?>">
-			<span class="tutor-icon-previous tutor-mr-8" area-hidden="true"></span>
+			<span class="tutor-icon-previous tutor-mr-8" aria-hidden="true"></span>
 			<?php esc_html_e( 'Back', 'tutor' ); ?>
 		</a>
 	</div>

--- a/views/quiz/header-context/frontend-dashboard-my-attempts.php
+++ b/views/quiz/header-context/frontend-dashboard-my-attempts.php
@@ -10,7 +10,7 @@
 
 if ( ! empty( $back_url ) ) : ?>
 	<a class="tutor-btn tutor-btn-ghost" href="<?php echo esc_url( $back_url ); ?>">
-		<span class="tutor-icon-previous tutor-mr-8" area-hidden="true"></span>
+		<span class="tutor-icon-previous tutor-mr-8" aria-hidden="true"></span>
 		<?php esc_html_e( 'Back', 'tutor' ); ?>
 	</a>
 <?php endif; ?>

--- a/views/quiz/header-context/frontend-dashboard-students-attempts.php
+++ b/views/quiz/header-context/frontend-dashboard-students-attempts.php
@@ -11,7 +11,7 @@
 if ( ! empty( $back_url ) ) : ?>
 	<div class="tutor-mb-24">
 		<a class="tutor-btn tutor-btn-ghost" href="<?php echo esc_url( $back_url ); ?>">
-			<span class="tutor-icon-previous tutor-mr-8" area-hidden="true"></span>
+			<span class="tutor-icon-previous tutor-mr-8" aria-hidden="true"></span>
 			<?php esc_html_e( 'Back', 'tutor' ); ?>
 		</a>
 	</div>


### PR DESCRIPTION
## What

`area-hidden` is not a valid HTML attribute. The intended attribute is `aria-hidden`, which instructs assistive technologies to skip decorative elements. The typo was silently accepted by browsers but had zero effect — all decorative icon `<span>` and `<i>` elements marked with `area-hidden="true"` were still announced to screen readers.

This is a one-character fix: `area` → `aria`, applied consistently across **167 occurrences in 85+ PHP template/view files and supporting JS files**.

Every instance follows the same pattern:

```html
<!-- Before -->
<span class="tutor-icon-user-line" area-hidden="true"></span>

<!-- After -->
<span class="tutor-icon-user-line" aria-hidden="true"></span>
```

No logic changes. No markup restructuring. Purely a spelling correction on an ARIA attribute name.

## Why this matters

Screen readers announce every element that isn't explicitly hidden via `aria-hidden="true"`. Decorative icons like `tutor-icon-user-line`, `tutor-icon-times`, and `tutor-icon-bullhorn` appear throughout the course listing, dashboard, and announcement views. Without a working `aria-hidden`, every icon gets read aloud as an unlabeled interactive or decorative element, degrading the experience for learners using assistive technology.

## Testing

1. Open any course listing or dashboard page with a screen reader (NVDA, JAWS, or VoiceOver).
2. Confirm decorative icons are no longer announced.
3. Confirm no functional change to visual rendering.

---
*Development and testing assisted by AI. All code reviewed and verified manually.*