### PR TITLE
🐛 Load all courses from cart beyond default limit

### DIFF
--- a/models/CartModel.php
+++ b/models/CartModel.php
@@ -46,7 +46,7 @@ class CartModel {
 	 * @param string $item_type Cart item type.
 	 * @param mixed  $item_details Cart item details.
 	 *
-	 * @return array Array containing the result of the insert operation.
+	 * @return int Inserted row ID on success, 0 otherwise.
 	 */
 	public function add_course_to_cart( $user_id, $course_id, $item_type = '', $item_details = '' ) {
 		global $wpdb;
@@ -147,7 +147,8 @@ class CartModel {
 				$select_columns,
 				$where,
 				array(),
-				'item.id'
+				'item.id',
+				-1
 			);
 		}
 


### PR DESCRIPTION
- Cart and Checkout pages now display all courses in the cart instead of the first 10.
- Checkout now processes every cart course when placing an order, not just the first 10.
- Cart item query no longer truncates results at the default `get_joined_data` limit of 10.

https://app.clickup.com/t/9018365849/86eycy8ay
