### PR TITLE
fix(quiz): ensure quiz summary total marks uses get_quiz_total_marks

### DIFF
--- a/templates/learning-area/quiz/content.php
+++ b/templates/learning-area/quiz/content.php
@@ -32,13 +32,10 @@ $time_units         = Quiz::quiz_time_units();
 $quiz_item_readable = $has_time_limit ? $quiz_time['time_value'] . ' ' . $time_units[ $quiz_time['time_type'] ] : null;
 $quiz_attempt       = ( new QuizModel() )->get_quiz_attempt( $quiz_id, $user_id ?? get_current_user_id() );
 $earned_marks       = 0;
-$total_marks        = 0;
+$total_marks        = Quiz::get_quiz_total_marks( $quiz_id );
 
 if ( is_object( $quiz_attempt ) && (float) ( $quiz_attempt->total_marks ?? 0 ) > 0 ) {
-	$total_marks  = (float) $quiz_attempt->total_marks;
 	$earned_marks = QuizModel::calculate_attempt_earned_percentage( $quiz_attempt );
-} else {
-	$total_marks = Quiz::get_quiz_total_marks( $quiz_id );
 }
 $limit_attempts   = (int) $quiz_options['limit_attempts_allowed'] ?? 0;
 $allowed_attempts = $limit_attempts ? $quiz_options['attempts_allowed'] ?? '' : '1';


### PR DESCRIPTION
### Summary of Changes
- In `templates/learning-area/quiz/content.php`, ensure `$total_marks` is always determined by `Quiz::get_quiz_total_marks( $quiz_id )`.
- Previously, if a prior quiz attempt existed, `$total_marks` was overwritten with `$quiz_attempt->total_marks`, causing randomized quizzes with question limits to display total marks in the quiz summary instead of omitting them.
- Earned grade percentage continues to be calculated accurately from the previous attempt object via `QuizModel::calculate_attempt_earned_percentage( $quiz_attempt )`.

### Testing
- Tested with newly created and existing quizzes with attempts.
- Verified PHP syntax and ran WordPress coding standards sniff with 0 errors/warnings.