### PR TITLE
🐛 Fix quiz total marks calculation when question order is random

### DIFF
--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -1081,16 +1081,16 @@ class Quiz {
 		$total_marks = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT CASE
-        WHEN %s = 'rand' AND %d > 0 AND COUNT(question_id) > %d THEN 0
-        ELSE (
-          SELECT SUM(questions.question_mark) FROM (
-            SELECT question_mark
-            FROM {$wpdb->prefix}tutor_quiz_questions
-            WHERE quiz_id = %d
-            ORDER BY {$order_by}
-            LIMIT %d
-          ) AS questions
-        )
+				WHEN %s = 'rand' AND %d > 0 AND COUNT(question_id) > %d THEN 0
+				ELSE (
+					SELECT SUM(questions.question_mark) FROM (
+						SELECT question_mark
+						FROM {$wpdb->prefix}tutor_quiz_questions
+						WHERE quiz_id = %d
+						ORDER BY {$order_by}
+						LIMIT %d
+					) AS questions
+				)
 				END
 				FROM {$wpdb->prefix}tutor_quiz_questions
 				WHERE quiz_id = %d",

--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -1068,39 +1068,49 @@ class Quiz {
 		$max_questions   = (int) tutor_utils()->get_quiz_option( $quiz_id, 'max_questions_for_answer' );
 		$questions_order = tutor_utils()->get_quiz_option( $quiz_id, 'questions_order', 'rand' );
 
-		$order_by_map = array(
-			'asc'     => 'question_id ASC',
-			'desc'    => 'question_id DESC',
-			'sorting' => 'question_order ASC',
-		);
-		$order_by     = $order_by_map[ $questions_order ] ?? 'question_order ASC';
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( $max_questions <= 0 ) {
+			// No question limit: sum all questions regardless of order.
+			$total_marks = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT SUM(question_mark)
+					FROM {$wpdb->prefix}tutor_quiz_questions
+					WHERE quiz_id = %d",
+					$quiz_id
+				)
+			);
+		} else {
+			// Question limit is active. $order_by is resolved from a fixed allowlist; no user input reaches it.
+			$order_by_map = array(
+				'asc'     => 'question_id ASC',
+				'desc'    => 'question_id DESC',
+				'sorting' => 'question_order ASC',
+			);
+			$order_by = $order_by_map[ $questions_order ] ?? 'question_order ASC';
 
-		$limit = $max_questions > 0 ? $max_questions : PHP_INT_MAX;
+			// • rand + COUNT > limit → a true random subset, total is unknowable → 0.
+			// • rand + COUNT ≤ limit → all questions shown, sum is deterministic.
+			// • deterministic        → sum of the first $max_questions by ORDER BY.
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$sql = "SELECT CASE
+					WHEN %s = 'rand' AND COUNT(question_id) > %d THEN 0
+					ELSE (
+						SELECT SUM(q.question_mark) FROM (
+							SELECT question_mark
+							FROM {$wpdb->prefix}tutor_quiz_questions
+							WHERE quiz_id = %d
+							ORDER BY {$order_by}
+							LIMIT %d
+						) AS q
+					)
+				END
+				FROM {$wpdb->prefix}tutor_quiz_questions
+				WHERE quiz_id = %d";
 
-		$total_marks = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT CASE
-        WHEN %s = 'rand' AND %d > 0 AND COUNT(question_id) > %d THEN 0
-        ELSE (
-          SELECT SUM(questions.question_mark) FROM (
-            SELECT question_mark
-            FROM {$wpdb->prefix}tutor_quiz_questions
-            WHERE quiz_id = %d
-            ORDER BY {$order_by}
-            LIMIT %d
-          ) AS questions
-        )
-      END
-      FROM {$wpdb->prefix}tutor_quiz_questions
-      WHERE quiz_id = %d",
-				$questions_order,
-				$max_questions,
-				$max_questions,
-				$quiz_id,
-				$limit,
-				$quiz_id
-			)
-		);
+			$total_marks = $wpdb->get_var( $wpdb->prepare( $sql, $questions_order, $max_questions, $quiz_id, $max_questions, $quiz_id ) );
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		return (float) $total_marks;
 	}

--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -1049,38 +1049,38 @@ class Quiz {
 		wp_redirect( tutor_utils()->input_old( '_wp_http_referer' ) );
 	}
 
-    /**
-     * Get total marks for a quiz
-     *
-     * @since 3.0.0
-     *
-     * @param int $quiz_id quiz id.
-     *
-     * @return int|float
-     */
-    public static function get_quiz_total_marks( $quiz_id ) {
-        global $wpdb;
+	/**
+	 * Get total marks for a quiz
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param int $quiz_id quiz id.
+	 *
+	 * @return int|float
+	 */
+	public static function get_quiz_total_marks( $quiz_id ) {
+		global $wpdb;
 
-        if ( ! $quiz_id ) {
-            return 0;
-        }
+		if ( ! $quiz_id ) {
+			return 0;
+		}
 
-        $max_questions   = (int) tutor_utils()->get_quiz_option( $quiz_id, 'max_questions_for_answer' );
-        $questions_order = tutor_utils()->get_quiz_option( $quiz_id, 'questions_order', 'rand' );
+		$max_questions   = (int) tutor_utils()->get_quiz_option( $quiz_id, 'max_questions_for_answer' );
+		$questions_order = tutor_utils()->get_quiz_option( $quiz_id, 'questions_order', 'rand' );
 
-        $order_by_map = array(
-                'asc'     => 'question_id ASC',
-                'desc'    => 'question_id DESC',
-                'sorting' => 'question_order ASC',
-        );
-        $order_by     = $order_by_map[ $questions_order ] ?? 'question_order ASC';
+		$order_by_map = array(
+			'asc'     => 'question_id ASC',
+			'desc'    => 'question_id DESC',
+			'sorting' => 'question_order ASC',
+		);
+		$order_by     = $order_by_map[ $questions_order ] ?? 'question_order ASC';
 
-        $limit = $max_questions > 0 ? $max_questions : PHP_INT_MAX;
+		$limit = $max_questions > 0 ? $max_questions : PHP_INT_MAX;
 
-        // phpcs:disable
-        $total_marks = $wpdb->get_var(
-                $wpdb->prepare(
-                        "SELECT CASE
+		// phpcs:disable
+		$total_marks = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT CASE
         WHEN %s = 'rand' AND %d > 0 AND COUNT(question_id) > %d THEN 0
         ELSE (
           SELECT SUM(questions.question_mark) FROM (
@@ -1094,18 +1094,18 @@ class Quiz {
 				END
 				FROM {$wpdb->prefix}tutor_quiz_questions
 				WHERE quiz_id = %d",
-                        $questions_order,
-                        $max_questions,
-                        $max_questions,
-                        $quiz_id,
-                        $limit,
-                        $quiz_id
-                )
-        );
-        // phpcs:enable
+				$questions_order,
+				$max_questions,
+				$max_questions,
+				$quiz_id,
+				$limit,
+				$quiz_id
+			)
+		);
+		// phpcs:enable
 
-        return (float) $total_marks;
-    }
+		return (float) $total_marks;
+	}
 
 	/**
 	 * Quiz timeout by ajax

--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -1065,56 +1065,42 @@ class Quiz {
 			return 0;
 		}
 
-		$questions = $wpdb->get_results(
+		$max_questions   = (int) tutor_utils()->get_quiz_option( $quiz_id, 'max_questions_for_answer' );
+		$questions_order = tutor_utils()->get_quiz_option( $quiz_id, 'questions_order', 'rand' );
+
+		$order_by_map = array(
+			'asc'     => 'question_id ASC',
+			'desc'    => 'question_id DESC',
+			'sorting' => 'question_order ASC',
+		);
+		$order_by     = $order_by_map[ $questions_order ] ?? 'question_order ASC';
+
+		$limit = $max_questions > 0 ? $max_questions : PHP_INT_MAX;
+
+		$total_marks = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT question_id, question_mark, question_order
-				FROM {$wpdb->prefix}tutor_quiz_questions
-				WHERE quiz_id = %d",
+				"SELECT CASE
+        WHEN %s = 'rand' AND %d > 0 AND COUNT(question_id) > %d THEN 0
+        ELSE (
+          SELECT SUM(questions.question_mark) FROM (
+            SELECT question_mark
+            FROM {$wpdb->prefix}tutor_quiz_questions
+            WHERE quiz_id = %d
+            ORDER BY {$order_by}
+            LIMIT %d
+          ) AS questions
+        )
+      END
+      FROM {$wpdb->prefix}tutor_quiz_questions
+      WHERE quiz_id = %d",
+				$questions_order,
+				$max_questions,
+				$max_questions,
+				$quiz_id,
+				$limit,
 				$quiz_id
 			)
 		);
-
-		if ( empty( $questions ) ) {
-			return 0;
-		}
-
-		$total_count = count( $questions );
-		$max_count   = (int) tutor_utils()->total_questions_for_student_by_quiz( $quiz_id );
-		$total_marks = 0;
-
-		// If no limit or max_count exceeds pool size, return sum of all.
-		if ( $max_count <= 0 || $max_count >= $total_count ) {
-			$total_marks = array_sum( array_column( $questions, 'question_mark' ) );
-		} else {
-			$questions_order = tutor_utils()->get_quiz_option( $quiz_id, 'questions_order', 'rand' );
-
-			// Deterministic order: sum marks of the first $max_count questions.
-			if ( 'sorting' === $questions_order ) {
-				usort( $questions, fn( $a, $b ) => (int) $a->question_order <=> (int) $b->question_order );
-				$sliced      = array_slice( $questions, 0, $max_count );
-				$total_marks = array_sum( array_column( $sliced, 'question_mark' ) );
-			} elseif ( 'asc' === $questions_order ) {
-				usort( $questions, fn( $a, $b ) => (int) $a->question_id <=> (int) $b->question_id );
-				$sliced      = array_slice( $questions, 0, $max_count );
-				$total_marks = array_sum( array_column( $sliced, 'question_mark' ) );
-			} elseif ( 'desc' === $questions_order ) {
-				usort( $questions, fn( $a, $b ) => (int) $b->question_id <=> (int) $a->question_id );
-				$sliced      = array_slice( $questions, 0, $max_count );
-				$total_marks = array_sum( array_column( $sliced, 'question_mark' ) );
-			} else {
-				// Random order:
-				// If question marks vary, total marks is indeterminate before starting.
-				$marks        = array_map( 'floatval', array_column( $questions, 'question_mark' ) );
-				$unique_marks = array_unique( $marks );
-
-				if ( count( $unique_marks ) > 1 ) {
-					return 0;
-				}
-
-				// All questions have equal marks: exact calculation.
-				$total_marks = reset( $unique_marks ) * $max_count;
-			}
-		}
 
 		return (float) $total_marks;
 	}

--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -1049,71 +1049,63 @@ class Quiz {
 		wp_redirect( tutor_utils()->input_old( '_wp_http_referer' ) );
 	}
 
-	/**
-	 * Get total marks for a quiz
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param int $quiz_id quiz id.
-	 *
-	 * @return int|float
-	 */
-	public static function get_quiz_total_marks( $quiz_id ) {
-		global $wpdb;
+    /**
+     * Get total marks for a quiz
+     *
+     * @since 3.0.0
+     *
+     * @param int $quiz_id quiz id.
+     *
+     * @return int|float
+     */
+    public static function get_quiz_total_marks( $quiz_id ) {
+        global $wpdb;
 
-		if ( ! $quiz_id ) {
-			return 0;
-		}
+        if ( ! $quiz_id ) {
+            return 0;
+        }
 
-		$max_questions   = (int) tutor_utils()->get_quiz_option( $quiz_id, 'max_questions_for_answer' );
-		$questions_order = tutor_utils()->get_quiz_option( $quiz_id, 'questions_order', 'rand' );
+        $max_questions   = (int) tutor_utils()->get_quiz_option( $quiz_id, 'max_questions_for_answer' );
+        $questions_order = tutor_utils()->get_quiz_option( $quiz_id, 'questions_order', 'rand' );
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		if ( $max_questions <= 0 ) {
-			// No question limit: sum all questions regardless of order.
-			$total_marks = $wpdb->get_var(
-				$wpdb->prepare(
-					"SELECT SUM(question_mark)
-					FROM {$wpdb->prefix}tutor_quiz_questions
-					WHERE quiz_id = %d",
-					$quiz_id
-				)
-			);
-		} else {
-			// Question limit is active. $order_by is resolved from a fixed allowlist; no user input reaches it.
-			$order_by_map = array(
-				'asc'     => 'question_id ASC',
-				'desc'    => 'question_id DESC',
-				'sorting' => 'question_order ASC',
-			);
-			$order_by = $order_by_map[ $questions_order ] ?? 'question_order ASC';
+        $order_by_map = array(
+                'asc'     => 'question_id ASC',
+                'desc'    => 'question_id DESC',
+                'sorting' => 'question_order ASC',
+        );
+        $order_by     = $order_by_map[ $questions_order ] ?? 'question_order ASC';
 
-			// • rand + COUNT > limit → a true random subset, total is unknowable → 0.
-			// • rand + COUNT ≤ limit → all questions shown, sum is deterministic.
-			// • deterministic        → sum of the first $max_questions by ORDER BY.
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$sql = "SELECT CASE
-					WHEN %s = 'rand' AND COUNT(question_id) > %d THEN 0
-					ELSE (
-						SELECT SUM(q.question_mark) FROM (
-							SELECT question_mark
-							FROM {$wpdb->prefix}tutor_quiz_questions
-							WHERE quiz_id = %d
-							ORDER BY {$order_by}
-							LIMIT %d
-						) AS q
-					)
+        $limit = $max_questions > 0 ? $max_questions : PHP_INT_MAX;
+
+        // phpcs:disable
+        $total_marks = $wpdb->get_var(
+                $wpdb->prepare(
+                        "SELECT CASE
+        WHEN %s = 'rand' AND %d > 0 AND COUNT(question_id) > %d THEN 0
+        ELSE (
+          SELECT SUM(questions.question_mark) FROM (
+            SELECT question_mark
+            FROM {$wpdb->prefix}tutor_quiz_questions
+            WHERE quiz_id = %d
+            ORDER BY {$order_by}
+            LIMIT %d
+          ) AS questions
+        )
 				END
 				FROM {$wpdb->prefix}tutor_quiz_questions
-				WHERE quiz_id = %d";
+				WHERE quiz_id = %d",
+                        $questions_order,
+                        $max_questions,
+                        $max_questions,
+                        $quiz_id,
+                        $limit,
+                        $quiz_id
+                )
+        );
+        // phpcs:enable
 
-			$total_marks = $wpdb->get_var( $wpdb->prepare( $sql, $questions_order, $max_questions, $quiz_id, $max_questions, $quiz_id ) );
-			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		}
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-
-		return (float) $total_marks;
-	}
+        return (float) $total_marks;
+    }
 
 	/**
 	 * Quiz timeout by ajax

--- a/classes/Quiz.php
+++ b/classes/Quiz.php
@@ -1050,7 +1050,7 @@ class Quiz {
 	}
 
 	/**
-	 * Get quiz total marks.
+	 * Get total marks for a quiz
 	 *
 	 * @since 3.0.0
 	 *
@@ -1061,16 +1061,62 @@ class Quiz {
 	public static function get_quiz_total_marks( $quiz_id ) {
 		global $wpdb;
 
-		$total_marks = $wpdb->get_var(
+		if ( ! $quiz_id ) {
+			return 0;
+		}
+
+		$questions = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT SUM(question_mark) total_marks 
+				"SELECT question_id, question_mark, question_order
 				FROM {$wpdb->prefix}tutor_quiz_questions
-				WHERE quiz_id=%d",
+				WHERE quiz_id = %d",
 				$quiz_id
 			)
 		);
 
-		return floatval( $total_marks );
+		if ( empty( $questions ) ) {
+			return 0;
+		}
+
+		$total_count = count( $questions );
+		$max_count   = (int) tutor_utils()->total_questions_for_student_by_quiz( $quiz_id );
+		$total_marks = 0;
+
+		// If no limit or max_count exceeds pool size, return sum of all.
+		if ( $max_count <= 0 || $max_count >= $total_count ) {
+			$total_marks = array_sum( array_column( $questions, 'question_mark' ) );
+		} else {
+			$questions_order = tutor_utils()->get_quiz_option( $quiz_id, 'questions_order', 'rand' );
+
+			// Deterministic order: sum marks of the first $max_count questions.
+			if ( 'sorting' === $questions_order ) {
+				usort( $questions, fn( $a, $b ) => (int) $a->question_order <=> (int) $b->question_order );
+				$sliced      = array_slice( $questions, 0, $max_count );
+				$total_marks = array_sum( array_column( $sliced, 'question_mark' ) );
+			} elseif ( 'asc' === $questions_order ) {
+				usort( $questions, fn( $a, $b ) => (int) $a->question_id <=> (int) $b->question_id );
+				$sliced      = array_slice( $questions, 0, $max_count );
+				$total_marks = array_sum( array_column( $sliced, 'question_mark' ) );
+			} elseif ( 'desc' === $questions_order ) {
+				usort( $questions, fn( $a, $b ) => (int) $b->question_id <=> (int) $a->question_id );
+				$sliced      = array_slice( $questions, 0, $max_count );
+				$total_marks = array_sum( array_column( $sliced, 'question_mark' ) );
+			} else {
+				// Random order:
+				// If question marks vary, total marks is indeterminate before starting.
+				$marks        = array_map( 'floatval', array_column( $questions, 'question_mark' ) );
+				$unique_marks = array_unique( $marks );
+
+				if ( count( $unique_marks ) > 1 ) {
+					return 0;
+				}
+
+				// All questions have equal marks: exact calculation.
+				$total_marks = reset( $unique_marks ) * $max_count;
+			}
+		}
+
+		return (float) $total_marks;
 	}
 
 	/**
@@ -1848,16 +1894,18 @@ class Quiz {
 			);
 		}
 
-		$quiz_summary[] = array(
-			'columns' => array(
-				array(
-					'content' => '<div class="tutor-flex tutor-gap-3 tutor-items-center">
-						' . SvgIcon::make()->name( Icon::PRIME_CHECK_CIRCLE )->size( 20 )->get() . __( 'Total Marks', 'tutor' ) . '
-					</div>',
+		if ( ! empty( $total_marks ) ) {
+			$quiz_summary[] = array(
+				'columns' => array(
+					array(
+						'content' => '<div class="tutor-flex tutor-gap-3 tutor-items-center">
+							' . SvgIcon::make()->name( Icon::PRIME_CHECK_CIRCLE )->size( 20 )->get() . __( 'Total Marks', 'tutor' ) . '
+						</div>',
+					),
+					array( 'content' => (float) $total_marks ),
 				),
-				array( 'content' => $total_marks ),
-			),
-		);
+			);
+		}
 
 		$quiz_summary[] = array(
 			'columns' => array(

--- a/templates/learning-area/quiz/content.php
+++ b/templates/learning-area/quiz/content.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Tutor\Helpers\UrlHelper;
 use TUTOR\Quiz;
-use TUTOR\Models\QuizModel;
+use Tutor\Models\QuizModel;
 
 global $tutor_current_post, $tutor_course_id;
 
@@ -25,7 +25,6 @@ if ( ! $quiz || ! is_a( $quiz, 'WP_Post' ) ) {
 $quiz_id            = $quiz->ID;
 $total_questions    = (int) tutor_utils()->total_questions_for_student_by_quiz( $quiz_id );
 $quiz_options       = tutor_utils()->get_quiz_option( $quiz_id );
-$total_marks        = Quiz::get_quiz_total_marks( $quiz_id );
 $passing_grade      = (int) ( $quiz_options['passing_grade'] ?? 0 );
 $quiz_time          = $quiz_options['time_limit'] ?? null;
 $has_time_limit     = is_array( $quiz_time ) && ! empty( $quiz_time['time_value'] ) && (int) $quiz_time['time_value'] > 0;
@@ -33,11 +32,13 @@ $time_units         = Quiz::quiz_time_units();
 $quiz_item_readable = $has_time_limit ? $quiz_time['time_value'] . ' ' . $time_units[ $quiz_time['time_type'] ] : null;
 $quiz_attempt       = ( new QuizModel() )->get_quiz_attempt( $quiz_id, $user_id ?? get_current_user_id() );
 $earned_marks       = 0;
+$total_marks        = 0;
 
-if ( $quiz_attempt && $total_marks > 0 ) {
-	$earned_marks = (float) $quiz_attempt->earned_marks;
-	$total        = (float) $total_marks;
-	$earned_marks = number_format( ( $earned_marks / $total_marks ) * 100, 2 );
+if ( is_object( $quiz_attempt ) && (float) ( $quiz_attempt->total_marks ?? 0 ) > 0 ) {
+	$total_marks  = (float) $quiz_attempt->total_marks;
+	$earned_marks = QuizModel::calculate_attempt_earned_percentage( $quiz_attempt );
+} else {
+	$total_marks = Quiz::get_quiz_total_marks( $quiz_id );
 }
 $limit_attempts   = (int) $quiz_options['limit_attempts_allowed'] ?? 0;
 $allowed_attempts = $limit_attempts ? $quiz_options['attempts_allowed'] ?? '' : '1';


### PR DESCRIPTION
- Replaces multiple PHP `usort`/`array_slice` loops with a single SQL query in `Quiz::get_quiz_total_marks()`
- Returns `0` immediately when random order is active **and** a question limit creates a true random subset (`COUNT > max_questions`)
- Returns the full `SUM` for random order when all questions are shown (no limit, or limit ≥ pool size)
- Deterministic orders (`asc`, `desc`, `sorting`) use a single subquery with an allowlisted `ORDER BY` clause and `LIMIT`
- No-limit case (`max_questions <= 0`) uses a plain `SUM` query with no subquery or `LIMIT`
- `ORDER BY` clause is built from a fixed PHP allowlist — no user input reaches the SQL string
