### PR TITLE
tutor lms paypal vaulting beta

### DIFF
--- a/ecommerce/OptionKeys.php
+++ b/ecommerce/OptionKeys.php
@@ -44,6 +44,9 @@ class OptionKeys {
 
 	const BUY_NOW = 'is_enable_buy_now';
 
+	// PayPal advanced settings.
+	const PAYPAL_ENABLE_VAULTING = 'tutor_paypal_enable_vaulting';
+
 	/**
 	 * Get billing field options
 	 *

--- a/ecommerce/PaymentGateways/Configs/PaypalConfig.php
+++ b/ecommerce/PaymentGateways/Configs/PaypalConfig.php
@@ -129,12 +129,14 @@ class PaypalConfig extends BaseConfig implements ConfigContract {
 	public function createConfig(): void {
 		parent::createConfig();
 
+		$enable_vaulting = (bool) tutor_utils()->get_option( 'tutor_paypal_enable_vaulting', true );
+
 		$config = array(
 			'client_id'           => $this->getClientID(),
 			'merchant_email'      => $this->getMerchantEmail(),
 			'api_url'             => $this->getApiURL(),
 			'client_secret'       => $this->getClientSecret(),
-			'save_payment_method' => true,
+			'save_payment_method' => $enable_vaulting,
 			'webhook_id'          => $this->webhook_id
 		);
 

--- a/ecommerce/PaymentGateways/Configs/PaypalConfig.php
+++ b/ecommerce/PaymentGateways/Configs/PaypalConfig.php
@@ -2,6 +2,7 @@
 
 namespace Tutor\PaymentGateways\Configs;
 
+use Tutor\Ecommerce\OptionKeys;
 use Tutor\Ecommerce\Settings;
 use Ollyo\PaymentHub\Core\Payment\BaseConfig;
 use Ollyo\PaymentHub\Contracts\Payment\ConfigContract;
@@ -129,7 +130,7 @@ class PaypalConfig extends BaseConfig implements ConfigContract {
 	public function createConfig(): void {
 		parent::createConfig();
 
-		$enable_vaulting = (bool) tutor_utils()->get_option( 'tutor_paypal_enable_vaulting', true );
+		$enable_vaulting = (bool) tutor_utils()->get_option( OptionKeys::PAYPAL_ENABLE_VAULTING, true );
 
 		$config = array(
 			'client_id'           => $this->getClientID(),

--- a/ecommerce/Settings.php
+++ b/ecommerce/Settings.php
@@ -241,6 +241,21 @@ class Settings {
 						),
 					),
 				),
+				array(
+					'label'      => __( 'PayPal Settings', 'tutor' ),
+					'desc'       => __( 'Advanced configuration options for PayPal.', 'tutor' ),
+					'slug'       => 'paypal_settings',
+					'block_type' => 'uniform',
+					'fields'     => array(
+						array(
+							'key'     => OptionKeys::PAYPAL_ENABLE_VAULTING,
+							'type'    => 'toggle_switch',
+							'label'   => __( 'Enable PayPal Vaulting (Save Payment Methods)', 'tutor' ),
+							'default' => 'on',
+							'desc'    => __( 'Allow PayPal to save customer payment methods for future purchases.', 'tutor' ),
+						),
+					),
+				),
 			),
 		);
 


### PR DESCRIPTION
This pull request adds support for configuring PayPal Vaulting (the ability to save customer payment methods) as an advanced option in the e-commerce settings. The main changes introduce a new setting for enabling/disabling PayPal Vaulting and ensure that this option is respected in the PayPal payment gateway configuration.

**PayPal Vaulting Feature Integration:**

* Added a new constant `PAYPAL_ENABLE_VAULTING` to `OptionKeys` for referencing the PayPal Vaulting setting.
* Updated the e-commerce settings UI to include a new "PayPal Settings" section with a toggle switch for enabling/disabling PayPal Vaulting.
* Modified `PaypalConfig` to use the new vaulting option: the `save_payment_method` config value now reflects the user's setting instead of always being `true`.

**Codebase Consistency:**

* Added an import of `OptionKeys` in `PaypalConfig.php` to access the new constant.

or

Option 1: https://github.com/themeum/tutor/pull/2815