### PR TITLE
Fix: Quiz answer image_id empty string fails on MariaDB strict mode

### DIFF
--- a/classes/QuizBuilder.php
+++ b/classes/QuizBuilder.php
@@ -120,6 +120,7 @@ class QuizBuilder {
 		$answer_title = Input::sanitize( wp_slash( $input['answer_title'] ) ?? '', '' );
 		$is_correct   = Input::sanitize( $input['is_correct'] ?? 0, 0, Input::TYPE_INT );
 		$image_id     = Input::sanitize( $input['image_id'] ?? null );
+		$image_id     = empty( $image_id ) ? null : (int) $image_id;
 		// Let the hook handle special cases (e.g. draw_image, pin_image) and return a normalized value (URL).
 		$answer_two_gap_match_raw = isset( $input['answer_two_gap_match'] ) ? wp_unslash( $input['answer_two_gap_match'] ) : '';
 		$answer_two_gap_match_raw = apply_filters(
@@ -170,7 +171,14 @@ class QuizBuilder {
 
 			// New answer.
 			if ( self::FLAG_NEW === $data_status ) {
-				$wpdb->insert( $answers_table, $answer_data );
+				// Filter out null values to use database column defaults.
+				$insert_data = array_filter(
+					$answer_data,
+					function ( $value ) {
+						return null !== $value;
+					}
+				);
+				$wpdb->insert( $answers_table, $insert_data );
 				$answer_id = $wpdb->insert_id;
 			}
 


### PR DESCRIPTION
## Summary

When saving a quiz answer without an image, the `image_id` value was passed as an empty string (`''`) to `wpdb->insert()`. On **MariaDB strict mode** (and MySQL strict mode), this causes a database insertion failure because the `image_id` column is defined as `bigint(20) DEFAULT NULL` — it only accepts integers or NULL, not empty strings.

## Root Cause

1. `QuizBuilder::prepare_answer_data()` calls `Input::sanitize($input['image_id'] ?? null)` which returns an empty string `''` when no image is provided
2. `wpdb->insert()` receives the empty string and passes it through `wpdb->prepare('%s', '')` producing `''`  in the SQL
3. The `image_id` column (`bigint(20) DEFAULT NULL`) rejects `''` on strict SQL modes

## Changes Made

**File: `classes/QuizBuilder.php`**

1. **`prepare_answer_data()` (line 123)** — After sanitization, convert empty `image_id` to `null`:
   ```php
   $image_id = empty( $image_id ) ? null : (int) $image_id;
   ```

2. **`save_question_answers()` (line 177)** — Filter out `null` values before `wpdb->insert()` so MySQL uses the column `DEFAULT NULL`:
   ```php
   $insert_data = array_filter(
       $answer_data,
       function ( $value ) { return null !== $value; }
   );
   $wpdb->insert( $answers_table, $insert_data );
   ```

## Steps to Reproduce

1. Use MariaDB with strict mode (`sql_mode = STRICT_TRANS_TABLES`)
2. Create a quiz with any question type that has answer options
3. Add an answer **without** selecting an image
4. Save the quiz question
5. **Before fix:** Answer fails to save (database error in debug log)
6. **After fix:** Answer saves correctly with `image_id = NULL`

## Testing Instructions

1. Switch DB to MariaDB with `STRICT_TRANS_TABLES` mode
2. Create a quiz, add a question, add answers without images
3. Verify answers are saved successfully
4. Check the `tutor_quiz_question_answers` table — `image_id` should be `NULL`
5. Also test with MySQL non-strict mode to verify no regression

## Does this PR change what data or activity we track or use?

No.

Fixes #1894