### PR TITLE
configure LightningCssMinimizerRspackPlugin to exclude logical properties

### DIFF
--- a/ecommerce/Settings.php
+++ b/ecommerce/Settings.php
@@ -354,7 +354,7 @@ class Settings {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return object
+	 * @return array
 	 */
 	public static function get_payment_settings() {
 		$settings = tutor_utils()->get_option( OptionKeys::PAYMENT_SETTINGS );

--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -233,7 +233,15 @@ const createConfig = (env, options) => {
             },
           },
         }),
-        new rspack.LightningCssMinimizerRspackPlugin(),
+        new rspack.LightningCssMinimizerRspackPlugin({
+          minimizerOptions: {
+            // Keep logical properties in the final CSS so RTL behavior relies on `dir`,
+            // not Lightning CSS language-based fallback selectors.
+            exclude: {
+              logicalProperties: true,
+            },
+          },
+        }),
       ],
     };
     baseConfig.output.clean = {

--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -235,8 +235,7 @@ const createConfig = (env, options) => {
         }),
         new rspack.LightningCssMinimizerRspackPlugin({
           minimizerOptions: {
-            // Keep logical properties in the final CSS so RTL behavior relies on `dir`,
-            // not Lightning CSS language-based fallback selectors.
+            // Keep logical properties in the final CSS so RTL behavior works as expected.
             exclude: {
               logicalProperties: true,
             },

--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -235,7 +235,6 @@ const createConfig = (env, options) => {
         }),
         new rspack.LightningCssMinimizerRspackPlugin({
           minimizerOptions: {
-            // Keep logical properties in the final CSS so RTL behavior works as expected.
             exclude: {
               logicalProperties: true,
             },


### PR DESCRIPTION
ensuring RTL behavior uses dir attribute instead of CSS language-based fallback selectors