### PR TITLE
🛠️[QNA] Ask question loader not removing

### DIFF
--- a/assets/src/js/v2/qna.js
+++ b/assets/src/js/v2/qna.js
@@ -103,7 +103,7 @@ window.jQuery(document).ready($=>{
         const closestWrapper = button.closest('.tutor-qna-reply-editor');
         if (_tutorobject.tutor_pro_url && tinymce) {
             // Current editor id
-            currentEditor = closestWrapper.querySelector('.tmce-active').getAttribute('id').split('-')[1];
+            currentEditor = closestWrapper.find('.tmce-active').attr('id').split('-')[1];
         }
         let form        = button.closest('[data-question_id]');
 

--- a/assets/src/js/v2/qna.js
+++ b/assets/src/js/v2/qna.js
@@ -100,7 +100,7 @@ window.jQuery(document).ready($=>{
     $(document).on('click', '.tutor-qa-reply button.tutor-btn, .tutor-qa-new button.sidebar-ask-new-qna-submit-btn', function(e){
         let button      = $(this);
         let currentEditor = '';
-        const closestWrapper = e.target.closest('.tutor-qna-reply-editor');
+        const closestWrapper = button.closest('.tutor-qna-reply-editor');
         if (_tutorobject.tutor_pro_url && tinymce) {
             // Current editor id
             currentEditor = closestWrapper.querySelector('.tmce-active').getAttribute('id').split('-')[1];


### PR DESCRIPTION
What happened during tutor_qna_create_update:

When you clicked "Ask Question", the script sent the `tutor_qna_create_update` AJAX request and added `.is-loading` to the button.
When the backend returned a successful response `(resp.success = true)`, the JavaScript entered the success callback in 

```javascript
// closestWrapper was created using e.target.closest() (vanilla DOM Node 'n')
if (closestWrapper.find('textarea').length) {
    closestWrapper.find('textarea').val();
}
``` 
Because `closestWrapper` was a native DOM element (not a jQuery object), calling `closestWrapper.find()` threw:
`tutor.js:1098 Uncaught TypeError: n.find is not a function`