### PR TITLE
Fix(🛠) : Lesson auto-completion not triggering completion email

### DIFF
--- a/classes/Ajax.php
+++ b/classes/Ajax.php
@@ -113,7 +113,6 @@ class Ajax {
 			LessonModel::update_lesson_reading_info( $post_id, $user_id, 'video_best_watched_time', 0 );
 
 			do_action( 'tutor_lesson_completed_email_after', $post_id, $user_id );
-			do_action( 'tutor_lesson_completed_after', $post_id, $user_id );
 		}
 		exit();
 	}

--- a/classes/Ajax.php
+++ b/classes/Ajax.php
@@ -111,6 +111,9 @@ class Ajax {
 		if ( Input::post( 'is_ended', false, Input::TYPE_BOOL ) ) {
 			LessonModel::mark_lesson_complete( $post_id );
 			LessonModel::update_lesson_reading_info( $post_id, $user_id, 'video_best_watched_time', 0 );
+
+			do_action( 'tutor_lesson_completed_email_after', $post_id, $user_id );
+			do_action( 'tutor_lesson_completed_after', $post_id, $user_id );
 		}
 		exit();
 	}


### PR DESCRIPTION
**Issue**:
Video auto-completion called **_LessonModel::mark_lesson_complete()_** directly without firing the **_tutor_lesson_completed_email_after_**  hook. As a result, completion emails were not sent when lessons were completed through video playback, unlike the manual **_Mark Complete_** flow.

**Fix:**
Updated **_sync_video_playback()_** to fire **_tutor_lesson_completed_email_after_** hook after completing the lesson, matching the existing behavior in **_Lesson::mark_lesson_complete()_**.