### PR TITLE
Fix: Correct login_form_middle filter parameter type

### DIFF
--- a/templates/login-form-legacy.php
+++ b/templates/login-form-legacy.php
@@ -67,7 +67,7 @@ do_action( 'tutor_before_login_form' );
 	<?php
 		do_action( 'tutor_login_form_middle' );
 		do_action( 'login_form' );
-		apply_filters( 'login_form_middle', '', '' );
+		apply_filters( 'login_form_middle', '', array() );
 	?>
 	<div class="tutor-d-flex tutor-justify-between tutor-align-center tutor-mb-40">
 		<div class="tutor-form-check">

--- a/templates/login-form.php
+++ b/templates/login-form.php
@@ -68,7 +68,7 @@ do_action( 'tutor_before_login_form' );
 	<?php
 		do_action( 'tutor_login_form_middle' );
 		do_action( 'login_form' );
-		apply_filters( 'login_form_middle', '', '' );
+		apply_filters( 'login_form_middle', '', array() );
 	?>
 	<div class="tutor-flex tutor-justify-between tutor-items-center tutor-mt-9">
 		<div class="tutor-input-field tutor-w-auto">


### PR DESCRIPTION
## Summary

The `apply_filters('login_form_middle')` call in both login form templates was passing an empty string (`''`) as the second argument instead of an `array`. This causes **fatal errors** (TypeError) when third-party plugins — such as hCaptcha for WordPress — register a callback on this filter with a type-hinted `array $args` parameter, which is what WordPress core specifies.

## Root Cause

Per [WordPress core](https://developer.wordpress.org/reference/hooks/login_form_middle/), the `login_form_middle` filter signature is:

```php
apply_filters( 'login_form_middle', string , array  )
```

Tutor passes:
```php
apply_filters( 'login_form_middle', '', '' )  // ← second arg should be array
```

## Changes Made

- `templates/login-form.php:71` — Changed second argument from `''` to `array()`
- `templates/login-form-legacy.php:70` — Same fix

## Testing Instructions

1. Install a plugin that hooks into `login_form_middle` with a type-hinted array parameter (e.g., hCaptcha for WordPress)
2. Open any page with the Tutor login form or modal login
3. **Before fix:** Fatal error / blank page (TypeError)
4. **After fix:** Login form renders correctly

## Does this PR change what data or activity we track or use?

No.

Fixes #2355