### PR TITLE
🐛 Fix block theme header styles and learning area width alignment

### DIFF
--- a/assets/src/js/frontend/services/site-shell.ts
+++ b/assets/src/js/frontend/services/site-shell.ts
@@ -7,6 +7,19 @@ const MAX_HEADER_HEIGHT = 250;
 const SITE_SHELL_ROOT_SELECTOR = '[data-tutor-learning-site-shell], [data-tutor-dashboard-site-shell]';
 
 /**
+ * Returns the effective height in pixels for a valid header element.
+ */
+const getHeaderHeight = (element: HTMLElement | null): number => {
+  if (!element || !element.isConnected) {
+    return 0;
+  }
+
+  const rect = element.getBoundingClientRect();
+  const height = rect.height > 0 && rect.height <= MAX_HEADER_HEIGHT ? rect.height : element.offsetHeight;
+  return Math.min(Math.max(0, Math.round(height)), MAX_HEADER_HEIGHT);
+};
+
+/**
  * Checks if an element represents a visible header bar with reasonable dimensions.
  */
 const isValidHeaderBar = (element: HTMLElement | null): boolean => {
@@ -135,23 +148,23 @@ class SiteShellController {
 
   start(): void {
     this.themeHeader = this.findThemeHeader();
-    this.updateOffset();
+    this.updateOffset(true);
 
     if (this.themeHeader && typeof ResizeObserver !== 'undefined') {
-      this.resizeObserver = new ResizeObserver(() => this.scheduleOffsetUpdate());
+      this.resizeObserver = new ResizeObserver(() => this.scheduleOffsetUpdate(true));
       this.resizeObserver.observe(this.themeHeader);
     }
 
-    window.addEventListener('resize', this.scheduleOffsetUpdate);
-    window.addEventListener('scroll', this.scheduleOffsetUpdate, { passive: true });
+    window.addEventListener('resize', this.scheduleResizeUpdate);
+    window.addEventListener('scroll', this.scheduleScrollUpdate, { passive: true });
   }
 
   destroy(): void {
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
 
-    window.removeEventListener('resize', this.scheduleOffsetUpdate);
-    window.removeEventListener('scroll', this.scheduleOffsetUpdate);
+    window.removeEventListener('resize', this.scheduleResizeUpdate);
+    window.removeEventListener('scroll', this.scheduleScrollUpdate);
 
     if (this.animationFrame !== null) {
       window.cancelAnimationFrame(this.animationFrame);
@@ -174,44 +187,47 @@ class SiteShellController {
     }
   }
 
-  private scheduleOffsetUpdate = (): void => {
+  private scheduleResizeUpdate = (): void => {
+    this.scheduleOffsetUpdate(true);
+  };
+
+  private scheduleScrollUpdate = (): void => {
+    this.scheduleOffsetUpdate(false);
+  };
+
+  private scheduleOffsetUpdate = (isResize: boolean): void => {
     if (this.animationFrame !== null) {
       return;
     }
 
     this.animationFrame = window.requestAnimationFrame(() => {
       this.animationFrame = null;
-      this.updateOffset();
+      this.updateOffset(isResize);
     });
   };
 
-  private updateOffset(): void {
+  private updateOffset(isResize = false): void {
     const adminBarBottom = getAdminBarBottom();
     const stickyHeader = findStickyHeaderElement(this.themeHeader);
-
-    let headerHeight = 0;
-    if (stickyHeader) {
-      const rect = stickyHeader.getBoundingClientRect();
-      headerHeight = rect.height > 0 && rect.height <= MAX_HEADER_HEIGHT ? rect.height : stickyHeader.offsetHeight;
-    }
+    const headerHeight = getHeaderHeight(stickyHeader);
 
     // For sticky/fixed theme headers, the offset below the header is adminBarBottom + headerHeight
     const totalHeaderOffset = stickyHeader ? adminBarBottom + headerHeight : adminBarBottom;
     const clampedOffset = Math.min(Math.max(0, Math.round(totalHeaderOffset)), MAX_HEADER_HEIGHT);
     this.root.style.setProperty(CSS_VARIABLE_HEADER_OFFSET, `${clampedOffset}px`);
 
-    // Overlay offset applies when a fixed/absolute/transparent header overlays the page on initial load
-    let overlayOffset = 0;
-    if (this.themeHeader && isOverlayHeader(this.themeHeader)) {
-      const rect = this.themeHeader.getBoundingClientRect();
-      const themeHeaderHeight =
-        rect.height > 0 && rect.height <= MAX_HEADER_HEIGHT ? rect.height : this.themeHeader.offsetHeight;
-      const rootTop = this.root.getBoundingClientRect().top;
-      overlayOffset = Math.max(0, adminBarBottom + themeHeaderHeight - Math.max(0, rootTop));
-    }
+    // Overlay offset sets initial reserve padding-top on load/resize without mutating during scroll
+    if (isResize) {
+      let overlayOffset = 0;
+      if (this.themeHeader && isOverlayHeader(this.themeHeader)) {
+        const themeHeaderHeight = getHeaderHeight(this.themeHeader);
+        const rootTop = this.root.getBoundingClientRect().top;
+        overlayOffset = Math.max(0, adminBarBottom + themeHeaderHeight - Math.max(0, rootTop));
+      }
 
-    const clampedOverlayOffset = Math.min(Math.max(0, Math.round(overlayOffset)), MAX_HEADER_HEIGHT);
-    this.root.style.setProperty(CSS_VARIABLE_HEADER_OVERLAY_OFFSET, `${clampedOverlayOffset}px`);
+      const clampedOverlayOffset = Math.min(Math.max(0, Math.round(overlayOffset)), MAX_HEADER_HEIGHT);
+      this.root.style.setProperty(CSS_VARIABLE_HEADER_OVERLAY_OFFSET, `${clampedOverlayOffset}px`);
+    }
   }
 }
 

--- a/assets/src/js/frontend/services/site-shell.ts
+++ b/assets/src/js/frontend/services/site-shell.ts
@@ -42,6 +42,7 @@ class SiteShellController {
     this.updateOffset();
 
     const isSticky = this.isStickyHeader(this.themeHeader);
+    const hasAdminBar = Boolean(document.getElementById(WP_ADMIN_BAR_ID));
 
     if (isSticky && this.themeHeader && typeof ResizeObserver !== 'undefined') {
       this.resizeObserver = new ResizeObserver(() => this.scheduleOffsetUpdate());
@@ -49,7 +50,10 @@ class SiteShellController {
     }
 
     window.addEventListener('resize', this.scheduleOffsetUpdate);
-    window.addEventListener('scroll', this.scheduleOffsetUpdate, { passive: true });
+
+    if (isSticky || hasAdminBar) {
+      window.addEventListener('scroll', this.scheduleOffsetUpdate, { passive: true });
+    }
   }
 
   destroy(): void {

--- a/assets/src/js/frontend/services/site-shell.ts
+++ b/assets/src/js/frontend/services/site-shell.ts
@@ -2,16 +2,125 @@ const CSS_VARIABLE_HEADER_OFFSET = '--tutor-site-header-offset';
 const CSS_VARIABLE_HEADER_OVERLAY_OFFSET = '--tutor-site-header-overlay-offset';
 
 const WP_ADMIN_BAR_ID = 'wpadminbar';
+const MAX_HEADER_HEIGHT = 250;
 
 const SITE_SHELL_ROOT_SELECTOR = '[data-tutor-learning-site-shell], [data-tutor-dashboard-site-shell]';
 
 /**
- * Returns the lowest visible bottom edge among the site header and admin bar.
+ * Checks if an element represents a visible header bar with reasonable dimensions.
  */
-const getVisibleHeaderBoundary = (elements: HTMLElement[]): number => {
-  return elements.reduce((offset, element) => {
-    return Math.max(offset, element.getBoundingClientRect().bottom, 0);
-  }, 0);
+const isValidHeaderBar = (element: HTMLElement | null): boolean => {
+  if (!element || !element.isConnected) {
+    return false;
+  }
+
+  const style = window.getComputedStyle(element);
+  if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+    return false;
+  }
+
+  const rect = element.getBoundingClientRect();
+  // Must be visible and have realistic header bar dimensions (reject full-screen mobile drawers/modals > 250px)
+  if (rect.height <= 0 || rect.width <= 0 || rect.height > MAX_HEADER_HEIGHT) {
+    return false;
+  }
+
+  // Must span a reasonable width across the viewport (reject small floating buttons/widgets)
+  if (rect.width < window.innerWidth * 0.4) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Checks if a header element is configured or behaving as a sticky / fixed header.
+ */
+const isStickyOrFixedHeader = (element: HTMLElement | null): boolean => {
+  if (!isValidHeaderBar(element)) {
+    return false;
+  }
+
+  const style = window.getComputedStyle(element!);
+  const pos = style.position;
+  if (pos === 'fixed' || pos === 'sticky') {
+    return true;
+  }
+
+  const className = (element!.className || '').toString();
+  return /sticky/i.test(className) || element!.hasAttribute('data-sticky');
+};
+
+/**
+ * Checks if a header element is configured as a transparent / floating overlay header.
+ */
+const isOverlayHeader = (element: HTMLElement | null): boolean => {
+  if (!isValidHeaderBar(element)) {
+    return false;
+  }
+
+  const style = window.getComputedStyle(element!);
+  const pos = style.position;
+  if (pos === 'fixed' || pos === 'absolute') {
+    return true;
+  }
+
+  const className = (element!.className || '').toString();
+  return /transparent/i.test(className);
+};
+
+/**
+ * Returns the bottom coordinate of the active WordPress admin bar if visible at the top.
+ */
+const getAdminBarBottom = (): number => {
+  const adminBar = document.getElementById(WP_ADMIN_BAR_ID);
+  if (!adminBar || !adminBar.isConnected) {
+    return 0;
+  }
+
+  const style = window.getComputedStyle(adminBar);
+  if (style.display === 'none' || style.visibility === 'hidden') {
+    return 0;
+  }
+
+  const rect = adminBar.getBoundingClientRect();
+  if (rect.bottom <= 0 || rect.height <= 0) {
+    return 0;
+  }
+
+  // On mobile (<= 600px), admin bar is position: absolute (scrolls with page)
+  const isFixed = style.position === 'fixed' || style.position === 'sticky';
+  if (!isFixed && rect.top < 0) {
+    return 0;
+  }
+
+  return Math.max(0, rect.bottom);
+};
+
+/**
+ * Finds the active sticky/fixed header bar element (or inner row) within the theme header.
+ */
+const findStickyHeaderElement = (header: HTMLElement | null): HTMLElement | null => {
+  if (!header || !header.isConnected) {
+    return null;
+  }
+
+  if (isStickyOrFixedHeader(header)) {
+    return header;
+  }
+
+  // Check top-level rows/bars inside the header (e.g. Sydney, Astra, TutorStarter)
+  const candidates = header.querySelectorAll<HTMLElement>(
+    'div, nav, header, [class*="header"], [class*="sticky"], [class*="navbar"], [class*="shfb"]',
+  );
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i];
+    if (isStickyOrFixedHeader(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
 };
 
 class SiteShellController {
@@ -28,18 +137,13 @@ class SiteShellController {
     this.themeHeader = this.findThemeHeader();
     this.updateOffset();
 
-    const isSticky = this.isStickyHeader(this.themeHeader);
-
-    if (isSticky && this.themeHeader && typeof ResizeObserver !== 'undefined') {
+    if (this.themeHeader && typeof ResizeObserver !== 'undefined') {
       this.resizeObserver = new ResizeObserver(() => this.scheduleOffsetUpdate());
       this.resizeObserver.observe(this.themeHeader);
     }
 
     window.addEventListener('resize', this.scheduleOffsetUpdate);
-
-    if (isSticky) {
-      window.addEventListener('scroll', this.scheduleOffsetUpdate, { passive: true });
-    }
+    window.addEventListener('scroll', this.scheduleOffsetUpdate, { passive: true });
   }
 
   destroy(): void {
@@ -70,52 +174,6 @@ class SiteShellController {
     }
   }
 
-  private isStickyHeader(header: HTMLElement | null): boolean {
-    if (!header) {
-      return false;
-    }
-
-    const position = window.getComputedStyle(header).position;
-    if (position === 'fixed' || position === 'sticky') {
-      return true;
-    }
-
-    const className = (header.className || '').toString();
-    return /sticky/i.test(className) || header.hasAttribute('data-sticky');
-  }
-
-  private getStickyHeader(header: HTMLElement | null): HTMLElement | null {
-    if (!header) {
-      return null;
-    }
-
-    const position = window.getComputedStyle(header).position;
-    if (position === 'fixed' || position === 'sticky') {
-      return header;
-    }
-
-    // Check if an inner row is fixed or sticky (e.g. Sydney, Astra)
-    const children = header.querySelectorAll<HTMLElement>('*');
-    for (let i = 0; i < children.length; i++) {
-      const pos = window.getComputedStyle(children[i]).position;
-      if (pos === 'fixed' || pos === 'sticky') {
-        return children[i];
-      }
-    }
-
-    // If the header has sticky classes (e.g. TutorStarter .header-sticky, Sydney .has-sticky-header)
-    // and is active in the viewport
-    const className = (header.className || '').toString();
-    if (/sticky/i.test(className) || header.hasAttribute('data-sticky')) {
-      const rect = header.getBoundingClientRect();
-      if (rect.top <= 50 && rect.bottom > 0) {
-        return header;
-      }
-    }
-
-    return null;
-  }
-
   private scheduleOffsetUpdate = (): void => {
     if (this.animationFrame !== null) {
       return;
@@ -128,22 +186,32 @@ class SiteShellController {
   };
 
   private updateOffset(): void {
-    const adminBar = document.getElementById(WP_ADMIN_BAR_ID);
-    const stickyHeader = this.getStickyHeader(this.themeHeader);
-    const elements = [stickyHeader, adminBar].filter(
-      (element): element is HTMLElement => element instanceof HTMLElement,
-    );
-    const offset = getVisibleHeaderBoundary(elements);
+    const adminBarBottom = getAdminBarBottom();
+    const stickyHeader = findStickyHeaderElement(this.themeHeader);
 
-    this.root.style.setProperty(CSS_VARIABLE_HEADER_OFFSET, `${offset}px`);
+    let headerHeight = 0;
+    if (stickyHeader) {
+      const rect = stickyHeader.getBoundingClientRect();
+      headerHeight = rect.height > 0 && rect.height <= MAX_HEADER_HEIGHT ? rect.height : stickyHeader.offsetHeight;
+    }
 
-    // The active-quiz form is positioned below a normal-flow theme header,
-    // but starts behind a fixed or stuck header. This value lets its
-    // absolutely positioned question panel reserve only the part of the
-    // visible boundary that overlays the Learning Area itself.
-    const rootTop = this.root.getBoundingClientRect().top;
-    const overlayOffset = Math.max(0, offset - Math.max(0, rootTop));
-    this.root.style.setProperty(CSS_VARIABLE_HEADER_OVERLAY_OFFSET, `${overlayOffset}px`);
+    // For sticky/fixed theme headers, the offset below the header is adminBarBottom + headerHeight
+    const totalHeaderOffset = stickyHeader ? adminBarBottom + headerHeight : adminBarBottom;
+    const clampedOffset = Math.min(Math.max(0, Math.round(totalHeaderOffset)), MAX_HEADER_HEIGHT);
+    this.root.style.setProperty(CSS_VARIABLE_HEADER_OFFSET, `${clampedOffset}px`);
+
+    // Overlay offset applies when a fixed/absolute/transparent header overlays the page on initial load
+    let overlayOffset = 0;
+    if (this.themeHeader && isOverlayHeader(this.themeHeader)) {
+      const rect = this.themeHeader.getBoundingClientRect();
+      const themeHeaderHeight =
+        rect.height > 0 && rect.height <= MAX_HEADER_HEIGHT ? rect.height : this.themeHeader.offsetHeight;
+      const rootTop = this.root.getBoundingClientRect().top;
+      overlayOffset = Math.max(0, adminBarBottom + themeHeaderHeight - Math.max(0, rootTop));
+    }
+
+    const clampedOverlayOffset = Math.min(Math.max(0, Math.round(overlayOffset)), MAX_HEADER_HEIGHT);
+    this.root.style.setProperty(CSS_VARIABLE_HEADER_OVERLAY_OFFSET, `${clampedOverlayOffset}px`);
   }
 }
 

--- a/assets/src/js/frontend/services/site-shell.ts
+++ b/assets/src/js/frontend/services/site-shell.ts
@@ -7,133 +7,24 @@ const MAX_HEADER_HEIGHT = 250;
 const SITE_SHELL_ROOT_SELECTOR = '[data-tutor-learning-site-shell], [data-tutor-dashboard-site-shell]';
 
 /**
- * Returns the effective height in pixels for a valid header element.
+ * Returns the lowest visible bottom edge among the site header and admin bar.
  */
-const getHeaderHeight = (element: HTMLElement | null): number => {
-  if (!element || !element.isConnected) {
-    return 0;
-  }
-
-  const rect = element.getBoundingClientRect();
-  const height = rect.height > 0 && rect.height <= MAX_HEADER_HEIGHT ? rect.height : element.offsetHeight;
-  return Math.min(Math.max(0, Math.round(height)), MAX_HEADER_HEIGHT);
-};
-
-/**
- * Checks if an element represents a visible header bar with reasonable dimensions.
- */
-const isValidHeaderBar = (element: HTMLElement | null): boolean => {
-  if (!element || !element.isConnected) {
-    return false;
-  }
-
-  const style = window.getComputedStyle(element);
-  if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
-    return false;
-  }
-
-  const rect = element.getBoundingClientRect();
-  // Must be visible and have realistic header bar dimensions (reject full-screen mobile drawers/modals > 250px)
-  if (rect.height <= 0 || rect.width <= 0 || rect.height > MAX_HEADER_HEIGHT) {
-    return false;
-  }
-
-  // Must span a reasonable width across the viewport (reject small floating buttons/widgets)
-  if (rect.width < window.innerWidth * 0.4) {
-    return false;
-  }
-
-  return true;
-};
-
-/**
- * Checks if a header element is configured or behaving as a sticky / fixed header.
- */
-const isStickyOrFixedHeader = (element: HTMLElement | null): boolean => {
-  if (!isValidHeaderBar(element)) {
-    return false;
-  }
-
-  const style = window.getComputedStyle(element!);
-  const pos = style.position;
-  if (pos === 'fixed' || pos === 'sticky') {
-    return true;
-  }
-
-  const className = (element!.className || '').toString();
-  return /sticky/i.test(className) || element!.hasAttribute('data-sticky');
-};
-
-/**
- * Checks if a header element is configured as a transparent / floating overlay header.
- */
-const isOverlayHeader = (element: HTMLElement | null): boolean => {
-  if (!isValidHeaderBar(element)) {
-    return false;
-  }
-
-  const style = window.getComputedStyle(element!);
-  const pos = style.position;
-  if (pos === 'fixed' || pos === 'absolute') {
-    return true;
-  }
-
-  const className = (element!.className || '').toString();
-  return /transparent/i.test(className);
-};
-
-/**
- * Returns the bottom coordinate of the active WordPress admin bar if visible at the top.
- */
-const getAdminBarBottom = (): number => {
-  const adminBar = document.getElementById(WP_ADMIN_BAR_ID);
-  if (!adminBar || !adminBar.isConnected) {
-    return 0;
-  }
-
-  const style = window.getComputedStyle(adminBar);
-  if (style.display === 'none' || style.visibility === 'hidden') {
-    return 0;
-  }
-
-  const rect = adminBar.getBoundingClientRect();
-  if (rect.bottom <= 0 || rect.height <= 0) {
-    return 0;
-  }
-
-  // On mobile (<= 600px), admin bar is position: absolute (scrolls with page)
-  const isFixed = style.position === 'fixed' || style.position === 'sticky';
-  if (!isFixed && rect.top < 0) {
-    return 0;
-  }
-
-  return Math.max(0, rect.bottom);
-};
-
-/**
- * Finds the active sticky/fixed header bar element (or inner row) within the theme header.
- */
-const findStickyHeaderElement = (header: HTMLElement | null): HTMLElement | null => {
-  if (!header || !header.isConnected) {
-    return null;
-  }
-
-  if (isStickyOrFixedHeader(header)) {
-    return header;
-  }
-
-  // Check top-level rows/bars inside the header (e.g. Sydney, Astra, TutorStarter)
-  const candidates = header.querySelectorAll<HTMLElement>(
-    'div, nav, header, [class*="header"], [class*="sticky"], [class*="navbar"], [class*="shfb"]',
-  );
-  for (let i = 0; i < candidates.length; i++) {
-    const candidate = candidates[i];
-    if (isStickyOrFixedHeader(candidate)) {
-      return candidate;
+const getVisibleHeaderBoundary = (elements: HTMLElement[]): number => {
+  const boundary = elements.reduce((offset, element) => {
+    const style = window.getComputedStyle(element);
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      return offset;
     }
-  }
 
-  return null;
+    const rect = element.getBoundingClientRect();
+    if (rect.bottom <= 0 || rect.top > MAX_HEADER_HEIGHT) {
+      return offset;
+    }
+
+    return Math.max(offset, rect.bottom);
+  }, 0);
+
+  return Math.min(Math.round(boundary), MAX_HEADER_HEIGHT);
 };
 
 class SiteShellController {
@@ -148,23 +39,25 @@ class SiteShellController {
 
   start(): void {
     this.themeHeader = this.findThemeHeader();
-    this.updateOffset(true);
+    this.updateOffset();
 
-    if (this.themeHeader && typeof ResizeObserver !== 'undefined') {
-      this.resizeObserver = new ResizeObserver(() => this.scheduleOffsetUpdate(true));
+    const isSticky = this.isStickyHeader(this.themeHeader);
+
+    if (isSticky && this.themeHeader && typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.scheduleOffsetUpdate());
       this.resizeObserver.observe(this.themeHeader);
     }
 
-    window.addEventListener('resize', this.scheduleResizeUpdate);
-    window.addEventListener('scroll', this.scheduleScrollUpdate, { passive: true });
+    window.addEventListener('resize', this.scheduleOffsetUpdate);
+    window.addEventListener('scroll', this.scheduleOffsetUpdate, { passive: true });
   }
 
   destroy(): void {
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
 
-    window.removeEventListener('resize', this.scheduleResizeUpdate);
-    window.removeEventListener('scroll', this.scheduleScrollUpdate);
+    window.removeEventListener('resize', this.scheduleOffsetUpdate);
+    window.removeEventListener('scroll', this.scheduleOffsetUpdate);
 
     if (this.animationFrame !== null) {
       window.cancelAnimationFrame(this.animationFrame);
@@ -187,47 +80,81 @@ class SiteShellController {
     }
   }
 
-  private scheduleResizeUpdate = (): void => {
-    this.scheduleOffsetUpdate(true);
-  };
+  private isStickyHeader(header: HTMLElement | null): boolean {
+    if (!header) {
+      return false;
+    }
 
-  private scheduleScrollUpdate = (): void => {
-    this.scheduleOffsetUpdate(false);
-  };
+    const position = window.getComputedStyle(header).position;
+    if (position === 'fixed' || position === 'sticky' || position === 'absolute') {
+      return true;
+    }
 
-  private scheduleOffsetUpdate = (isResize: boolean): void => {
+    const className = (header.className || '').toString();
+    return /sticky|transparent/i.test(className) || header.hasAttribute('data-sticky');
+  }
+
+  private getStickyHeader(header: HTMLElement | null): HTMLElement | null {
+    if (!header) {
+      return null;
+    }
+
+    const isHeaderBar = (el: HTMLElement): boolean => {
+      const style = window.getComputedStyle(el);
+      if (style.display === 'none' || style.visibility === 'hidden') {
+        return false;
+      }
+      const rect = el.getBoundingClientRect();
+      // Must have realistic header bar dimensions (reject full-screen mobile drawers/modals > 250px)
+      return rect.height > 0 && rect.height <= MAX_HEADER_HEIGHT && rect.width >= window.innerWidth * 0.4;
+    };
+
+    if (this.isStickyHeader(header) && isHeaderBar(header)) {
+      return header;
+    }
+
+    // Check if an inner row is fixed or sticky (e.g. Sydney, Astra)
+    const children = header.querySelectorAll<HTMLElement>(
+      'div, nav, header, [class*="header"], [class*="sticky"], [class*="navbar"], [class*="shfb"]',
+    );
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (this.isStickyHeader(child) && isHeaderBar(child)) {
+        return child;
+      }
+    }
+
+    return null;
+  }
+
+  private scheduleOffsetUpdate = (): void => {
     if (this.animationFrame !== null) {
       return;
     }
 
     this.animationFrame = window.requestAnimationFrame(() => {
       this.animationFrame = null;
-      this.updateOffset(isResize);
+      this.updateOffset();
     });
   };
 
-  private updateOffset(isResize = false): void {
-    const adminBarBottom = getAdminBarBottom();
-    const stickyHeader = findStickyHeaderElement(this.themeHeader);
-    const headerHeight = getHeaderHeight(stickyHeader);
+  private updateOffset(): void {
+    const adminBar = document.getElementById(WP_ADMIN_BAR_ID);
+    const stickyHeader = this.getStickyHeader(this.themeHeader);
+    const elements = [stickyHeader, adminBar].filter(
+      (element): element is HTMLElement => element instanceof HTMLElement,
+    );
+    const offset = getVisibleHeaderBoundary(elements);
 
-    // For sticky/fixed theme headers, the offset below the header is adminBarBottom + headerHeight
-    const totalHeaderOffset = stickyHeader ? adminBarBottom + headerHeight : adminBarBottom;
-    const clampedOffset = Math.min(Math.max(0, Math.round(totalHeaderOffset)), MAX_HEADER_HEIGHT);
-    this.root.style.setProperty(CSS_VARIABLE_HEADER_OFFSET, `${clampedOffset}px`);
+    this.root.style.setProperty(CSS_VARIABLE_HEADER_OFFSET, `${offset}px`);
 
-    // Overlay offset sets initial reserve padding-top on load/resize without mutating during scroll
-    if (isResize) {
-      let overlayOffset = 0;
-      if (this.themeHeader && isOverlayHeader(this.themeHeader)) {
-        const themeHeaderHeight = getHeaderHeight(this.themeHeader);
-        const rootTop = this.root.getBoundingClientRect().top;
-        overlayOffset = Math.max(0, adminBarBottom + themeHeaderHeight - Math.max(0, rootTop));
-      }
-
-      const clampedOverlayOffset = Math.min(Math.max(0, Math.round(overlayOffset)), MAX_HEADER_HEIGHT);
-      this.root.style.setProperty(CSS_VARIABLE_HEADER_OVERLAY_OFFSET, `${clampedOverlayOffset}px`);
-    }
+    // The active-quiz form is positioned below a normal-flow theme header,
+    // but starts behind a fixed or stuck header. This value lets its
+    // absolutely positioned question panel reserve only the part of the
+    // visible boundary that overlays the Learning Area itself.
+    const rootTop = this.root.getBoundingClientRect().top;
+    const overlayOffset = Math.max(0, offset - Math.max(0, rootTop));
+    this.root.style.setProperty(CSS_VARIABLE_HEADER_OVERLAY_OFFSET, `${overlayOffset}px`);
   }
 }
 

--- a/assets/src/scss/frontend/dashboard/layout/_account.scss
+++ b/assets/src/scss/frontend/dashboard/layout/_account.scss
@@ -5,6 +5,8 @@
   --tutor-site-header-offset: 0px;
   --tutor-site-header-overlay-offset: 0px;
 
+  width: 100%;
+
   .tutor-account-header {
     position: sticky;
     top: 0;

--- a/assets/src/scss/frontend/dashboard/layout/_account.scss
+++ b/assets/src/scss/frontend/dashboard/layout/_account.scss
@@ -36,13 +36,10 @@
 
   &.tutor-has-site-shell {
     padding-top: var(--tutor-site-header-overlay-offset);
-
-    .tutor-account-header {
-      top: var(--tutor-site-header-offset);
-    }
   }
 }
 
+.tutor-account-page-wrapper.tutor-has-site-shell .tutor-account-header,
 body:has(#wpadminbar) .tutor-account-page-wrapper.tutor-has-site-shell .tutor-account-header {
   top: var(--tutor-site-header-offset);
 }

--- a/assets/src/scss/frontend/dashboard/layout/_header.scss
+++ b/assets/src/scss/frontend/dashboard/layout/_header.scss
@@ -281,10 +281,7 @@
   }
 }
 
-.tutor-dashboard-layout.tutor-has-site-shell .tutor-dashboard-header {
-  top: var(--tutor-site-header-offset);
-}
-
+.tutor-dashboard-layout.tutor-has-site-shell .tutor-dashboard-header,
 body:has(#wpadminbar) .tutor-dashboard-layout.tutor-has-site-shell .tutor-dashboard-header {
   top: var(--tutor-site-header-offset);
 }

--- a/assets/src/scss/frontend/dashboard/layout/_layout.scss
+++ b/assets/src/scss/frontend/dashboard/layout/_layout.scss
@@ -8,6 +8,7 @@
   --tutor-site-header-offset: 0px;
   --tutor-site-header-overlay-offset: 0px;
 
+  width: 100%;
   display: grid;
   grid-template-columns: 274px 1fr;
 
@@ -41,6 +42,8 @@
 .tutor-dashboard-isolated-page-wrapper {
   --tutor-site-header-offset: 0px;
   --tutor-site-header-overlay-offset: 0px;
+
+  width: 100%;
 
   &.tutor-has-site-shell {
     padding-top: var(--tutor-site-header-overlay-offset);

--- a/assets/src/scss/frontend/dashboard/layout/_profile-header.scss
+++ b/assets/src/scss/frontend/dashboard/layout/_profile-header.scss
@@ -55,10 +55,7 @@
   }
 }
 
-.tutor-has-site-shell .tutor-profile-header {
-  top: var(--tutor-site-header-offset);
-}
-
+.tutor-has-site-shell .tutor-profile-header,
 body:has(#wpadminbar) .tutor-has-site-shell .tutor-profile-header {
   top: var(--tutor-site-header-offset);
 }

--- a/assets/src/scss/frontend/dashboard/layout/_sidebar.scss
+++ b/assets/src/scss/frontend/dashboard/layout/_sidebar.scss
@@ -120,11 +120,7 @@
   }
 }
 
-.tutor-dashboard-layout.tutor-has-site-shell .tutor-dashboard-sidebar {
-  top: var(--tutor-site-header-offset);
-  min-height: calc(100dvh - var(--tutor-site-header-offset));
-}
-
+.tutor-dashboard-layout.tutor-has-site-shell .tutor-dashboard-sidebar,
 body:has(#wpadminbar) .tutor-dashboard-layout.tutor-has-site-shell .tutor-dashboard-sidebar {
   top: var(--tutor-site-header-offset);
   min-height: calc(100dvh - var(--tutor-site-header-offset));

--- a/assets/src/scss/frontend/learning-area/_quiz.scss
+++ b/assets/src/scss/frontend/learning-area/_quiz.scss
@@ -555,18 +555,8 @@ $tutor-quiz-draw-pin-chrome: '#{$tutor-spacing-5} + 2.5rem + #{$tutor-spacing-8}
       }
 
       &[data-has-scroll-left='true'][data-has-scroll-right='false'] {
-        -webkit-mask-image: linear-gradient(
-          to right,
-          transparent 0,
-          black #{$tutor-spacing-10},
-          black 100%
-        );
-        mask-image: linear-gradient(
-          to right,
-          transparent 0,
-          black #{$tutor-spacing-10},
-          black 100%
-        );
+        -webkit-mask-image: linear-gradient(to right, transparent 0, black #{$tutor-spacing-10}, black 100%);
+        mask-image: linear-gradient(to right, transparent 0, black #{$tutor-spacing-10}, black 100%);
       }
 
       &[data-has-scroll-left='false'][data-has-scroll-right='true'] {
@@ -576,12 +566,7 @@ $tutor-quiz-draw-pin-chrome: '#{$tutor-spacing-5} + 2.5rem + #{$tutor-spacing-8}
           black calc(100% - #{$tutor-spacing-10}),
           transparent 100%
         );
-        mask-image: linear-gradient(
-          to right,
-          black 0,
-          black calc(100% - #{$tutor-spacing-10}),
-          transparent 100%
-        );
+        mask-image: linear-gradient(to right, black 0, black calc(100% - #{$tutor-spacing-10}), transparent 100%);
       }
 
       &::-webkit-scrollbar {
@@ -1299,7 +1284,7 @@ $tutor-quiz-draw-pin-chrome: '#{$tutor-spacing-5} + 2.5rem + #{$tutor-spacing-8}
           display: block;
           // Cap against the questions slot (size container), not a stretched card.
           // Interpolate the whole value so Sass does not strip the outer calc().
-          max-height: #{"min(744px, calc(100cqh - (#{$tutor-quiz-draw-pin-chrome})))"};
+          max-height: #{'min(744px, calc(100cqh - (#{$tutor-quiz-draw-pin-chrome})))'};
           max-width: 100%;
           width: auto;
           height: auto;
@@ -1471,13 +1456,16 @@ $tutor-quiz-draw-pin-chrome: '#{$tutor-spacing-5} + 2.5rem + #{$tutor-spacing-8}
 // An active quiz is normally an isolated, viewport-fixed screen. When the
 // Learning Area renders the theme shell, keep its controls inside the quiz
 // instead so the theme footer remains in document flow after the attempt.
-.tutor-learning-area.tutor-has-site-shell {
+.tutor-learning-area.tutor-has-site-shell,
+body:has(#wpadminbar) .tutor-learning-area.tutor-has-site-shell {
   .tutor-quiz-header {
     position: sticky;
     top: var(--tutor-site-header-offset);
   }
 
   .tutor-quiz-submission {
+    padding-top: 0;
+
     &[data-question-layout-view='single_question'],
     &[data-question-layout-view='question_pagination'] {
       height: calc(100dvh - var(--tutor-site-header-overlay-offset));
@@ -1503,32 +1491,5 @@ $tutor-quiz-draw-pin-chrome: '#{$tutor-spacing-5} + 2.5rem + #{$tutor-spacing-8}
 
   .tutor-quiz-questions-pagination {
     position: absolute;
-  }
-}
-
-// Keep the site-shell geometry authoritative when the WordPress admin bar is
-// present; the isolated-mode admin-bar selectors above intentionally win in
-// every other context.
-body:has(#wpadminbar) .tutor-learning-area.tutor-has-site-shell {
-  .tutor-quiz-header {
-    position: sticky;
-    top: var(--tutor-site-header-offset);
-  }
-
-  .tutor-quiz-submission {
-    &[data-question-layout-view='single_question'],
-    &[data-question-layout-view='question_pagination'] {
-      height: calc(100dvh - var(--tutor-site-header-overlay-offset));
-    }
-  }
-
-  .tutor-quiz-questions {
-    &[data-question-layout-view='single_question'],
-    &[data-question-layout-view='question_pagination'] {
-      top: calc(#{$tutor-quiz-header-offset} + var(--tutor-site-header-overlay-offset));
-      height: calc(
-        100% - #{$tutor-quiz-header-offset} - #{$tutor-quiz-footer-offset} - var(--tutor-site-header-overlay-offset)
-      );
-    }
   }
 }

--- a/assets/src/scss/frontend/learning-area/layout/_layout.scss
+++ b/assets/src/scss/frontend/learning-area/layout/_layout.scss
@@ -6,6 +6,10 @@
 $tutor-fixed-footer-height: 80px;
 $tutor-fixed-footer-offset: $tutor-spacing-6;
 
+.tutor-learning-page {
+  width: 100%;
+}
+
 .tutor-learning-area {
   --tutor-site-header-offset: 0px;
   --tutor-site-header-overlay-offset: 0px;
@@ -27,6 +31,14 @@ $tutor-fixed-footer-offset: $tutor-spacing-6;
     padding-inline-start: 0;
   }
 
+  .tutor-learning-area-content {
+    padding-inline-end: $tutor-spacing-4;
+  }
+
+  &.is-fullscreen .tutor-learning-area-content {
+    padding-inline: $tutor-spacing-4;
+  }
+
   &.tutor-has-site-shell {
     // Sticky positioning offsets the header visually without reserving that
     // offset in normal flow. Reserve only the theme-header portion that
@@ -35,6 +47,7 @@ $tutor-fixed-footer-offset: $tutor-spacing-6;
 
     .tutor-learning-area-content {
       padding-top: 0;
+      padding-inline-end: $tutor-spacing-4;
     }
 
     @include tutor-breakpoint-up(lg) {
@@ -57,6 +70,7 @@ $tutor-fixed-footer-offset: $tutor-spacing-6;
       .tutor-learning-area-content {
         grid-column: 2;
         min-width: 0;
+        padding-inline-end: $tutor-spacing-4;
       }
     }
 
@@ -66,6 +80,10 @@ $tutor-fixed-footer-offset: $tutor-spacing-6;
       .tutor-learning-sidebar {
         top: var(--tutor-site-header-offset);
         height: calc(100dvh - var(--tutor-site-header-offset));
+      }
+
+      .tutor-learning-area-content {
+        padding-inline-end: 0;
       }
     }
   }
@@ -82,6 +100,7 @@ $tutor-fixed-footer-offset: $tutor-spacing-6;
 
       .tutor-learning-area-content {
         grid-column: 2;
+        padding-inline: $tutor-spacing-4;
       }
     }
   }

--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -9067,6 +9067,9 @@ class Utils {
 
 		if ( $show ) {
 			if ( $is_block_theme ) {
+				$theme          = wp_get_theme();
+				$theme_slug     = $theme->get( 'TextDomain' );
+				$header_content = do_blocks( '<!-- wp:template-part {"slug":"header","theme":"' . $theme_slug . '","tagName":"header","className":"site-header","layout":{"inherit":true}} /-->' );
 				?>
 				<!doctype html>
 					<html <?php language_attributes(); ?>>
@@ -9078,9 +9081,7 @@ class Utils {
 				<?php wp_body_open(); ?>
 						<div class="wp-site-blocks">
 				<?php
-				$theme      = wp_get_theme();
-				$theme_slug = $theme->get( 'TextDomain' );
-				echo do_blocks( '<!-- wp:template-part {"slug":"header","theme":"' . $theme_slug . '","tagName":"header","className":"site-header","layout":{"inherit":true}} /-->' );
+				echo $header_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			} else {
 				get_header();
 			}
@@ -9127,8 +9128,16 @@ class Utils {
 			if ( $is_block_theme ) {
 				$theme      = wp_get_theme();
 				$theme_slug = $theme->get( 'TextDomain' );
-				echo do_blocks( '<!-- wp:template-part {"slug":"footer","theme":"' . $theme_slug . '","tagName":"footer","className":"site-footer","layout":{"inherit":true}} /-->' );
+				echo do_blocks( '<!-- wp:template-part {"slug":"footer","theme":"' . $theme_slug . '","tagName":"footer","className":"site-footer","layout":{"inherit":true}} /-->' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo '</div>';
+
+				if ( function_exists( 'wp_style_engine_get_stylesheet_from_context' ) ) {
+					$late_styles = wp_style_engine_get_stylesheet_from_context( 'block-supports' );
+					if ( ! empty( $late_styles ) ) {
+						echo '<style id="wp-block-supports-late-inline-css">' . $late_styles . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					}
+				}
+
 				wp_footer();
 				echo '</body>';
 				echo '</html>';


### PR DESCRIPTION
- Pre-render header block template parts before `wp_head()` so WordPress block container layout styles (`wp-container-*`) apply to custom header and footer in block themes
- Output late-generated block support styles in `tutor_custom_footer()`
- Ensure `.tutor-learning-page` maintains full width in flex containers without shrinking
- Align Learning Area content right-edge padding with the header layout
- Prevent mobile viewport content from being pushed off-screen by rejecting oversized mobile menu drawers in sticky header offset detection
- Maintain consistent sticky header offsets during scroll for themes with sticky/transparent headers
- Smoothly transition mobile admin bar offset as it leaves the viewport
- Prevent redundant top padding on active quiz submission screens in site-shell mode
- Deduplicate admin-bar specificity selector blocks across SCSS partials
- Keep site-shell TypeScript controller functions and baseline structure aligned with `dev`
- Conditionally attach the scroll listener only when a sticky theme header or WordPress admin bar is present
