### PR TITLE
🐛 Fix lesson video duration sync and video meta handling

### DIFF
--- a/assets/src/js/v3/entries/course-builder/components/modals/LessonModal.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/modals/LessonModal.tsx
@@ -409,9 +409,13 @@ const LessonModal = ({
                     )
                   }
                   onGetDuration={(duration) => {
-                    form.setValue('duration.hour', duration.hours);
-                    form.setValue('duration.minute', duration.minutes);
-                    form.setValue('duration.second', duration.seconds);
+                    if (!form.getFieldState('video').isDirty) {
+                      return;
+                    }
+
+                    form.setValue('duration.hour', duration.hours, { shouldDirty: true });
+                    form.setValue('duration.minute', duration.minutes, { shouldDirty: true });
+                    form.setValue('duration.second', duration.seconds, { shouldDirty: true });
                   }}
                   visibilityKey={VisibilityControlKeys.COURSE_BUILDER.CURRICULUM.LESSON.VIDEO}
                 />

--- a/assets/src/js/v3/entries/course-builder/components/modals/LessonModal.tsx
+++ b/assets/src/js/v3/entries/course-builder/components/modals/LessonModal.tsx
@@ -408,14 +408,19 @@ const LessonModal = ({
                       formatBytes(Number(tutorConfig?.max_upload_size || 0)),
                     )
                   }
-                  onGetDuration={(duration) => {
+                  onChange={(video) => {
+                    if (video?.source) {
+                      return;
+                    }
+
+                    form.setValue('duration', { hour: 0, minute: 0, second: 0 }, { shouldDirty: true });
+                  }}
+                  onGetDuration={({ hours, minutes, seconds }) => {
                     if (!form.getFieldState('video').isDirty) {
                       return;
                     }
 
-                    form.setValue('duration.hour', duration.hours, { shouldDirty: true });
-                    form.setValue('duration.minute', duration.minutes, { shouldDirty: true });
-                    form.setValue('duration.second', duration.seconds, { shouldDirty: true });
+                    form.setValue('duration', { hour: hours, minute: minutes, second: seconds }, { shouldDirty: true });
                   }}
                   visibilityKey={VisibilityControlKeys.COURSE_BUILDER.CURRICULUM.LESSON.VIDEO}
                 />

--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -1893,7 +1893,7 @@ class Utils {
 		}
 
 		$resolved_path = isset( $info['path'] ) ? $info['path'] : null;
-		$info          = array_merge( $info, $this->filter_video_meta( (array) $video ) );
+		$info          = array_merge( $this->filter_video_meta( (array) $video ), $info );
 
 		if ( $resolved_path ) {
 			$info['path'] = $resolved_path;


### PR DESCRIPTION
- Fixes the lesson video duration not staying in sync with the uploaded video in the course builder.
- Prevents duration being silently overwritten while the video field has not been touched.
- Resets the video duration to zero when the selected video is removed.
- Fixes resolved video info being overwritten by default metadata during video meta filtering.

https://app.clickup.com/t/9018365849/z8zyy1cq9x