### PR TITLE
Fix(🛠️) : Canceling an unpaid duplicate order was removing student enrollment, even when a valid paid order existed for the course and student.

### DIFF
--- a/ecommerce/HooksHandler.php
+++ b/ecommerce/HooksHandler.php
@@ -387,8 +387,9 @@ class HooksHandler {
 				}
 			}
 
-			$has_enrollment = EnrollmentModel::is_enrolled( $object_id, $student_id, false );
-			if ( $has_enrollment ) {
+			$has_enrollment             = EnrollmentModel::is_enrolled( $object_id, $student_id, false );
+			$active_enrollment_order_id = isset( $has_enrollment->order_id ) ? $has_enrollment->order_id : null;
+			if ( $has_enrollment && $order_id === $active_enrollment_order_id ) {
 				// Update enrollment status based on order status.
 				$update = EnrollmentModel::update_enrollments( $enrollment_status, array( $has_enrollment->ID ) );
 				if ( $update ) {


### PR DESCRIPTION
When a student had multiple orders (e.g., an unpaid and a paid order) for the same course, then canceling the unpaid order would terminate the active enrollment created by the valid paid order.