### PR TITLE
🐛 Prevent Alpine re-registration on dnd-kit placeholder clones

### DIFF
--- a/templates/dashboard/instructor/home.php
+++ b/templates/dashboard/instructor/home.php
@@ -386,7 +386,7 @@ $sortable_sections_ids = array_reduce(
 									->type( InputType::CHECKBOX )
 									->name( "$section[id]" )
 									->label( $section['label'] )
-									->attr( 'x-bind', "register('$section[id]')" )
+									->attr( 'x-bind', "\$el.closest('[data-dnd-placeholder]') ? {} : register('{$section['id']}')" )
 									->attr( '@click.stop', 'handleCheckboxClick(event)' )
 									->render();
 							?>


### PR DESCRIPTION
- Prevents form value corruption when sorting sections via drag-and-drop in the instructor dashboard
- Skips Alpine `register()` bindings on dnd-kit placeholder clones to avoid re-registering form fields

https://app.clickup.com/t/9018365849/86exyuu22
