### PR TITLE
🐛 Add go-to content links in Q&A single views and deep-linkable course tabs

### DIFF
--- a/assets/src/scss/frontend/components/_discussion-single.scss
+++ b/assets/src/scss/frontend/components/_discussion-single.scss
@@ -41,8 +41,3 @@
     @include tutor-flex(0);
   }
 }
-
-// @TODO:: Will be removed after transition.scss merged
-.tutor-animate-spin {
-  @include tutor-spin();
-}

--- a/templates/dashboard/discussions/comment-single.php
+++ b/templates/dashboard/discussions/comment-single.php
@@ -7,6 +7,9 @@
  * @author Themeum <support@themeum.com>
  * @link https://themeum.com
  * @since 4.0.0
+ *
+ * @var int    $discussion_id
+ * @var string $discussion_url
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -60,13 +63,12 @@ $action_url = add_query_arg( 'page_tab', 'comments', get_permalink( $lesson_comm
 				->label( __( 'Go to Lesson', 'tutor' ) )
 				->variant( Variant::LINK )
 				->size( Size::X_SMALL )
-				->icon( Icon::CHEVRON_RIGHT, 'right' )
+				->icon( Icon::CHEVRON_RIGHT_2, 'right' )
 				->flip_rtl()
 				->tag( 'a' )
 				->attr( 'href', esc_url( $action_url ) )
 				->attr( 'target', '_blank' )
 				->attr( 'rel', 'noopener noreferrer' )
-				->attr( 'class', 'tutor-gap-2' )
 				->render();
 			?>
 		<?php endif; ?>

--- a/templates/dashboard/discussions/comment-single.php
+++ b/templates/dashboard/discussions/comment-single.php
@@ -24,6 +24,7 @@ use Tutor\Components\Constants\Color;
 use Tutor\Components\Constants\Variant;
 use TUTOR\Input;
 use TUTOR\Lesson;
+use TUTOR\User;
 
 $lesson_comment = get_comment( $discussion_id );
 if ( ! $lesson_comment ) {
@@ -40,11 +41,12 @@ $comment_delete_modal_id = 'tutor-comment-delete-modal';
 $replies_order = Input::get( 'order', 'DESC' );
 $replies       = Lesson::get_comment_replies( $discussion_id, $replies_order );
 
-$course = get_post( tutor_utils()->get_course_id_by( 'lesson', $lesson_comment->comment_post_ID ) );
+$course     = get_post( tutor_utils()->get_course_id_by( 'lesson', $lesson_comment->comment_post_ID ) );
+$action_url = add_query_arg( 'page_tab', 'comments', get_permalink( $lesson_comment->comment_post_ID ) );
 
 ?>
 <div class="tutor-discussion-single">
-	<div class="tutor-flex tutor-justify-between tutor-px-6 tutor-py-5 tutor-border-b">
+	<div class="tutor-flex tutor-justify-between tutor-items-center tutor-px-6 tutor-py-5 tutor-border-b">
 		<a 
 			href="<?php echo esc_url( UrlHelper::add_query_params( $discussion_url, array( 'tab' => 'lesson-comments' ) ) ); ?>" 
 			class="tutor-btn tutor-btn-secondary tutor-btn-small tutor-gap-2"
@@ -52,6 +54,22 @@ $course = get_post( tutor_utils()->get_course_id_by( 'lesson', $lesson_comment->
 			<?php SvgIcon::make()->name( Icon::ARROW_LEFT_2 )->flip_rtl()->render(); ?>
 			<?php esc_html_e( 'Back', 'tutor' ); ?>
 		</a>
+		<?php if ( User::is_student_view() && ! empty( $action_url ) ) : ?>
+			<?php
+			Button::make()
+				->label( __( 'Go to Lesson', 'tutor' ) )
+				->variant( Variant::LINK )
+				->size( Size::X_SMALL )
+				->icon( Icon::CHEVRON_RIGHT, 'right' )
+				->flip_rtl()
+				->tag( 'a' )
+				->attr( 'href', esc_url( $action_url ) )
+				->attr( 'target', '_blank' )
+				->attr( 'rel', 'noopener noreferrer' )
+				->attr( 'class', 'tutor-gap-2' )
+				->render();
+			?>
+		<?php endif; ?>
 	</div>
 	<div class="tutor-discussion-single-body tutor-p-6 tutor-border-b">
 		<div class="tutor-flex tutor-gap-5 tutor-mb-5">

--- a/templates/dashboard/discussions/qna-single.php
+++ b/templates/dashboard/discussions/qna-single.php
@@ -40,9 +40,21 @@ $is_solved    = (int) tutor_utils()->array_get( 'tutor_qna_solved', $question->m
 $is_important = (int) tutor_utils()->array_get( 'tutor_qna_important', $question->meta, 0 );
 $is_archived  = (int) tutor_utils()->array_get( 'tutor_qna_archived', $question->meta, 0 );
 
+$content_post_type = get_post_type( $question->comment_post_ID );
+$action_url        = '';
+$action_text       = '';
+
+if ( tutor()->lesson_post_type === $content_post_type ) {
+	$action_url  = add_query_arg( 'page_tab', 'comments', get_permalink( $question->comment_post_ID ) );
+	$action_text = __( 'Go to Lesson', 'tutor' );
+} elseif ( tutor()->course_post_type === $content_post_type ) {
+	$action_url  = add_query_arg( 'page_tab', 'qna', get_permalink( $question->comment_post_ID ) );
+	$action_text = __( 'Go to all Q&A', 'tutor' );
+}
+
 ?>
 <div class="tutor-discussion-single" x-init="isSolved = <?php echo $is_solved ? 'true' : 'false'; ?>; isImportant = <?php echo $is_important ? 'true' : 'false'; ?>; isArchived = <?php echo $is_archived ? 'true' : 'false'; ?>;">
-	<div class="tutor-flex tutor-justify-between tutor-px-6 tutor-py-5 tutor-border-b">
+	<div class="tutor-flex tutor-justify-between tutor-items-center tutor-px-6 tutor-py-5 tutor-border-b">
 		<a href="<?php echo esc_url( $discussion_url ); ?>" class="tutor-btn tutor-btn-secondary tutor-btn-small tutor-gap-2">
 			<?php SvgIcon::make()->name( Icon::ARROW_LEFT_2 )->flip_rtl()->render(); ?>
 			<?php esc_html_e( 'Back', 'tutor' ); ?>
@@ -91,6 +103,21 @@ $is_archived  = (int) tutor_utils()->array_get( 'tutor_qna_archived', $question-
 				<?php esc_html_e( 'Important', 'tutor' ); ?>
 			</button>
 		</div>
+		<?php elseif ( User::is_student_view() && ! empty( $action_url ) ) : ?>
+			<?php
+			Button::make()
+				->label( $action_text )
+				->variant( Variant::LINK )
+				->size( Size::X_SMALL )
+				->icon( Icon::CHEVRON_RIGHT, 'right' )
+				->flip_rtl()
+				->tag( 'a' )
+				->attr( 'href', esc_url( $action_url ) )
+				->attr( 'target', '_blank' )
+				->attr( 'rel', 'noopener noreferrer' )
+				->attr( 'class', 'tutor-gap-2' )
+				->render();
+			?>
 		<?php endif; ?>
 	</div>
 	<div class="tutor-discussion-single-body tutor-p-6 tutor-border-b">

--- a/templates/dashboard/discussions/qna-single.php
+++ b/templates/dashboard/discussions/qna-single.php
@@ -7,6 +7,9 @@
  * @author Themeum <support@themeum.com>
  * @link https://themeum.com
  * @since 4.0.0
+ *
+ * @var int    $discussion_id
+ * @var string $discussion_url
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -24,7 +27,7 @@ use TUTOR\Input;
 use TUTOR\User;
 
 $question = tutor_utils()->get_qa_question( (int) $discussion_id );
-if ( ! $question ) {
+if ( ! is_object( $question ) ) {
 	wp_safe_redirect( $discussion_url );
 	return;
 }
@@ -40,18 +43,7 @@ $is_solved    = (int) tutor_utils()->array_get( 'tutor_qna_solved', $question->m
 $is_important = (int) tutor_utils()->array_get( 'tutor_qna_important', $question->meta, 0 );
 $is_archived  = (int) tutor_utils()->array_get( 'tutor_qna_archived', $question->meta, 0 );
 
-$content_post_type = get_post_type( $question->comment_post_ID );
-$action_url        = '';
-$action_text       = '';
-
-if ( tutor()->lesson_post_type === $content_post_type ) {
-	$action_url  = add_query_arg( 'page_tab', 'comments', get_permalink( $question->comment_post_ID ) );
-	$action_text = __( 'Go to Lesson', 'tutor' );
-} elseif ( tutor()->course_post_type === $content_post_type ) {
-	$action_url  = add_query_arg( 'page_tab', 'qna', get_permalink( $question->comment_post_ID ) );
-	$action_text = __( 'Go to all Q&A', 'tutor' );
-}
-
+$action_url = add_query_arg( 'page_tab', 'qna', get_permalink( $question->comment_post_ID ) );
 ?>
 <div class="tutor-discussion-single" x-init="isSolved = <?php echo $is_solved ? 'true' : 'false'; ?>; isImportant = <?php echo $is_important ? 'true' : 'false'; ?>; isArchived = <?php echo $is_archived ? 'true' : 'false'; ?>;">
 	<div class="tutor-flex tutor-justify-between tutor-items-center tutor-px-6 tutor-py-5 tutor-border-b">
@@ -106,16 +98,15 @@ if ( tutor()->lesson_post_type === $content_post_type ) {
 		<?php elseif ( User::is_student_view() && ! empty( $action_url ) ) : ?>
 			<?php
 			Button::make()
-				->label( $action_text )
+				->label( __( 'Go to all Q&A', 'tutor' ) )
 				->variant( Variant::LINK )
 				->size( Size::X_SMALL )
-				->icon( Icon::CHEVRON_RIGHT, 'right' )
+				->icon( Icon::CHEVRON_RIGHT_2, 'right' )
 				->flip_rtl()
 				->tag( 'a' )
 				->attr( 'href', esc_url( $action_url ) )
 				->attr( 'target', '_blank' )
 				->attr( 'rel', 'noopener noreferrer' )
-				->attr( 'class', 'tutor-gap-2' )
 				->render();
 			?>
 		<?php endif; ?>

--- a/templates/single-course.php
+++ b/templates/single-course.php
@@ -11,6 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Tutor\Models\EnrollmentModel;
+use TUTOR\Input;
 
 $course_id     = get_the_ID();
 $course_rating = tutor_utils()->get_course_rating( $course_id );
@@ -56,14 +57,32 @@ $is_enabled_wishlist = tutor_utils()->get_option( 'enable_wishlist', true );
 				<?php endif; ?>
 
 				<div class="tutor-course-details-tab tutor-mt-32">
+					<?php
+					$active_tab = Input::get( 'page_tab', Input::get( 'tab', 'info' ) );
+					if ( 'qna' === $active_tab ) {
+						$active_tab = 'questions';
+					}
+					if ( ! is_array( $course_nav_item ) || ! array_key_exists( $active_tab, $course_nav_item ) ) {
+						$active_tab = 'info';
+					}
+					$default_active_key = apply_filters( 'tutor_default_topics_active_tab', $active_tab );
+					?>
 					<?php if ( is_array( $course_nav_item ) && count( $course_nav_item ) > 1 ) : ?>
 						<div class="tutor-is-sticky">
-							<?php tutor_load_template( 'single.course.enrolled.nav', array( 'course_nav_item' => $course_nav_item ) ); ?>
+							<?php
+							tutor_load_template(
+								'single.course.enrolled.nav',
+								array(
+									'course_nav_item'    => $course_nav_item,
+									'default_active_key' => $default_active_key,
+								)
+							);
+							?>
 						</div>
 					<?php endif; ?>
 					<div class="tutor-tab tutor-pt-24">
 						<?php foreach ( $course_nav_item as $key => $subpage ) : ?>
-							<div id="tutor-course-details-tab-<?php echo esc_attr( $key ); ?>" class="tutor-tab-item<?php echo 'info' == $key ? ' is-active' : ''; ?>">
+							<div id="tutor-course-details-tab-<?php echo esc_attr( $key ); ?>" class="tutor-tab-item<?php echo $default_active_key == $key ? ' is-active' : ''; ?>">
 								<?php
 									do_action( 'tutor_course/single/tab/' . $key . '/before' );
 

--- a/templates/single/course/enrolled/nav.php
+++ b/templates/single/course/enrolled/nav.php
@@ -18,14 +18,11 @@ do_action( 'tutor_course/single/enrolled/nav/before' );
 ?>
 <nav class="tutor-nav" tutor-priority-nav>
 	<?php
+	$active_key = isset( $default_active_key ) ? $default_active_key : apply_filters( 'tutor_default_topics_active_tab', 'info' );
 	foreach ( $course_nav_item as $nav_key => $nav_item ) {
-		/**
-		 * Apply filters to show default active tab
-		 */
-		$default_active_key = apply_filters( 'tutor_default_topics_active_tab', 'info' );
 		?>
 				<li class="tutor-nav-item">
-					<a class="tutor-nav-link<?php echo $nav_key == $default_active_key ? ' is-active' : ''; ?>" href="#" data-tutor-nav-target="tutor-course-details-tab-<?php echo esc_attr( $nav_key ); ?>"><?php echo esc_html( $nav_item['title'] ); ?></a>
+					<a class="tutor-nav-link<?php echo $nav_key == $active_key ? ' is-active' : ''; ?>" href="#" data-tutor-nav-target="tutor-course-details-tab-<?php echo esc_attr( $nav_key ); ?>"><?php echo esc_html( $nav_item['title'] ); ?></a>
 				</li>
 			<?php
 	}


### PR DESCRIPTION
- Add "Go to Lesson" action link on the lesson comment single page for student view
- Add "Go to Lesson" / "Go to all Q&A" action links on the Q&A single page based on content type
- Support opening a specific course details tab via the `page_tab` query parameter
- Map `page_tab=qna` to the questions tab when resolving the active tab
- Pass the resolved active tab to the course enrolled nav so tab and content stay in sync
- Align discussion single page header items vertically
- Remove obsolete `.tutor-animate-spin` style block

https://app.clickup.com/t/9018365849/z8zyy1dcpv
