### PR TITLE
WPML Fix: Switching language throws error on translated courses dashboard

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -913,6 +913,14 @@ class Utils {
 			}
 		}
 
+		if ( ! $result && $get_stats ) {
+			$result = array(
+				'completed_percent' => 0,
+				'completed_count'   => 0,
+				'total_count'       => 0,
+			);
+		}
+
 		return apply_filters( 'tutor_course_completed_percent', $result, $course_id, $user_id, $get_stats );
 	}
 

--- a/models/CourseModel.php
+++ b/models/CourseModel.php
@@ -1381,11 +1381,15 @@ class CourseModel {
 
 				foreach ( $course_ids as $id ) {
 					foreach ( $result->posts as $post ) {
-						$post->ID == $id ? $new_array[] = $post : 0;
+						if ( $post->ID == $id ) {
+							$new_array[] = $post;
+						}
 					}
 				}
 
-				$result->posts = $new_array;
+				if ( count( $new_array ) ) {
+					$result->posts = $new_array;
+				}
 			}
 
 			return $result;


### PR DESCRIPTION
- Translated course if enrolled shows on both main dashboard and other language dashboard when language is switched, but since there is no course progress it was throwing error as the `$result` returned is 0 on `get_course_completed_percent` and it does not find the key `completed_percent`, to fix this i have checked if result is 0 and is `get_stat` is called then return the default stats array with all key value being 0

- Another issue was in `get_enrolled_courses_by_user` if the post id is not matched , the `new_array` remains empty and this modifies the `WP_Query->posts` array and the `the_post()` call returns null which is throwing error, to fix this i have checked if the `new_array` is empty so that it does not modify the `posts` array with empty array

https://app.clickup.com/t/9018365849/z8zyy1c5p2