### PR TITLE
Fix: Logged out user gets redirected to 404 page instead of login

### DIFF
--- a/classes/Dashboard.php
+++ b/classes/Dashboard.php
@@ -63,7 +63,8 @@ class Dashboard {
 	 */
 	public function redirect_old_dashboard_pages() {
 		$current_url = rtrim( UrlHelper::current(), '/' );
-		if ( is_user_logged_in() && ! is_admin() ) {
+
+		if ( ! is_admin() ) {
 			// Redirect logic here.
 			$redirect_mappings = array(
 				tutor_utils()->tutor_dashboard_url( self::PROFILE_PAGE_SLUG ) => self::get_account_page_url( 'profile' ),


### PR DESCRIPTION
- When clicking any dashboard link from mail, it goes to 404 page instead of login page