### PR TITLE
🐛 Fix legacy date picker date format and parsing

### DIFF
--- a/v2-library/src/components/datapicker/TutorDateRangePicker.js
+++ b/v2-library/src/components/datapicker/TutorDateRangePicker.js
@@ -9,7 +9,7 @@ const DatePicker = lazy(() => import(/* webpackChunkName: "tutor-react-datepicke
 const CalendarContainer = lazy(() => import('react-datepicker').then((module) => ({ default: module.CalendarContainer })));
 
 const TutorDateRangePicker = () => {
-	const dateFormat = 'Y-M-d';
+	const dateFormat = 'yyyy-MM-dd';
 
 	const [dropdownMonth, setDropdownMonth] = useState(false);
 	const [dropdownYear, setDropdownYear] = useState(false);

--- a/v2-library/src/components/datapicker/TutorDateTimePicker.js
+++ b/v2-library/src/components/datapicker/TutorDateTimePicker.js
@@ -29,7 +29,7 @@ const TutorDateTimePicker = (data) => {
 				<DatePicker
 					inline={data.inline ? true : false}
 					customInput={<CustomInput />}
-					placeholderText="Y-M-d h:mm aa"
+					placeholderText="yyyy-MM-dd h:mm aa"
 					selected={startDate}
 					onChange={(date) => handleCalendarChange(date)}
 					showPopperArrow={false}
@@ -38,7 +38,7 @@ const TutorDateTimePicker = (data) => {
 					onCalendarClose={handleCalendarClose}
 					onClick={handleCalendarClose}
 					timeCaption={__('Time', 'tutor')}
-					dateFormat="Y-M-d h:mm aa"
+					dateFormat="yyyy-MM-dd h:mm aa"
 					minDate={data.disable_previous ? new Date() : false}
 					formatWeekDay={(nameOfDay) => translateWeekday(nameOfDay)}
 					calendarStartDay={_tutorobject.start_of_week}

--- a/v2-library/src/components/datapicker/TutorDatepicker.js
+++ b/v2-library/src/components/datapicker/TutorDatepicker.js
@@ -20,7 +20,7 @@ const TutorDatepicker = (data) => {
 	if (data.disable_past_date) {
 		isPreviousDateAllowed = false;
 	}
-	const dateFormat = 'Y-M-d';
+	const dateFormat = 'yyyy-MM-dd';
 	const default_date = data.input_value || null;
 	const url = new URL(window.location.href);
 	const params = url.searchParams;

--- a/v2-library/src/components/datapicker/TutorDatepicker.js
+++ b/v2-library/src/components/datapicker/TutorDatepicker.js
@@ -47,7 +47,7 @@ const TutorDatepicker = (data) => {
 
 	useEffect(() => {
 		if (params.has('date') && !!params.get('date')) {
-			setStartDate(new Date(params.get('date')));
+			setStartDate(stringToDate(params.get('date'), 'yyyy-mm-dd', '-'));
 		}
 	}, []);
 

--- a/v2-library/src/components/datapicker/utils.js
+++ b/v2-library/src/components/datapicker/utils.js
@@ -31,7 +31,7 @@ export const weeks = [
 export function stringToDate(_date, _format, _delimiter) {
     const formatLowerCase = _format.toLowerCase();
     const formatItems = formatLowerCase.split(_delimiter);
-    const dateItems = _date.split(_delimiter);
+    const dateItems = String(_date).split(_delimiter);
     const monthIndex = formatItems.indexOf('mm');
     const dayIndex = formatItems.indexOf('dd');
     const yearIndex = formatItems.indexOf('yyyy');


### PR DESCRIPTION
- Fixes legacy date format tokens (`Y-M-d`) rendering incorrect dates in date range, date, and datetime pickers.
- Uses `yyyy-MM-dd` format consistently across date picker components.
- Parses the `date` URL query param through `stringToDate` so it is read correctly in the legacy datepicker.
- Coerces the date string to `String` in `stringToDate` to prevent errors on non-string input.

https://app.clickup.com/t/9018365849/86eyd9wzb
