### PR TITLE
🐛 Fix quiz question pagination scroll and active item visibility

### DIFF
--- a/assets/src/js/frontend/learning-area/quiz/constants.ts
+++ b/assets/src/js/frontend/learning-area/quiz/constants.ts
@@ -1,3 +1,5 @@
+import { __ } from '@wordpress/i18n';
+
 export type RevealQuestionType = (typeof QUIZ_REVEAL_CONFIG.SUPPORTED_TYPES)[number];
 
 export const QUIZ_REVEAL_CONFIG = {
@@ -34,9 +36,9 @@ export const QuizLayoutType = {
 } as const;
 
 export const ERROR_MESSAGES = {
-  SUBMIT_FAILED: 'Failed to submit quiz',
-  ABANDON_FAILED: 'Failed to abandon quiz',
-  REQUIRED_QUESTIONS: 'Please answer all required questions before submitting.',
+  SUBMIT_FAILED: __('Failed to submit quiz', 'tutor'),
+  ABANDON_FAILED: __('Failed to abandon quiz', 'tutor'),
+  REQUIRED_QUESTIONS: __('Please answer all required questions before submitting.', 'tutor'),
 } as const;
 
 export const QUIZ_LAYOUT_SELECTORS = {

--- a/assets/src/js/frontend/learning-area/quiz/constants.ts
+++ b/assets/src/js/frontend/learning-area/quiz/constants.ts
@@ -40,8 +40,14 @@ export const ERROR_MESSAGES = {
 } as const;
 
 export const QUIZ_LAYOUT_SELECTORS = {
+  QUESTIONS_CONTAINER: '.tutor-quiz-questions',
   QUESTION_WRAPPER_ATTR: 'data-quiz-question-index',
   QUESTION_WRAPPER: '.tutor-quiz-question-wrapper',
+  PAGINATION: '.tutor-quiz-questions-pagination',
+  PAGINATION_ITEM_ATTR: 'data-quiz-question-index',
+  PAGINATION_ITEM: '.tutor-quiz-question-paginate-item',
+  PAGINATION_HAS_SCROLL_LEFT_ATTR: 'data-has-scroll-left',
+  PAGINATION_HAS_SCROLL_RIGHT_ATTR: 'data-has-scroll-right',
 } as const;
 
 export const QUIZ_LAYOUT_KEYS = {

--- a/assets/src/js/frontend/learning-area/quiz/helpers.ts
+++ b/assets/src/js/frontend/learning-area/quiz/helpers.ts
@@ -137,3 +137,63 @@ export const getAttemptedQuestionCountFromForm = (formId: string): number => {
   const values = form.getFormState(formId).values ?? {};
   return getAttemptedQuestionCount(values);
 };
+
+/**
+ * Attaches mouse drag-to-scroll behaviour to a horizontally scrollable element.
+ * Skips drag when the element has no overflow. Suppresses click events on child
+ * elements when the pointer moved enough to count as a drag (prevents accidental
+ * navigation after a drag gesture).
+ *
+ * @returns A cleanup function that removes all attached listeners.
+ */
+export const createDragScroll = (el: HTMLElement): (() => void) => {
+  let isDragging = false;
+  let startX = 0;
+  let startScrollLeft = 0;
+  let hasDragged = false;
+
+  const onMouseDown = (e: MouseEvent) => {
+    if (el.scrollWidth - el.clientWidth <= 1) return;
+    isDragging = true;
+    hasDragged = false;
+    startX = e.pageX - el.offsetLeft;
+    startScrollLeft = el.scrollLeft;
+  };
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (!isDragging) return;
+    e.preventDefault();
+    const x = e.pageX - el.offsetLeft;
+    const delta = x - startX;
+    if (Math.abs(delta) > 3) hasDragged = true;
+    el.scrollLeft = startScrollLeft - delta;
+  };
+
+  const onMouseUp = () => {
+    isDragging = false;
+  };
+  const onMouseLeave = () => {
+    isDragging = false;
+  };
+
+  const onClickCapture = (e: MouseEvent) => {
+    if (hasDragged) {
+      e.stopPropagation();
+      hasDragged = false;
+    }
+  };
+
+  el.addEventListener('mousedown', onMouseDown);
+  el.addEventListener('mousemove', onMouseMove);
+  el.addEventListener('mouseup', onMouseUp);
+  el.addEventListener('mouseleave', onMouseLeave);
+  el.addEventListener('click', onClickCapture, true);
+
+  return () => {
+    el.removeEventListener('mousedown', onMouseDown);
+    el.removeEventListener('mousemove', onMouseMove);
+    el.removeEventListener('mouseup', onMouseUp);
+    el.removeEventListener('mouseleave', onMouseLeave);
+    el.removeEventListener('click', onClickCapture, true);
+  };
+};

--- a/assets/src/js/frontend/learning-area/quiz/layout.ts
+++ b/assets/src/js/frontend/learning-area/quiz/layout.ts
@@ -17,6 +17,9 @@ const quizLayout = (config: QuizLayoutConfig) => {
 
   let handleFirstTab: ((e: KeyboardEvent) => void) | null = null;
   let handleMouseDown: (() => void) | null = null;
+  let paginationEl: HTMLElement | null | undefined = null;
+  let handlePaginationScroll: (() => void) | null = null;
+  let paginationResizeObserver: ResizeObserver | null = null;
 
   return {
     layout: config.layout ?? QuizLayoutType.QUESTION_BELOW_EACH_OTHER,
@@ -37,7 +40,7 @@ const quizLayout = (config: QuizLayoutConfig) => {
     $root: null as HTMLElement | null,
 
     init() {
-      container = (this.$root ?? this.$el)?.querySelector('.tutor-quiz-questions');
+      container = (this.$root ?? this.$el)?.querySelector(QUIZ_LAYOUT_SELECTORS.QUESTIONS_CONTAINER);
 
       // Keyboard vs Mouse Navigation helper for focus styles
       handleFirstTab = (e: KeyboardEvent) => {
@@ -71,6 +74,25 @@ const quizLayout = (config: QuizLayoutConfig) => {
       }
       this.currentIndex = 1;
       this.syncCurrentRevealFooterState();
+
+      paginationEl = (this.$root ?? this.$el)?.querySelector<HTMLElement>(QUIZ_LAYOUT_SELECTORS.PAGINATION) ?? null;
+      if (paginationEl) {
+        handlePaginationScroll = () => {
+          this.updatePaginationScrollState();
+        };
+        paginationEl.addEventListener('scroll', handlePaginationScroll, { passive: true });
+
+        if (typeof ResizeObserver !== 'undefined') {
+          paginationResizeObserver = new ResizeObserver(() => {
+            this.updatePaginationScrollState();
+          });
+          paginationResizeObserver.observe(paginationEl);
+        }
+
+        window.requestAnimationFrame(() => {
+          this.updatePaginationScrollState();
+        });
+      }
     },
 
     destroy() {
@@ -80,6 +102,13 @@ const quizLayout = (config: QuizLayoutConfig) => {
       if (handleMouseDown) {
         window.removeEventListener('mousedown', handleMouseDown);
         window.removeEventListener('touchstart', handleMouseDown);
+      }
+      if (paginationEl && handlePaginationScroll) {
+        paginationEl.removeEventListener('scroll', handlePaginationScroll);
+      }
+      if (paginationResizeObserver) {
+        paginationResizeObserver.disconnect();
+        paginationResizeObserver = null;
       }
     },
 
@@ -525,6 +554,54 @@ const quizLayout = (config: QuizLayoutConfig) => {
         return;
       }
       wrapper.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      this.scrollPaginationToCurrentQuestion();
+    },
+
+    updatePaginationScrollState() {
+      const root = this.$root ?? this.$el;
+      const pagination = paginationEl ?? root?.querySelector<HTMLElement>(QUIZ_LAYOUT_SELECTORS.PAGINATION) ?? null;
+      if (!pagination) {
+        return;
+      }
+
+      const maxScrollLeft = pagination.scrollWidth - pagination.clientWidth;
+      const hasOverflow = maxScrollLeft > 1;
+
+      if (!hasOverflow) {
+        pagination.setAttribute(QUIZ_LAYOUT_SELECTORS.PAGINATION_HAS_SCROLL_LEFT_ATTR, 'false');
+        pagination.setAttribute(QUIZ_LAYOUT_SELECTORS.PAGINATION_HAS_SCROLL_RIGHT_ATTR, 'false');
+        return;
+      }
+
+      const scrollLeft = pagination.scrollLeft;
+      const hasScrollLeft = scrollLeft > 1;
+      const hasScrollRight = scrollLeft < maxScrollLeft - 1;
+
+      pagination.setAttribute(QUIZ_LAYOUT_SELECTORS.PAGINATION_HAS_SCROLL_LEFT_ATTR, hasScrollLeft ? 'true' : 'false');
+      pagination.setAttribute(
+        QUIZ_LAYOUT_SELECTORS.PAGINATION_HAS_SCROLL_RIGHT_ATTR,
+        hasScrollRight ? 'true' : 'false',
+      );
+    },
+
+    scrollPaginationToCurrentQuestion() {
+      const root = this.$root ?? this.$el;
+      const pagination = paginationEl ?? root?.querySelector<HTMLElement>(QUIZ_LAYOUT_SELECTORS.PAGINATION) ?? null;
+      const item = pagination?.querySelector<HTMLElement>(
+        `${QUIZ_LAYOUT_SELECTORS.PAGINATION_ITEM}[${QUIZ_LAYOUT_SELECTORS.PAGINATION_ITEM_ATTR}="${this.currentIndex}"]`,
+      );
+
+      if (!pagination || !item) {
+        return;
+      }
+
+      window.requestAnimationFrame(() => {
+        pagination.scrollTo({
+          left: item.offsetLeft - (pagination.clientWidth - item.offsetWidth) / 2,
+          behavior: 'smooth',
+        });
+        this.updatePaginationScrollState();
+      });
     },
 
     getQuestionIdByIndex(values: Record<string, unknown>, index: number) {

--- a/assets/src/js/frontend/learning-area/quiz/layout.ts
+++ b/assets/src/js/frontend/learning-area/quiz/layout.ts
@@ -1,7 +1,7 @@
 import type { AlpineComponentMeta } from '@Core/ts/types';
 
 import { QUIZ_LAYOUT_KEYS, QUIZ_LAYOUT_SELECTORS, QUIZ_REVEAL_CONFIG, QuizLayoutType } from './constants';
-import { revealQuestionWithAnswers } from './helpers';
+import { createDragScroll, revealQuestionWithAnswers } from './helpers';
 
 export interface QuizLayoutConfig {
   layout: (typeof QuizLayoutType)[keyof typeof QuizLayoutType];
@@ -20,6 +20,7 @@ const quizLayout = (config: QuizLayoutConfig) => {
   let paginationEl: HTMLElement | null | undefined = null;
   let handlePaginationScroll: (() => void) | null = null;
   let paginationResizeObserver: ResizeObserver | null = null;
+  let destroyDragScroll: (() => void) | null = null;
 
   return {
     layout: config.layout ?? QuizLayoutType.QUESTION_BELOW_EACH_OTHER,
@@ -92,6 +93,8 @@ const quizLayout = (config: QuizLayoutConfig) => {
         window.requestAnimationFrame(() => {
           this.updatePaginationScrollState();
         });
+
+        destroyDragScroll = createDragScroll(paginationEl);
       }
     },
 
@@ -106,6 +109,7 @@ const quizLayout = (config: QuizLayoutConfig) => {
       if (paginationEl && handlePaginationScroll) {
         paginationEl.removeEventListener('scroll', handlePaginationScroll);
       }
+      destroyDragScroll?.();
       if (paginationResizeObserver) {
         paginationResizeObserver.disconnect();
         paginationResizeObserver = null;

--- a/assets/src/scss/frontend/components/_quiz-attempt-details.scss
+++ b/assets/src/scss/frontend/components/_quiz-attempt-details.scss
@@ -287,7 +287,23 @@
     padding: $tutor-spacing-4;
     overflow: hidden;
 
+    &:has(.tutor-quiz-review-item-title) {
+      @include tutor-flex(column, flex-start, center);
+      gap: $tutor-spacing-none;
+    }
+
+    .tutor-quiz-review-item-title {
+      @include tutor-typography(tiny);
+      color: inherit;
+      min-width: 0;
+      overflow-wrap: break-word;
+      word-break: break-word;
+    }
+
+    .tutor-quiz-review-item-text,
     span {
+      @include tutor-typography(small, semibold);
+      color: inherit;
       min-width: 0;
       overflow-wrap: break-word;
       word-break: break-word;

--- a/assets/src/scss/frontend/learning-area/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/_quiz.scss
@@ -521,6 +521,21 @@ $tutor-quiz-content-bottom-offset: calc(
         max-width: none;
         margin-inline: auto;
       }
+
+      @media (hover: hover) and (pointer: fine) {
+        &[data-has-scroll-left='true'],
+        &[data-has-scroll-right='true'] {
+          cursor: grab;
+
+          &:active {
+            cursor: grabbing;
+
+            .tutor-quiz-question-paginate-item {
+              cursor: grabbing;
+            }
+          }
+        }
+      }
     }
 
     &[data-pagination-style='shape'] {

--- a/assets/src/scss/frontend/learning-area/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/_quiz.scss
@@ -5,7 +5,7 @@ $tutor-admin-bar-height: 46px;
 $tutor-quiz-header-offset: 96px;
 $tutor-quiz-footer-offset: 96px;
 $tutor-quiz-pagination-gap-from-footer: 32px;
-$tutor-quiz-pagination-height: 48px;
+$tutor-quiz-pagination-height: 60px;
 $tutor-quiz-content-bottom-offset: calc(
   #{$tutor-quiz-pagination-gap-from-footer} + #{$tutor-quiz-pagination-height} + #{$tutor-spacing-2}
 );
@@ -447,6 +447,82 @@ $tutor-quiz-content-bottom-offset: calc(
       }
     }
 
+    &[data-pagination-style='shape'],
+    &[data-pagination-style='radio'],
+    &[data-pagination-style='number'] {
+      @include tutor-frontend-layout();
+      width: calc(100dvw - #{$tutor-spacing-8});
+      justify-content: flex-start;
+      padding-block: 10px;
+      overflow-x: auto;
+      overflow-y: hidden;
+      overscroll-behavior-x: contain;
+      scrollbar-width: none;
+      -webkit-mask-image: none;
+      mask-image: none;
+      transition:
+        -webkit-mask-image 0.25s ease,
+        mask-image 0.25s ease;
+
+      &[data-has-scroll-left='true'][data-has-scroll-right='true'] {
+        -webkit-mask-image: linear-gradient(
+          to right,
+          transparent 0,
+          black #{$tutor-spacing-10},
+          black calc(100% - #{$tutor-spacing-10}),
+          transparent 100%
+        );
+        mask-image: linear-gradient(
+          to right,
+          transparent 0,
+          black #{$tutor-spacing-10},
+          black calc(100% - #{$tutor-spacing-10}),
+          transparent 100%
+        );
+      }
+
+      &[data-has-scroll-left='true'][data-has-scroll-right='false'] {
+        -webkit-mask-image: linear-gradient(
+          to right,
+          transparent 0,
+          black #{$tutor-spacing-10},
+          black 100%
+        );
+        mask-image: linear-gradient(
+          to right,
+          transparent 0,
+          black #{$tutor-spacing-10},
+          black 100%
+        );
+      }
+
+      &[data-has-scroll-left='false'][data-has-scroll-right='true'] {
+        -webkit-mask-image: linear-gradient(
+          to right,
+          black 0,
+          black calc(100% - #{$tutor-spacing-10}),
+          transparent 100%
+        );
+        mask-image: linear-gradient(
+          to right,
+          black 0,
+          black calc(100% - #{$tutor-spacing-10}),
+          transparent 100%
+        );
+      }
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+
+      ul {
+        flex-wrap: nowrap;
+        width: max-content;
+        max-width: none;
+        margin-inline: auto;
+      }
+    }
+
     &[data-pagination-style='shape'] {
       ul {
         gap: $tutor-spacing-2;
@@ -611,10 +687,7 @@ $tutor-quiz-content-bottom-offset: calc(
 
     &[data-pagination-style='number'] {
       ul {
-        flex-wrap: nowrap;
-        max-width: 100%;
         height: 28px;
-        overflow: visible;
         background-color: $tutor-surface-l1;
         border: 1px solid $tutor-border-idle;
         border-radius: $tutor-radius-full;

--- a/templates/learning-area/quiz/attempt.php
+++ b/templates/learning-area/quiz/attempt.php
@@ -235,6 +235,7 @@ $default_values = array(
 						<button
 							type="button"
 							class="tutor-quiz-question-paginate-item"
+							data-quiz-question-index="<?php echo esc_attr( $index + 1 ); ?>"
 							:class="getPaginationItemClass(<?php echo esc_attr( $index + 1 ); ?>)"
 							:data-state="getPaginationState(<?php echo esc_attr( $index + 1 ); ?>)"
 							@click="goTo(<?php echo esc_attr( $index + 1 ); ?>)"

--- a/templates/shared/components/quiz/attempt-details/questions/review-answer-dnd.php
+++ b/templates/shared/components/quiz/attempt-details/questions/review-answer-dnd.php
@@ -75,6 +75,7 @@ if ( 'ordering' === $question_type ) {
 		$is_row_ok     = $normalize( $given_text ) === $normalize( $correct_text );
 
 		$rows[] = array(
+			'answer_title'  => ! $is_image_matching ? ( $correct_item->answer_title ?? '' ) : '',
 			'given_text'    => $given_text,
 			'given_image'   => $is_image_matching && $selected_item ? $get_image_url( $selected_item ) : '',
 			'correct_text'  => $correct_text,
@@ -112,22 +113,29 @@ if ( 'ordering' === $question_type ) {
 	<div class="tutor-quiz-review-dnd-rows">
 		<?php
 		foreach ( $rows as $row ) :
+			$answer_title = isset( $row['answer_title'] ) ? Quiz::sanitize_quiz_content( $row['answer_title'] ) : '';
 			$given_text   = isset( $row['given_text'] ) ? Quiz::sanitize_quiz_content( $row['given_text'] ) : '';
 			$correct_text = isset( $row['correct_text'] ) ? Quiz::sanitize_quiz_content( $row['correct_text'] ) : '';
 			$given_status = isset( $row['given_status'] ) ? $row['given_status'] : 'neutral';
 			?>
 			<div class="tutor-quiz-review-dnd-row">
 				<div class="tutor-quiz-review-item tutor-quiz-review-given" data-option="<?php echo esc_attr( $given_status ); ?>">
+					<?php if ( ! empty( $answer_title ) ) : ?>
+						<div class="tutor-quiz-review-item-title"><?php echo esc_html( $answer_title ); ?></div>
+					<?php endif; ?>
 					<?php if ( ! empty( $row['given_image'] ) ) : ?>
 						<img src="<?php echo esc_url( $row['given_image'] ); ?>" alt="<?php echo esc_attr( $given_text ); ?>">
 					<?php endif; ?>
-					<span><?php echo esc_html( $given_text ); ?></span>
+					<span class="tutor-quiz-review-item-text"><?php echo esc_html( '' !== $given_text ? $given_text : '—' ); ?></span>
 				</div>
 				<div class="tutor-quiz-review-item tutor-quiz-review-correct" data-option="neutral">
+					<?php if ( ! empty( $answer_title ) ) : ?>
+						<div class="tutor-quiz-review-item-title"><?php echo esc_html( $answer_title ); ?></div>
+					<?php endif; ?>
 					<?php if ( ! empty( $row['correct_image'] ) ) : ?>
 						<img src="<?php echo esc_url( $row['correct_image'] ); ?>" alt="<?php echo esc_attr( $correct_text ); ?>">
 					<?php endif; ?>
-					<span><?php echo esc_html( $correct_text ); ?></span>
+					<span class="tutor-quiz-review-item-text"><?php echo esc_html( $correct_text ); ?></span>
 				</div>
 			</div>
 		<?php endforeach; ?>


### PR DESCRIPTION
- Fixes the question pagination overflowing horizontally in the quiz learning area.
- Adds edge fade indicators on the pagination when items are scrollable.
- Auto-scrolls the pagination to keep the active question item in view.
- Adds a `data-quiz-question-index` attribute to pagination items for targeting.
- Keeps the currently active question visible when navigating between questions.
