### PR TITLE
✨ Add focus ring to legacy buttons to match v4

### DIFF
--- a/classes/Options_V2.php
+++ b/classes/Options_V2.php
@@ -1466,7 +1466,7 @@ class Options_V2 {
 								'key'     => 'page_elements',
 								'type'    => 'toggle_matrix',
 								'label'   => __( 'Header & Footer', 'tutor' ),
-								'desc'    => __( 'Control the visibility of Header and Footer for Dashboard and Learning Experience', 'tutor' ),
+								'desc'    => __( 'Control the visibility of Header and Footer for Dashboard and Learning Area', 'tutor' ),
 								'columns' => array(
 									'header' => array(
 										'label'      => __( 'Header', 'tutor' ),
@@ -1491,7 +1491,7 @@ class Options_V2 {
 										),
 									),
 									'learning'  => array(
-										'label'  => __( 'Learning Experience', 'tutor' ),
+										'label'  => __( 'Learning Area', 'tutor' ),
 										'header' => array(
 											'key'     => 'show_learning_site_header',
 											'default' => $default_visibility,

--- a/v2-library/src/scss/elements/_buttons.scss
+++ b/v2-library/src/scss/elements/_buttons.scss
@@ -1,5 +1,17 @@
 $disabled-color: #e9e9ea !default;
 
+button.tutor-btn,
+a.tutor-btn,
+.tutor-btn {
+	&:focus,
+	&:focus-visible {
+		&:not(:disabled):not([disabled]):not(.disabled) {
+			outline: none;
+			box-shadow: 0px 0px 0px 2px var(--tutor-brand-450, #90A0F7);
+		}
+	}
+}
+
 .tutor-btn {
 	display: inline-flex;
 	align-items: center;
@@ -17,7 +29,15 @@ $disabled-color: #e9e9ea !default;
 	border-radius: 6px;
 	box-sizing: border-box;
 	cursor: pointer;
-	transition: color 200ms ease-in-out, background-color 200ms ease-in-out, border-color 200ms ease-in-out;
+	transition: color 200ms ease-in-out, background-color 200ms ease-in-out, border-color 200ms ease-in-out, box-shadow 200ms ease-in-out;
+
+	&:focus,
+	&:focus-visible {
+		&:not(:disabled):not([disabled]):not(.disabled) {
+			outline: none;
+			box-shadow: 0px 0px 0px 2px var(--tutor-brand-450, #90A0F7);
+		}
+	}
 
 	&[disabled],
 	&.disabled {
@@ -392,9 +412,16 @@ $disabled-color: #e9e9ea !default;
     display: inline-flex;
     vertical-align: middle;
 
+	button.tutor-btn,
+	a.tutor-btn,
 	.tutor-btn {
 		position: relative;
 		flex: 1;
+
+		&:focus,
+		&:focus-visible {
+			z-index: 1;
+		}
 
 		&:not(:last-child) {
 			border-top-right-radius: 0;


### PR DESCRIPTION
- Adds a brand-colored focus ring to legacy `.tutor-btn` on `:focus` and `:focus-visible` to match v4 button behavior
- Enhances selector specificity for legacy buttons (`button.tutor-btn`, `a.tutor-btn`, `.tutor-btn`) against WordPress and theme styles
- Fixes button stacking order in `.tutor-btn-group` on focus to ensure focus rings are not obscured
- Updates label wording in settings matrix to refer to Learning Area
