### PR TITLE
Fix: PHP fatal error when renewing WC Subscription

### DIFF
--- a/classes/WooCommerce.php
+++ b/classes/WooCommerce.php
@@ -625,8 +625,10 @@ class WooCommerce extends Tutor_Base {
 		 * Prevent adding earning data when order is created with WC block checkout page.
 		 *
 		 * @since 3.9.14
+		 *
+		 * @since 4.0.5 Check session before using $order->has_status
 		 */
-		if ( $order->has_status( 'checkout-draft' ) ) {
+		if ( WC()->session && $order->has_status( 'checkout-draft' ) ) {
 			return;
 		}
 
@@ -804,6 +806,7 @@ class WooCommerce extends Tutor_Base {
 	 * @return void
 	 */
 	public function course_placing_order_from_customer( $item_id, $item, $order_id ) {
+
 		if ( is_admin() ) {
 			return;
 		}
@@ -817,8 +820,10 @@ class WooCommerce extends Tutor_Base {
 		 * Prevent when order is created with WC block checkout page.
 		 *
 		 * @since 3.9.14
+		 *
+		 * @since 4.0.5 Check session before using $order->has_status
 		 */
-		if ( $order->has_status( 'checkout-draft' ) ) {
+		if ( WC()->session && $order->has_status( 'checkout-draft' ) ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -343,13 +343,18 @@ Tutor LMS allows you to offer certificates to your students upon course completi
 Update: Hid the course products on shop page settings when monetize is native.
 Update: UX updated for mobile devices to get back to website's home page from learning area.
 Update: Updated instructor capability for better security.
+Update: Updating a course author now set new instructor as author for all the course contents.
 Fix: Resolve an issue where enrollment time extend date-picker was showing wrong date. (Pro)
+Fix: Sending manual email is not working. (Pro)
+Fix: Wrong site url set on the login otp email. (Pro)
+Fix: WC Subscription renewal order trigger PHP fatal error. (Pro)
 Fix: Fixed the cart & checkout shows only 10 items.
 Fix: Course bundle maximum enrollment limit issue fixed. (Pro)
 Fix: Cancelling a failed order revokes access from a valid paid order.
 Fix: Co-author unable to see submitted assignments. (Pro)
 Fix: Youtube link's preview not showing on the quiz's answer explanation.
 Fix: Course detail page on the record showing incorrect enrollment date. (Pro)
+Fix: LaTeX equations not render properly on the quiz options.
 
 = 4.0.4 - 31 July, 2026
 


### PR DESCRIPTION
Issue: When a WC subscription gets renewed in the background, there is no active session. With the release of v3.9.14, we have added this `$order->has_status( 'checkout-draft' )` to the `has_status` function trigger in a filter hook; that method has code `WC()->session->get()`. Since the session is not available, it triggers a fatal error.

Fix: `WC()->session && $order->has_status( 'checkout-draft' )`. Before checking has status, a session check was added. WC always stores a session before checkout when doing it manually.