### PR TITLE
fix(i18n): add missing translations and calendar locale support

### DIFF
--- a/assets/core/scss/components/_calendar.scss
+++ b/assets/core/scss/components/_calendar.scss
@@ -94,8 +94,8 @@
 }
 
 .tutor-range-calendar-popover {
-  width: 700px;
-  max-width: 700px;
+  min-width: 700px;
+  max-width: 750px;
 
   @include tutor-breakpoint-down(md) {
     width: 300px;

--- a/assets/core/ts/index.ts
+++ b/assets/core/ts/index.ts
@@ -1,5 +1,6 @@
 import collapse from '@alpinejs/collapse';
 import focus from '@alpinejs/focus';
+import { setLocaleData } from '@wordpress/i18n';
 import Alpine from 'alpinejs';
 
 import { TutorComponentRegistry } from '@Core/ts/ComponentRegistry';
@@ -75,11 +76,16 @@ const initializePlugin = async () => {
   });
 
   TutorComponentRegistry.registerLazy({
-    calendar: () =>
-      import(
+    calendar: () => {
+      if (tutorConfig.calendar_locales) {
+        setLocaleData(tutorConfig.calendar_locales, 'tutor');
+      }
+
+      return import(
         /* webpackChunkName: "tutor-calendar" */
         '@Core/ts/components/calendar'
-      ).then(({ calendarMeta }) => calendarMeta),
+      ).then(({ calendarMeta }) => calendarMeta);
+    },
 
     form: () =>
       import(

--- a/classes/Assets.php
+++ b/classes/Assets.php
@@ -374,6 +374,9 @@ class Assets {
 				}
 			}
 		} else {
+			if ( 'en_US' !== $localize_data['local'] ) {
+				$localize_data['calendar_locales'] = tutils()->get_script_locale_data( 'tutor-calendar', $localize_data['local'] );
+			}
 
 			// Assign quiz option.
 			if ( ! empty( $post->post_type ) && 'tutor_quiz' === $post->post_type ) {

--- a/classes/User.php
+++ b/classes/User.php
@@ -800,6 +800,7 @@ class User {
 		}
 
 		$switch_mode  = '';
+		$switch_label = '';
 		$current_mode = Input::post( 'current_mode' );
 
 		if ( ! in_array( $current_mode, array( self::VIEW_AS_INSTRUCTOR, self::VIEW_AS_STUDENT ), true ) ) {
@@ -807,15 +808,17 @@ class User {
 		}
 
 		if ( self::VIEW_AS_INSTRUCTOR === $current_mode ) {
-			$switch_mode = self::VIEW_AS_STUDENT;
+			$switch_mode  = self::VIEW_AS_STUDENT;
+			$switch_label = __( 'Student', 'tutor' );
 		} elseif ( self::VIEW_AS_STUDENT === $current_mode ) {
-			$switch_mode = self::VIEW_AS_INSTRUCTOR;
+			$switch_mode  = self::VIEW_AS_INSTRUCTOR;
+			$switch_label = __( 'Instructor', 'tutor' );
 		}
 
 		update_user_meta( $user_id, self::VIEW_MODE_USER_META, $switch_mode );
 
 		// translators:%s for switching mode.
-		$this->response_success( sprintf( __( 'Profile switched to %s!', 'tutor' ), $switch_mode ) );
+		$this->response_success( sprintf( __( 'Profile switched to %s!', 'tutor' ), $switch_label ) );
 	}
 
 	/**

--- a/templates/dashboard/account/billing/order-history.php
+++ b/templates/dashboard/account/billing/order-history.php
@@ -89,7 +89,7 @@ $status_options = apply_filters( 'tutor_order_history_status_options', array(), 
 <?php
 if ( empty( $orders ) ) :
 	EmptyState::make()
-		->title( 'No Orders Found!' )
+		->title( __( 'No Orders Found!', 'tutor' ) )
 		->icon( tutor_utils()->get_themed_svg( 'images/illustrations/order-empty.svg' ) )
 		->render();
 else :

--- a/templates/dashboard/discussions/comment-list.php
+++ b/templates/dashboard/discussions/comment-list.php
@@ -105,7 +105,7 @@ remove_filter( 'comments_clauses', $tutor_comments_filter, 10 );
 <?php if ( empty( $lesson_comments ) ) : ?>
 	<?php
 		EmptyState::make()
-			->title( 'No Comments Found!' )
+			->title( __( 'No Comments Found!', 'tutor' ) )
 			->icon( tutor_utils()->get_themed_svg( 'images/illustrations/comments-empty.svg' ) )
 			->render();
 	?>

--- a/templates/dashboard/discussions/qna-list.php
+++ b/templates/dashboard/discussions/qna-list.php
@@ -77,7 +77,7 @@ $nav_items = array(
 <?php if ( empty( $questions ) ) : ?>
 	<?php
 		EmptyState::make()
-			->title( 'No Questions Found!' )
+			->title( __( 'No Questions Found!', 'tutor' ) )
 			->icon( tutor_utils()->get_themed_svg( 'images/illustrations/qna-empty.svg' ) )
 			->render();
 	?>

--- a/templates/dashboard/instructor/logged-in.php
+++ b/templates/dashboard/instructor/logged-in.php
@@ -18,7 +18,7 @@ $instructor_status = get_user_meta( $user_id, '_tutor_instructor_status', true )
 
 if ( 'try_again' === $instructor_status ) {
 	Alert::make()
-		->text( 'You have been rejected from being an instructor.' )
+		->text( __( 'You have been rejected from being an instructor.', 'tutor' ) )
 		->variant( Alert::WARNING )
 		->icon( Icon::WARNING )
 		->render();
@@ -34,11 +34,11 @@ if ( $is_instructor ) {
 				<?php
 				$instructor_status_text = '';
 				if ( 'pending' === $instructor_status ) {
-					$instructor_status_text = 'Your application will be reviewed and the results will be sent to you by email.';
+					$instructor_status_text = __( 'Your application will be reviewed and the results will be sent to you by email.', 'tutor' );
 				} elseif ( 'approved' === $instructor_status ) {
-					$instructor_status_text = 'Your application has been accepted. Further necessary details have been sent to your registered email account.';
+					$instructor_status_text = __( 'Your application has been accepted. Further necessary details have been sent to your registered email account.', 'tutor' );
 				} elseif ( 'blocked' === $instructor_status ) {
-					$instructor_status_text = 'You have been blocked from being an instructor.';
+					$instructor_status_text = __( 'You have been blocked from being an instructor.', 'tutor' );
 				}
 				Alert::make()
 					->text( $instructor_status_text )

--- a/templates/dashboard/my-courses.php
+++ b/templates/dashboard/my-courses.php
@@ -155,7 +155,7 @@ if ( ! current_user_can( 'administrator' ) && ! tutor_utils()->get_option( 'inst
 		<?php if ( empty( $results ) ) : ?>
 			<?php
 				EmptyState::make()
-					->title( 'No Courses Found' )
+					->title( __( 'No Courses Found', 'tutor' ) )
 					->icon( tutor_utils()->get_themed_svg( 'images/illustrations/learning-empty.svg' ) )
 					->render();
 			?>

--- a/templates/learning-area/lesson/comments.php
+++ b/templates/learning-area/lesson/comments.php
@@ -105,8 +105,8 @@ $comment_list   = Lesson::get_comments( $comments_list_args );
 	<?php
 	ConfirmationModal::make()
 		->id( 'delete-comment-modal' )
-		->title( 'Delete This Item?' )
-		->message( 'This action cannot be undone.' )
+		->title( __( 'Delete This Item?', 'tutor' ) )
+		->message( __( 'This action cannot be undone.', 'tutor' ) )
 		->icon( Icon::DELETE_2, 80 )
 		->mutation_state( 'deleteCommentMutation' )
 		->confirm_handler( 'deleteCommentMutation?.mutate({ comment_id: payload?.commentId })' )

--- a/templates/learning-area/subpages/qna.php
+++ b/templates/learning-area/subpages/qna.php
@@ -117,7 +117,7 @@ $questions   = tutor_utils()->get_qa_questions(
 		<?php if ( empty( $questions ) ) : ?>
 			<?php
 				EmptyState::make()
-					->title( 'No Questions Found!' )
+					->title( __( 'No Questions Found!', 'tutor' ) )
 					->icon( tutor_utils()->get_themed_svg( 'images/illustrations/qna-empty.svg' ) )
 					->render();
 			?>


### PR DESCRIPTION
Wrap hardcoded UI strings across templates and PHP classes with WordPress translation functions Add calendar locale loading logic for non-en_US locales to enable translated calendar components Update view mode switch labels in User class to use translatable text