### PR TITLE
feat(ecommerce): add filter for PayPal vaulting

### DIFF
--- a/ecommerce/PaymentGateways/Configs/PaypalConfig.php
+++ b/ecommerce/PaymentGateways/Configs/PaypalConfig.php
@@ -129,12 +129,14 @@ class PaypalConfig extends BaseConfig implements ConfigContract {
 	public function createConfig(): void {
 		parent::createConfig();
 
+		$enable_vaulting = apply_filters( 'tutor_paypal_enable_vaulting', true );
+
 		$config = array(
 			'client_id'           => $this->getClientID(),
 			'merchant_email'      => $this->getMerchantEmail(),
 			'api_url'             => $this->getApiURL(),
 			'client_secret'       => $this->getClientSecret(),
-			'save_payment_method' => true,
+			'save_payment_method' => $enable_vaulting,
 			'webhook_id'          => $this->webhook_id
 		);
 


### PR DESCRIPTION
This pull request introduces a minor but important change to the PayPal payment gateway configuration. The ability to save a payment method (vaulting) is now controlled by a filter, allowing for greater customization by developers.

Configuration flexibility:

* The `save_payment_method` option in the PayPal config is now set based on the `tutor_paypal_enable_vaulting` filter, defaulting to `true`, instead of always being enabled. This allows site owners or plugin developers to dynamically enable or disable payment method vaulting.

Or

Option 2: https://github.com/themeum/tutor/pull/2816