### PR TITLE
🐛 [QUIZ] Use array index for ordering display and correct dnd review data-option

### DIFF
--- a/templates/learning-area/quiz/questions/ordering.php
+++ b/templates/learning-area/quiz/questions/ordering.php
@@ -35,14 +35,14 @@ $register_attr = "register('{$answer_field_name}'{$register_rules})";
 			name="<?php echo esc_attr( $answer_field_name ); ?>"
 			x-bind="<?php echo esc_attr( $register_attr ); ?>"
 		>
-		<?php foreach ( $question['question_answers'] as $answer ) : ?>
+		<?php foreach ( $question['question_answers'] as $index => $answer ) : ?>
 			<div
 				class="tutor-quiz-question-option"
 				data-option="draggable"
 				data-id="<?php echo esc_attr( $answer['answer_id'] ); ?>"
 			>
-				<div data-option-order="<?php echo esc_attr( $answer['answer_order'] ); ?>">
-					<?php echo esc_html( $answer['answer_order'] ); ?>
+				<div data-option-order="<?php echo esc_attr( $index + 1 ); ?>">
+					<?php echo esc_html( $index + 1 ); ?>
 				</div>
 				<div data-title>
 					<?php if ( ! empty( $answer['image_id'] ) ) : ?>

--- a/templates/shared/components/quiz/attempt-details/questions/review-answer-dnd.php
+++ b/templates/shared/components/quiz/attempt-details/questions/review-answer-dnd.php
@@ -113,9 +113,10 @@ if ( 'ordering' === $question_type ) {
 		foreach ( $rows as $row ) :
 			$given_text   = isset( $row['given_text'] ) ? wp_unslash( $row['given_text'] ) : '';
 			$correct_text = isset( $row['correct_text'] ) ? wp_unslash( $row['correct_text'] ) : '';
+			$given_status = isset( $row['given_status'] ) ? $row['given_status'] : 'neutral';
 			?>
 			<div class="tutor-quiz-review-dnd-row">
-				<div class="tutor-quiz-review-item tutor-quiz-review-given" data-option="<?php echo esc_attr( $row['given_status'] ); ?>">
+				<div class="tutor-quiz-review-item tutor-quiz-review-given" data-option="<?php echo esc_attr( $given_status ); ?>">
 					<?php if ( ! empty( $row['given_image'] ) ) : ?>
 						<img src="<?php echo esc_url( $row['given_image'] ); ?>" alt="<?php echo esc_attr( $given_text ); ?>">
 					<?php endif; ?>

--- a/templates/shared/components/quiz/attempt-details/questions/review-answer-dnd.php
+++ b/templates/shared/components/quiz/attempt-details/questions/review-answer-dnd.php
@@ -115,7 +115,7 @@ if ( 'ordering' === $question_type ) {
 			$correct_text = isset( $row['correct_text'] ) ? wp_unslash( $row['correct_text'] ) : '';
 			?>
 			<div class="tutor-quiz-review-dnd-row">
-				<div class="tutor-quiz-review-item tutor-quiz-review-given" data-option="<?php echo esc_attr( $given_text ); ?>">
+				<div class="tutor-quiz-review-item tutor-quiz-review-given" data-option="<?php echo esc_attr( $row['given_status'] ); ?>">
 					<?php if ( ! empty( $row['given_image'] ) ) : ?>
 						<img src="<?php echo esc_url( $row['given_image'] ); ?>" alt="<?php echo esc_attr( $given_text ); ?>">
 					<?php endif; ?>


### PR DESCRIPTION
- Fixed ordering question display to use array index instead of stored answer_order value
- Fixed drag-and-drop review data-option attribute to use given_status instead of given_text
