### PR TITLE
🐛 fix(learning-area): stabilize expand button positioning and content transition in site shell

### DIFF
--- a/assets/src/scss/frontend/learning-area/layout/_header.scss
+++ b/assets/src/scss/frontend/learning-area/layout/_header.scss
@@ -8,7 +8,7 @@
   padding: $tutor-spacing-4;
   position: fixed;
   top: 0;
-  z-index: $tutor-z-header;
+  z-index: calc($tutor-z-sidebar + 1);
   width: 100%;
 
   @include tutor-breakpoint-up(md) {

--- a/assets/src/scss/frontend/learning-area/layout/_layout.scss
+++ b/assets/src/scss/frontend/learning-area/layout/_layout.scss
@@ -16,7 +16,7 @@ $tutor-fixed-footer-offset: $tutor-spacing-6;
   .tutor-learning-area-body {
     padding-inline-start: 320px;
     position: relative;
-    @include tutor-transition(padding);
+    @include tutor-transition((padding, grid-template-columns), 0.3s);
 
     @include tutor-breakpoint-down(lg) {
       padding-inline-start: 0;
@@ -43,6 +43,7 @@ $tutor-fixed-footer-offset: $tutor-spacing-6;
         grid-template-columns: 320px minmax(0, 1fr);
         align-items: start;
         padding-inline-start: 0;
+        @include tutor-transition(grid-template-columns, 0.3s);
       }
 
       .tutor-learning-sidebar {
@@ -77,7 +78,6 @@ $tutor-fixed-footer-offset: $tutor-spacing-6;
 
       .tutor-learning-sidebar {
         padding: 0;
-        width: 0;
       }
 
       .tutor-learning-area-content {

--- a/assets/src/scss/frontend/learning-area/layout/_sidebar.scss
+++ b/assets/src/scss/frontend/learning-area/layout/_sidebar.scss
@@ -7,6 +7,7 @@
   @include tutor-flex(column);
   gap: $tutor-spacing-6;
   padding: $tutor-spacing-4;
+  padding-bottom: calc(#{$tutor-spacing-6} + 40px);
   position: fixed;
   height: calc(100dvh - 62px);
   top: 62px;
@@ -37,15 +38,11 @@
     }
 
     .tutor-expand-btn {
-      position: fixed;
-      inset-inline-start: $tutor-spacing-6;
-      bottom: $tutor-spacing-6;
       pointer-events: auto;
-      transform: translateX(calc(100% + $tutor-spacing-6));
-      z-index: calc($tutor-z-sidebar + 1);
+      transform: translateX(320px);
 
       [dir='rtl'] & {
-        transform: translateX(calc(-100% - $tutor-spacing-6));
+        transform: translateX(-320px);
       }
     }
   }
@@ -59,7 +56,7 @@
     height: 100dvh;
     overflow-y: auto;
     background-color: $tutor-surface-base;
-    z-index: $tutor-z-sidebar;
+    z-index: calc($tutor-z-sidebar + 2);
 
     .tutor-has-site-shell & {
       z-index: $tutor-z-highest;
@@ -441,9 +438,13 @@
   }
 
   .tutor-expand-btn {
-    align-self: flex-start;
-    flex-shrink: 0;
+    position: absolute;
+    bottom: $tutor-spacing-6;
+    inset-inline-start: $tutor-spacing-6;
+    z-index: calc($tutor-z-sidebar + 1);
     color: $tutor-icon-secondary;
+    transform: translateX(0);
+    @include tutor-transition(transform);
 
     @include tutor-breakpoint-down(lg) {
       display: none;

--- a/assets/src/scss/frontend/learning-area/layout/_sidebar.scss
+++ b/assets/src/scss/frontend/learning-area/layout/_sidebar.scss
@@ -57,6 +57,7 @@
     overflow-y: auto;
     background-color: $tutor-surface-base;
     z-index: calc($tutor-z-sidebar + 2);
+    padding-bottom: $tutor-spacing-4;
 
     .tutor-has-site-shell & {
       z-index: $tutor-z-highest;


### PR DESCRIPTION
- Smoothly transition the learning area content when expanding or collapsing the sidebar in site shell mode
- Anchor the expand/collapse button position at bottom-start without layout shift across collapsed and expanded states
- Prevent the expand/collapse button from overlapping the theme footer in site shell mode
- Ensure the learning area header maintains stacking precedence above the sidebar on desktop screens
- Provide bottom clearance in the sidebar so scrolling curriculum items are not obscured by the pinned button
